### PR TITLE
[tools] Move render.com services to the starter plan

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,6 +8,7 @@ services:
     rootDir: tools-public
     buildCommand: yarn && yarn build
     startCommand: node_modules/.bin/toolpad start
+    pullRequestPreviewsEnabled: false
     plan: standard
     envVars:
       - key: NODE_VERSION
@@ -28,6 +29,7 @@ services:
     rootDir: examples/custom-datagrid-column
     buildCommand: yarn && yarn build
     startCommand: node_modules/.bin/toolpad start
+    pullRequestPreviewsEnabled: false
     envVars:
       - key: NODE_VERSION
         value: 18

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,4 @@
+previewsEnabled: true
 previewsExpireAfterDays: 3
 
 services:
@@ -7,7 +8,6 @@ services:
     rootDir: tools-public
     buildCommand: yarn && yarn build
     startCommand: node_modules/.bin/toolpad start
-    pullRequestPreviewsEnabled: true
     plan: standard
     envVars:
       - key: NODE_VERSION
@@ -28,7 +28,6 @@ services:
     rootDir: examples/custom-datagrid-column
     buildCommand: yarn && yarn build
     startCommand: node_modules/.bin/toolpad start
-    pullRequestPreviewsEnabled: true
     envVars:
       - key: NODE_VERSION
         value: 18

--- a/render.yaml
+++ b/render.yaml
@@ -1,4 +1,3 @@
-previewsEnabled: true
 previewsExpireAfterDays: 3
 
 services:
@@ -8,8 +7,8 @@ services:
     rootDir: tools-public
     buildCommand: yarn && yarn build
     startCommand: node_modules/.bin/toolpad start
-    pullRequestPreviewsEnabled: false
-    plan: standard
+    pullRequestPreviewsEnabled: true
+    plan: starter
     envVars:
       - key: NODE_VERSION
         value: 18
@@ -29,7 +28,7 @@ services:
     rootDir: examples/custom-datagrid-column
     buildCommand: yarn && yarn build
     startCommand: node_modules/.bin/toolpad start
-    pullRequestPreviewsEnabled: false
+    pullRequestPreviewsEnabled: true
     envVars:
       - key: NODE_VERSION
         value: 18


### PR DESCRIPTION
~PR previews don't expire. We've been paying 25$ per month for the last six month for a stale PR: https://github.com/mui/mui-public/pull/121.~

~This PR moves us to preview which does expire after 3 days, and which should have the same implications as PR previews since we all our services were using PR previews and we don't have anything else~

Moving the service to the starter plan. Waiting with the preview env changes as I didn't take into account they don't respect the rootDir setting the same way PR previews do