### PR TITLE
[tools] Migrate from recharts to MUI X Charts

### DIFF
--- a/tools-public/package.json
+++ b/tools-public/package.json
@@ -12,6 +12,7 @@
     "@googleapis/sheets": "^4.0.2",
     "@mui/toolpad": "^0.1.40",
     "@mui/x-charts": "^6.19.3",
+    "@mui/system": "^5.0.0",
     "@octokit/core": "^4.2.1",
     "axios": "^1.3.6",
     "dayjs": "^1.11.8",

--- a/tools-public/package.json
+++ b/tools-public/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@googleapis/sheets": "^4.0.2",
     "@mui/toolpad": "^0.1.40",
+    "@mui/x-charts": "^6.19.3",
     "@octokit/core": "^4.2.1",
     "axios": "^1.3.6",
     "dayjs": "^1.11.8",
@@ -18,7 +19,6 @@
     "graphql": "^16.6.0",
     "graphql-request": "^6.0.0",
     "mysql": "^2.18.1",
-    "recharts": "^2.8.0",
     "ssh2-promise": "^1.0.3"
   },
   "devDependencies": {

--- a/tools-public/pnpm-lock.yaml
+++ b/tools-public/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@mui/toolpad':
     specifier: ^0.1.40
     version: 0.1.48(prop-types@15.8.1)(webpack@5.90.1)
+  '@mui/x-charts':
+    specifier: ^6.19.3
+    version: 6.19.3(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.15.6)(@mui/system@5.15.6)(react-dom@18.2.0)(react@18.2.0)
   '@octokit/core':
     specifier: ^4.2.1
     version: 4.2.4
@@ -32,9 +35,6 @@ dependencies:
   mysql:
     specifier: ^2.18.1
     version: 2.18.1
-  recharts:
-    specifier: ^2.8.0
-    version: 2.11.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
   ssh2-promise:
     specifier: ^1.0.3
     version: 1.0.3
@@ -1229,6 +1229,41 @@ packages:
 
   /@mui/x-charts@6.19.1(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.15.6)(@mui/system@5.15.6)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-7FJFwL+6o0Qt7RcQCeDeGL5aPzMpX8Dyh7+IOoNoaLiIHVNssAYh4D3uD2mKpZ+pcW6SE54aE5WM1SWDEC8TQA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.4.1
+      '@mui/system': ^5.4.1
+      react: ^17.0.0 || ^18.0.0
+      react-dom: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/react': 11.11.3(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.3)(react@18.2.0)
+      '@mui/base': 5.0.0-beta.34(react-dom@18.2.0)(react@18.2.0)
+      '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
+      '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
+      '@react-spring/rafz': 9.7.3
+      '@react-spring/web': 9.7.3(react-dom@18.2.0)(react@18.2.0)
+      clsx: 2.1.0
+      d3-color: 3.1.0
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /@mui/x-charts@6.19.3(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.15.6)(@mui/system@5.15.6)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-VxF+mHXtmR2LxalH2KRzF4gLT6KFDbYMvis6rkcyr+w6J17KBxMsEGx8V0nn1CIEslzcSXgbv41jIzodhiFyMQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@emotion/react': ^11.9.0
@@ -5668,27 +5703,6 @@ packages:
 
   /recharts@2.10.4(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-/Q7/wdf8bW91lN3NEeCjL9RWfaiXQViJFgdnas4Eix/I8B9HAI3tHHK/CW/zDfgRMh4fzW1zlfjoz1IAapLO1Q==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      prop-types: ^15.6.0
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      clsx: 2.1.0
-      eventemitter3: 4.0.7
-      lodash: 4.17.21
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-is: 16.13.1
-      react-smooth: 2.0.5(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
-      recharts-scale: 0.4.5
-      tiny-invariant: 1.3.1
-      victory-vendor: 36.8.6
-    dev: false
-
-  /recharts@2.11.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-5s+u1m5Hwxb2nh0LABkE3TS/lFqFHyWl7FnPbQhHobbQQia4ih1t3o3+ikPYr31Ns+kYe4FASIthKeKi/YYvMg==}
     engines: {node: '>=14'}
     peerDependencies:
       prop-types: ^15.6.0

--- a/tools-public/pnpm-lock.yaml
+++ b/tools-public/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@googleapis/sheets':
     specifier: ^4.0.2
     version: 4.0.2
+  '@mui/system':
+    specifier: ^5.0.0
+    version: 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
   '@mui/toolpad':
     specifier: ^0.1.40
     version: 0.1.48(prop-types@15.8.1)(webpack@5.90.1)
@@ -796,7 +799,7 @@ packages:
       '@babel/runtime': 7.23.9
       '@floating-ui/react-dom': 2.0.8(react-dom@18.2.0)(react@18.2.0)
       '@mui/types': 7.2.13
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       '@popperjs/core': 2.11.8
       clsx: 2.1.0
       prop-types: 15.8.1
@@ -871,7 +874,7 @@ packages:
       '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
       '@mui/types': 7.2.13
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       clsx: 2.1.0
       prop-types: 15.8.1
       react: 18.2.0
@@ -902,7 +905,7 @@ packages:
       '@mui/core-downloads-tracker': 5.15.7
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
       '@mui/types': 7.2.13
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.0
       csstype: 3.1.3
@@ -973,7 +976,7 @@ packages:
       '@mui/private-theming': 5.15.7(react@18.2.0)
       '@mui/styled-engine': 5.15.7(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
       '@mui/types': 7.2.13
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       clsx: 2.1.0
       csstype: 3.1.3
       prop-types: 15.8.1
@@ -1309,7 +1312,7 @@ packages:
       '@babel/runtime': 7.23.9
       '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       '@mui/x-data-grid': 6.19.1(@mui/material@5.15.6)(@mui/system@5.15.6)(react-dom@18.2.0)(react@18.2.0)
       '@mui/x-license-pro': 6.10.2(react@18.2.0)
       '@types/format-util': 1.0.4
@@ -1334,7 +1337,7 @@ packages:
       '@babel/runtime': 7.23.9
       '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       clsx: 2.1.0
       prop-types: 15.8.1
       react: 18.2.0
@@ -1387,7 +1390,7 @@ packages:
       '@mui/base': 5.0.0-beta.34(react-dom@18.2.0)(react@18.2.0)
       '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       '@mui/x-date-pickers': 6.19.0(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.15.6)(@mui/system@5.15.6)(dayjs@1.11.10)(react-dom@18.2.0)(react@18.2.0)
       '@mui/x-license-pro': 6.10.2(react@18.2.0)
       clsx: 2.1.0
@@ -1443,7 +1446,7 @@ packages:
       '@mui/base': 5.0.0-beta.34(react-dom@18.2.0)(react@18.2.0)
       '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.0
       dayjs: 1.11.10
@@ -1462,7 +1465,7 @@ packages:
       react: ^17.0.0 || ^18.0.0
     dependencies:
       '@babel/runtime': 7.23.9
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -1485,7 +1488,7 @@ packages:
       '@mui/base': 5.0.0-beta.34(react-dom@18.2.0)(react@18.2.0)
       '@mui/material': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react-dom@18.2.0)(react@18.2.0)
       '@mui/system': 5.15.6(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(react@18.2.0)
-      '@mui/utils': 5.15.6(react@18.2.0)
+      '@mui/utils': 5.15.7(react@18.2.0)
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.0
       prop-types: 15.8.1

--- a/tools-public/toolpad/application.yml
+++ b/tools-public/toolpad/application.yml
@@ -1,3 +1,3 @@
 apiVersion: v1
 kind: application
-spec: {}
+spec: { authentication: {}, authorization: {} }

--- a/tools-public/toolpad/components/PieChart.tsx
+++ b/tools-public/toolpad/components/PieChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import Box from '@mui/system/Box';
-import { PieChart } from '@mui/x-charts/PieChart';
+import { PieChart, pieArcLabelClasses } from '@mui/x-charts/PieChart';
 import { createComponent } from '@mui/toolpad/browser';
 
 // Copied from https://wpdatatables.com/data-visualization-color-palette/
@@ -40,12 +40,21 @@ function PieChartExport({ data, loading }: PieChartProps) {
               color: COLORS[index % COLORS.length],
               value: entry.value,
             })),
+            arcLabel: (item) => item.label!,
+            arcLabelMinAngle: 30,
             valueFormatter: ({ value }) =>
               Intl.NumberFormat('en', { notation: 'compact' }).format(value),
           },
         ]}
+        sx={{
+          [`& .${pieArcLabelClasses.root}`]: {
+            fill: 'white',
+            fontWeight: 'bold',
+          },
+        }}
         width={width}
         height={height}
+        slotProps={{ legend: { hidden: true } }}
       />
     </div>
   );

--- a/tools-public/toolpad/components/PieChart.tsx
+++ b/tools-public/toolpad/components/PieChart.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import Box from '@mui/system/Box';
 import { PieChart } from '@mui/x-charts/PieChart';
 import { createComponent } from '@mui/toolpad/browser';
 
@@ -20,9 +21,12 @@ export interface PieChartProps {
   loading: boolean;
 }
 
+const height = 300;
+const width = 300;
+
 function PieChartExport({ data, loading }: PieChartProps) {
   if (loading) {
-    return null;
+    return <Box sx={{ width, height, display: 'flex', alignItems: 'center', px: 2 }}>Loading…</Box>;
   }
 
   return (
@@ -40,8 +44,8 @@ function PieChartExport({ data, loading }: PieChartProps) {
               Intl.NumberFormat('en', { notation: 'compact' }).format(value),
           },
         ]}
-        width={300}
-        height={300}
+        width={width}
+        height={height}
       />
     </div>
   );
@@ -58,9 +62,7 @@ export default createComponent(PieChartExport, {
         { name: 'Group D', value: 200 },
       ],
     },
-    loading: {
-      type: 'boolean',
-      default: false,
-    },
   },
+  loadingPropSource: ['data'],
+  loadingProp: 'loading',
 });

--- a/tools-public/toolpad/components/PieChart.tsx
+++ b/tools-public/toolpad/components/PieChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { PieChart } from '@mui/x-charts/PieChart';
 import { createComponent } from '@mui/toolpad/browser';
-import { PieChart, Pie, Cell, Tooltip } from 'recharts';
 
 // Copied from https://wpdatatables.com/data-visualization-color-palette/
 const COLORS = [
@@ -16,29 +16,34 @@ const COLORS = [
 ];
 
 export interface PieChartProps {
-  data: object[];
+  data: any[];
+  loading: boolean;
 }
 
-function PieChartExport({ data }: PieChartProps) {
+function PieChartExport({ data, loading }: PieChartProps) {
+  if (loading) {
+    return null;
+  }
+
   return (
-    <PieChart width={300} height={300}>
-      <Pie
-        data={data}
-        cx={150}
-        cy={150}
-        innerRadius={0}
-        outerRadius={80}
-        fill="#8884d8"
-        dataKey="value"
-      >
-        {data.map((entry, index) => (
-          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-        ))}
-      </Pie>
-      <Tooltip
-        formatter={(value) => Intl.NumberFormat('en', { notation: 'compact' }).format(value)}
+    <div>
+      <PieChart
+        series={[
+          {
+            data: data.map((entry, index) => ({
+              id: index,
+              label: entry.name,
+              color: COLORS[index % COLORS.length],
+              value: entry.value,
+            })),
+            valueFormatter: ({ value }) =>
+              Intl.NumberFormat('en', { notation: 'compact' }).format(value),
+          },
+        ]}
+        width={300}
+        height={300}
       />
-    </PieChart>
+    </div>
   );
 }
 
@@ -52,6 +57,10 @@ export default createComponent(PieChartExport, {
         { name: 'Group C', value: 300 },
         { name: 'Group D', value: 200 },
       ],
+    },
+    loading: {
+      type: 'boolean',
+      default: false,
     },
   },
 });

--- a/tools-public/toolpad/pages/npmVersion/page.yml
+++ b/tools-public/toolpad/pages/npmVersion/page.yml
@@ -56,8 +56,6 @@ spec:
                   return acc
                 }, {})
             ).map((group) => ({ name: group[0], value: group[1] }))
-        loading:
-          $$jsExpression: downloadsVersions.isLoading || false
       layout:
         columnSize: 1
   queries:

--- a/tools-public/toolpad/pages/npmVersion/page.yml
+++ b/tools-public/toolpad/pages/npmVersion/page.yml
@@ -30,8 +30,6 @@ spec:
             page.parameters.package
     - component: codeComponent.PieChart
       name: codeComponent_PieChart
-      layout:
-        columnSize: 1
       props:
         data:
           $$jsExpression: |
@@ -58,6 +56,10 @@ spec:
                   return acc
                 }, {})
             ).map((group) => ({ name: group[0], value: group[1] }))
+        loading:
+          $$jsExpression: downloadsVersions.isLoading || false
+      layout:
+        columnSize: 1
   queries:
     - name: downloadsVersions
       query:


### PR DESCRIPTION
I was curious to see how we stack up compared to Recharts. A big reason why MUI X Charts should exist is the belief that work on Recharts deserves to be carried on going forward, but it's not happening. So for this to happen, the migration experience should be easy.

Before: https://tools-public.mui.com/prod/pages/npmVersion?package=next

https://github.com/mui/mui-public/assets/3165635/85eab4d1-26f2-4aae-a999-8280934632fc

After: https://mui-publictools-public-mui-public-pr-147.up.railway.app/prod/pages/npmVersion?package=next

https://github.com/mui/mui-public/assets/3165635/77e7ca04-4d06-4600-9d4a-6c567d6a7150
