### PR TITLE
[core] Rename `needTriage` to `waitingForMaintainer` and change search param

### DIFF
--- a/tools-public/toolpad/pages/waitingForMaintainer/page.yml
+++ b/tools-public/toolpad/pages/waitingForMaintainer/page.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: page
 spec:
   id: hj1i3hqe
-  title: needTriage
+  title: waitingForMaintainer
   parameters:
     - name: repository
       value: material-ui
@@ -15,13 +15,13 @@ spec:
       props:
         value:
           $$jsExpression: |
-            needTriage.data.total_count
+            waitingForMaintainer.data.total_count
         warning: 25
         problem: 50
         unit: " issues"
         lowerIsBetter: true
   queries:
-    - name: needTriage
+    - name: waitingForMaintainer
       query:
         kind: rest
         url: https://api.github.com/search/issues
@@ -29,8 +29,7 @@ spec:
           - name: q
             value:
               $$jsExpression: >
-                `is:issue repo:mui/${parameters.repository} label:"status: needs
-                triage" `
+                `is:issue is:open repo:mui/${parameters.repository} label:"status: waiting for maintainer" `
         headers: []
         method: GET
       parameters:


### PR DESCRIPTION
This moves the metric `needTriage` to a new name `waitingForMaintainer` and changes the label that has been searched for to `"status: waiting for maintainer"` accordingly

@Janpot could you add the redirect as discussed earlier today? Thanks!