### PR TITLE
[tools] Include Base UI in 1st tier support

### DIFF
--- a/tools-public/toolpad/resources/queryPRs.ts
+++ b/tools-public/toolpad/resources/queryPRs.ts
@@ -83,6 +83,28 @@ export async function queryPRs() {
             }
           }
         }
+        baseui: repository(owner: "mui", name: "base-ui") {
+          pullRequests(
+            first: 100
+            orderBy: {direction: DESC, field: CREATED_AT}
+          ) {
+            nodes {
+              number
+              url
+              title
+              state
+              repository {
+                name
+              }
+              isDraft
+              labels(first: 10) {
+                nodes {
+                  name
+                }
+              }
+            }
+          }
+        }
       }
             `;
 
@@ -97,5 +119,6 @@ export async function queryPRs() {
 
   return response.materialui.pullRequests.nodes
     .concat(response.muix.pullRequests.nodes)
+    .concat(response.baseui.pullRequests.nodes)
     .map((x) => ({ ...x, repository: x.repository.name }));
 }


### PR DESCRIPTION
Now that we have https://github.com/mui/base-ui, we should update https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca to cover Base UI.

@zannager if you want to give it a try, feel free to, would be great to apply what you are learning, otherwise, I think @michelengelen could help get to the finish line. I have created this PR in draft mode to seed 🌱 the work.