### PR TITLE
Remove UMD bundle size comparison code

### DIFF
--- a/contributor-dashboard-legacy/src/pages/SizeComparison.tsx
+++ b/contributor-dashboard-legacy/src/pages/SizeComparison.tsx
@@ -262,11 +262,6 @@ const CompareTable = memo(function CompareTable({
 });
 
 function getMainBundleLabel(bundleId: string): string {
-	if (
-		bundleId === "packages/material-ui/build/umd/material-ui.production.min.js"
-	) {
-		return "@mui/material[umd]";
-	}
 	if (bundleId === "@material-ui/core/Textarea") {
 		return "TextareaAutosize";
 	}

--- a/tools-public/toolpad/resources/bundleSizeQueries.ts
+++ b/tools-public/toolpad/resources/bundleSizeQueries.ts
@@ -2,9 +2,6 @@
 import axios from 'axios';
 
 function getMainBundleLabel(bundleId: string): string {
-  if (bundleId === 'packages/material-ui/build/umd/material-ui.production.min.js') {
-    return '@mui/material[umd]';
-  }
   if (bundleId === '@material-ui/core/Textarea') {
     return 'TextareaAutosize';
   }


### PR DESCRIPTION
UMD bundle is being removed in https://github.com/mui/material-ui/pull/42172.