### PR TITLE
[tools] Fix rate limiting for GitHub API

### DIFF
--- a/tools-public/toolpad/pages/issueWithoutProductScope/page.yml
+++ b/tools-public/toolpad/pages/issueWithoutProductScope/page.yml
@@ -76,7 +76,7 @@ spec:
             value: '100'
           - name: state
             value: all
-        headers: []
+        headers: [{ name: Authorization, value: { $$env: GITHUB_TOKEN } }]
         method: GET
     - name: muix
       query:


### PR DESCRIPTION
The problem:

Go to https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca?pvs=4#3888e87146b34feaa793c7d26f07220d open the link, it doesn't work

The solution:

Use the GitHub API token, queries are run on the server side, so from a single Node.js IP, which GitHub rate limit again, 60 requests/hour on the end-point we call without a token.