### PR TITLE
[tools] Update the core community dashboard

### DIFF
--- a/tools-public/toolpad/pages/communityCore/page.yml
+++ b/tools-public/toolpad/pages/communityCore/page.yml
@@ -33,6 +33,234 @@ spec:
                 type: number
                 width: 141
     - component: PageRow
+      name: pageRow2
+      children:
+        - component: Text
+          name: text
+          props:
+            value: Community PRs reviews
+    - component: PageRow
+      name: pageRow1
+      children:
+        - component: Chart
+          name: reviews
+          props:
+            data:
+              - kind: line
+                label: michaldudak
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "michaldudak")
+                xKey: event_month
+                yKey: reviewed
+                color: "#1976d2"
+              - kind: line
+                label: mnajdova
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "mnajdova")
+                xKey: event_month
+                yKey: reviewed
+                color: "#9c27b0"
+              - label: siriwatknp
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "siriwatknp")
+                color: "#e91e63"
+                xKey: event_month
+                yKey: reviewed
+              - label: mj12albert
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "mj12albert")
+                color: "#009688"
+                xKey: event_month
+                yKey: reviewed
+              - label: DiegoAndai
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "DiegoAndai")
+                color: "#ff5722"
+                xKey: event_month
+                yKey: reviewed
+              - label: brijeshb42
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "brijeshb42")
+                color: "#ff9800"
+                xKey: event_month
+                yKey: reviewed
+    - component: PageRow
+      name: pageRow4
+      children:
+        - component: Text
+          name: text1
+          props:
+            value: PRs created
+    - component: PageRow
+      name: pageRow3
+      children:
+        - component: Chart
+          name: reviews1
+          props:
+            data:
+              - kind: line
+                label: michaldudak
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "michaldudak")
+                xKey: event_month
+                yKey: opened
+                color: "#1976d2"
+              - kind: line
+                label: mnajdova
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "mnajdova")
+                xKey: event_month
+                yKey: opened
+                color: "#9c27b0"
+              - label: siriwatknp
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "siriwatknp")
+                color: "#e91e63"
+                xKey: event_month
+                yKey: opened
+              - label: mj12albert
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "mj12albert")
+                color: "#009688"
+                xKey: event_month
+                yKey: opened
+              - label: DiegoAndai
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "DiegoAndai")
+                color: "#ff5722"
+                xKey: event_month
+                yKey: opened
+              - label: brijeshb42
+                kind: line
+                data:
+                  $$jsExpression: |
+                    [...PRsOpenandReviewedQuery.data]
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "brijeshb42")
+                color: "#ff9800"
+                xKey: event_month
+                yKey: opened
+    - component: PageRow
+      name: pageRow6
+      children:
+        - component: Text
+          name: text2
+          props:
+            value: Community support ratio
+    - component: PageRow
+      name: pageRow5
+      children:
+        - component: Chart
+          name: reviews2
+          props:
+            data:
+              - kind: line
+                label: michaldudak
+                data:
+                  $$jsExpression: >
+                    [...PRsOpenandReviewedQuery.data]
+                      .map((entry) => ({ ...entry, ratio: entry.reviewed / entry.opened }))
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "michaldudak")
+                xKey: event_month
+                yKey: ratio
+                color: "#1976d2"
+              - kind: line
+                label: mnajdova
+                data:
+                  $$jsExpression: >
+                    [...PRsOpenandReviewedQuery.data]
+                      .map((entry) => ({ ...entry, ratio: entry.reviewed / entry.opened }))
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "mnajdova")
+                xKey: event_month
+                yKey: ratio
+                color: "#9c27b0"
+              - label: siriwatknp
+                kind: line
+                data:
+                  $$jsExpression: >
+                    [...PRsOpenandReviewedQuery.data]
+                      .map((entry) => ({ ...entry, ratio: entry.reviewed / entry.opened }))
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "siriwatknp")
+                color: "#e91e63"
+                xKey: event_month
+                yKey: ratio
+              - label: mj12albert
+                kind: line
+                data:
+                  $$jsExpression: >
+                    [...PRsOpenandReviewedQuery.data]
+                      .map((entry) => ({ ...entry, ratio: entry.reviewed / entry.opened }))
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "mj12albert")
+                color: "#009688"
+                xKey: event_month
+                yKey: ratio
+              - label: DiegoAndai
+                kind: line
+                data:
+                  $$jsExpression: >
+                    [...PRsOpenandReviewedQuery.data]
+                      .map((entry) => ({ ...entry, ratio: entry.reviewed / entry.opened }))
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "DiegoAndai")
+                color: "#ff5722"
+                xKey: event_month
+                yKey: ratio
+              - label: brijeshb42
+                kind: line
+                data:
+                  $$jsExpression: >
+                    [...PRsOpenandReviewedQuery.data]
+                      .map((entry) => ({ ...entry, ratio: entry.reviewed / entry.opened }))
+                      .reverse()
+                      .filter((entry) => entry.reviewed_by === "brijeshb42")
+                color: "#ff9800"
+                xKey: event_month
+                yKey: ratio
+    - component: PageRow
       name: pageRow
       children:
         - component: Chart
@@ -43,7 +271,7 @@ spec:
                 label: pr_community_count
                 data:
                   $$jsExpression: |
-                    PRsOpenandReviewedQuery.data
+                    PrsPerMonth.data
                 xKey: event_month
                 yKey: pr_community_count
                 color: "#7cb342"
@@ -51,7 +279,7 @@ spec:
                 label: pr_maintainers_count
                 data:
                   $$jsExpression: |
-                    PRsOpenandReviewedQuery.data
+                    PrsPerMonth.data
                 xKey: event_month
                 yKey: pr_maintainers_count
                 color: "#27aeef"
@@ -61,3 +289,10 @@ spec:
       query:
         function: PRsOpenandReviewedQuery
         kind: local
+    - name: PrsPerMonth
+      query:
+        function: functions.ts#PRsPerMonth
+        kind: local
+      parameters:
+        - name: repositoryId
+          value: "23083156"

--- a/tools-public/toolpad/resources/functions.ts
+++ b/tools-public/toolpad/resources/functions.ts
@@ -31,9 +31,10 @@ with pr_opened as (
     AND ge.actor_login NOT LIKE 'mnajdova'
     AND ge.actor_login NOT LIKE 'michaldudak'
     AND ge.actor_login NOT LIKE 'siriwatknp'
-    AND ge.actor_login NOT LIKE 'hbjORbj'
     AND ge.actor_login NOT LIKE 'oliviertassinari'
     AND ge.actor_login NOT LIKE 'mj12albert'
+    AND ge.actor_login NOT LIKE 'DiegoAndai'
+    AND ge.actor_login NOT LIKE 'brijeshb42'
 ), pr_reviewed as (
   SELECT
     number,
@@ -48,7 +49,7 @@ with pr_opened as (
   AND ge.created_at >= '2021-12-01'
   AND ge.actor_login NOT LIKE '%bot'
   AND ge.actor_login NOT LIKE '%[bot]'
-  AND ge.actor_login IN ('mnajdova','michaldudak','siriwatknp','hbjORbj','oliviertassinari','mj12albert')
+  AND ge.actor_login IN ('mnajdova','michaldudak','siriwatknp','oliviertassinari','mj12albert', 'DiegoAndai', 'brijeshb42')
 ), pr_reviewed_with_open_by as (
   SELECT
     pr_reviewed.event_month,
@@ -73,7 +74,7 @@ with pr_opened as (
     AND actor_login NOT LIKE '%bot'
     AND actor_login NOT LIKE '%[bot]'
     AND ge.actor_login IN
-  ('mnajdova','michaldudak','siriwatknp','hbjORbj','oliviertassinari','mj12albert')
+    ('mnajdova','michaldudak','siriwatknp','oliviertassinari','mj12albert', 'DiegoAndai', 'brijeshb42')
 ), final_table AS (
   SELECT
     n.event_month,


### PR DESCRIPTION
Things done in the PR:
- fixed the community vs maintainers PR count
- added multi-line charts for the data in the data grid - it allows better representation for me
- added new joiners, removed people that left the team

Things that can be considered:
- adding charts based on the data grid data can likely be simplified, for e.g. I needed to manually add the lines on the charts <img width="300px" src="https://github.com/mui/mui-public/assets/4512430/1d3dea57-950b-43f2-9f50-48c37d064da9" /> 
it would have been much simpler if I was able to just choose the dimension "reviewed_by" and it would do everything for me - likely suited as a feature request for the X team - cc @joserodolfofreitas 
- the new lines were altering between only two colors, I needed to manually change the colors - we could at least use the 16 available colors before repeating the colors for the new line (dimension)

What I liked:
- after I've added the first chart, it was great that I can just copy the chart and adjust it to show different metric - was great!
