### PR TITLE
Replace yarn run and call the script directly

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -29,4 +29,4 @@ services:
     pullRequestPreviewsEnabled: true
     envVars:
       - key: NODE_VERSION
-        value: 16
+        value: 18

--- a/render.yaml
+++ b/render.yaml
@@ -6,7 +6,7 @@ services:
     env: node
     rootDir: tools-public
     buildCommand: yarn && yarn build
-    startCommand: yarn start
+    startCommand: node_modules/.bin/toolpad start
     pullRequestPreviewsEnabled: true
     plan: standard
     envVars:
@@ -25,7 +25,7 @@ services:
     repo: https://github.com/mui/mui-toolpad.git
     rootDir: examples/custom-datagrid-column
     buildCommand: yarn && yarn build
-    startCommand: yarn start
+    startCommand: node_modules/.bin/toolpad start
     pullRequestPreviewsEnabled: true
     envVars:
       - key: NODE_VERSION

--- a/tools-public/package.json
+++ b/tools-public/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tools-public",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "toolpad dev",


### PR DESCRIPTION
On top of the changes of https://github.com/mui/mui-toolpad/pull/2379 I'm able to get a 30% decrease in memory for free by avoiding `yarn run` and calling the script directly (on the datagrid example).

<img width="1063" alt="Screenshot 2023-07-26 at 12 48 39" src="https://github.com/mui/mui-public/assets/2109932/d47900f8-4e7a-4ce7-9623-d35423f39aca">

_Note: the graph is on top of the changes of https://github.com/mui/mui-toolpad/pull/2379, which already decreased memory by 50%. So the decrease in memory compared to the actual state will be more around 15%._