### PR TITLE
Propagate errors from the backend automatically

### DIFF
--- a/tools-public/toolpad/pages/validateSupport/page.yml
+++ b/tools-public/toolpad/pages/validateSupport/page.yml
@@ -104,13 +104,7 @@ spec:
             loading: false
             value:
               $$jsExpression: |
-                (() => {
-                  if (updateMuiPaidSupport.error) {
-                    return updateMuiPaidSupport.error
-                  }
-
-                  return updateMuiPaidSupport.data.message
-                })()
+                updateMuiPaidSupport.data?.message
             mode: text
           layout:
             columnSize: 1.6802030456852792


### PR DESCRIPTION
Latest toolpad (0.1.18) passes the error from a query to the text field if the field is using the query data. This makes error checks like these unnecessary