### PR TITLE
[core] Update `no-response` workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug.yml
@@ -1,6 +1,6 @@
 name: Bug report 🐛
 description: Create a bug report for MUI Public.
-labels: ['status: needs triage']
+labels: ['status: waiting for maintainer']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2.feature.yml
+++ b/.github/ISSUE_TEMPLATE/2.feature.yml
@@ -1,6 +1,6 @@
 name: Feature request 💄
 description: Suggest a new idea for MUI Core.
-labels: ['status: needs triage']
+labels: ['status: waiting for maintainer']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/3.rfc.yml
+++ b/.github/ISSUE_TEMPLATE/3.rfc.yml
@@ -1,7 +1,7 @@
 name: RFC 💬
 description: Request for comments for your proposal.
 title: '[RFC] '
-labels: ['status: needs triage', 'RFC']
+labels: ['status: waiting for maintainer', 'RFC']
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/ensure-triage-label.yml
+++ b/.github/workflows/ensure-triage-label.yml
@@ -30,6 +30,6 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                labels: ['status: needs triage']
+                labels: ['status: waiting for maintainer']
               })
             }

--- a/.github/workflows/mark-duplicate.yml
+++ b/.github/workflows/mark-duplicate.yml
@@ -19,5 +19,5 @@ jobs:
           actions: 'mark-duplicate'
           token: ${{ secrets.GITHUB_TOKEN }}
           duplicate-labels: 'duplicate'
-          remove-labels: 'status: incomplete,status: needs triage'
+          remove-labels: 'status: incomplete,status: waiting for maintainer'
           close-issue: true

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,8 +1,10 @@
 name: No response
 
-# Both `issue_comment` and `scheduled` event types are required for this Action
+# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
 # to work properly.
 on:
+  issues:
+    types: [closed]
   issue_comment:
     types: [created]
   schedule:
@@ -18,13 +20,15 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb # v0.5.0
+      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response
           daysUntilClose: 7
           # Label requiring a response
-          responseRequiredLabel: 'status: needs more information'
+          responseRequiredLabel: 'status: waiting for author'
+          # Label to add back when the `responseRequiredLabel` is removed
+          optionalFollowupLabel: 'status: waiting for maintainer'
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable
           closeComment: >
             Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947
+      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947 # v0.0.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Number of days of inactivity before an Issue is closed for lack of response

--- a/tools-public/toolpad/pages/closedIssuesNoNeedtriage/page.yml
+++ b/tools-public/toolpad/pages/closedIssuesNoNeedtriage/page.yml
@@ -59,7 +59,7 @@ spec:
         url: https://api.github.com/repos/mui/material-ui/issues
         searchParams:
           - name: labels
-            value: 'status: needs triage'
+            value: 'status: waiting for maintainer'
           - name: per_page
             value: '100'
           - name: state
@@ -72,7 +72,7 @@ spec:
         url: https://api.github.com/repos/mui/mui-x/issues
         searchParams:
           - name: labels
-            value: 'status: needs triage'
+            value: 'status: waiting for maintainer'
           - name: per_page
             value: '100'
           - name: state
@@ -85,7 +85,7 @@ spec:
         url: https://api.github.com/repos/mui/mui-design-kits/issues
         searchParams:
           - name: labels
-            value: 'status: needs triage'
+            value: 'status: waiting for maintainer'
           - name: per_page
             value: '100'
           - name: state

--- a/tools-public/toolpad/pages/issueWithoutProductScope/page.yml
+++ b/tools-public/toolpad/pages/issueWithoutProductScope/page.yml
@@ -74,7 +74,7 @@ spec:
         url: https://api.github.com/repos/mui/material-ui/issues
         searchParams:
           - name: labels
-            value: 'status: needs triage'
+            value: 'status: waiting for maintainer'
           - name: per_page
             value: '100'
           - name: state
@@ -87,7 +87,7 @@ spec:
         url: https://api.github.com/repos/mui/mui-x/issues
         searchParams:
           - name: labels
-            value: 'status: needs triage'
+            value: 'status: waiting for maintainer'
           - name: per_page
             value: '100'
           - name: state
@@ -100,7 +100,7 @@ spec:
         url: https://api.github.com/repos/mui/mui-design-kits/issues
         searchParams:
           - name: labels
-            value: 'status: needs triage'
+            value: 'status: waiting for maintainer'
           - name: per_page
             value: '100'
           - name: state

--- a/tools-public/toolpad/pages/needtriageNotAssigned/page.yml
+++ b/tools-public/toolpad/pages/needtriageNotAssigned/page.yml
@@ -63,7 +63,7 @@ spec:
         searchParams:
           - name: q
             value: 'repo:mui/material-ui repo:mui/mui-x is:open is:issue label:"status:
-              needs triage" no:assignee'
+              waiting for maintainer" no:assignee'
         headers:
           - name: Bearer
             value: abc


### PR DESCRIPTION
Addresses point # 4 of https://github.com/mui/mui-x/issues/10810

Just before merging this PR, the GitHub label `status: needs more information` should be renamed to `status: waiting for author`, and a new label `status: waiting for maintainer` should be created.