### PR TITLE
[frontend-public] Fix broken HiBob gender metrics

### DIFF
--- a/tools-public/toolpad/pages/genderEngineering/page.yml
+++ b/tools-public/toolpad/pages/genderEngineering/page.yml
@@ -26,7 +26,7 @@ spec:
         kind: local
       parameters:
         - name: department
-          value: Engineering
+          value: '256186803'
   display: shell
   alias:
     - ZGrUwtd

--- a/tools-public/toolpad/resources/queryGender.ts
+++ b/tools-public/toolpad/resources/queryGender.ts
@@ -12,7 +12,7 @@ export async function queryGender(department: string) {
     throw new Error(`Env variable HIBOB_TOKEN_READ_STANDARD not configured`);
   }
 
-  const res = await fetch('https://api.hibob.com/v1/people?humanReadable=true', {
+  const res = await fetch('https://api.hibob.com/v1/profiles', {
     headers: {
       'content-type': 'application/json',
       Authorization: `Basic ${btoa(`SERVICE-5772:${process.env.HIBOB_TOKEN_READ_STANDARD}`)}`,
@@ -27,8 +27,8 @@ export async function queryGender(department: string) {
 
   let employees = data.employees;
 
-  if (department === 'Engineering') {
-    employees = employees.filter((employee) => employee.work.department === 'Engineering');
+  if (department) {
+    employees = employees.filter((employee) => employee.work.department === department);
   }
 
   return (countWomen(employees) / employees.length) * 100;
@@ -39,7 +39,7 @@ export async function queryGenderManagement() {
     throw new Error(`Env variable HIBOB_TOKEN_READ_STANDARD not configured`);
   }
 
-  const res = await fetch('https://api.hibob.com/v1/people?humanReadable=true', {
+  const res = await fetch('https://api.hibob.com/v1/profiles', {
     headers: {
       'content-type': 'application/json',
       Authorization: `Basic ${btoa(`SERVICE-5772:${process.env.HIBOB_TOKEN_READ_STANDARD}`)}`,
@@ -52,7 +52,7 @@ export async function queryGenderManagement() {
   }
   const data = await res.json();
 
-  const managers = data.employees.filter((employee) => employee.work.isManager === 'Yes');
+  const managers = data.employees.filter((employee) => employee.work.isManager === true);
 
   return (countWomen(managers) / managers.length) * 100;
 }


### PR DESCRIPTION
You can notice those KPIs being broken in https://www.notion.so/mui-org/KPIs-1ce9658b85ce4628a2a2ed2ae74ff69c?pvs=4#e044bac9c9514919b27caec440a824b3

<img width="465" alt="SCR-20240825-clvc" src="https://github.com/user-attachments/assets/b376133a-5527-4c1f-a37d-7d53b81a623c">

The problem is that we are using a legacy API. HiBob imposed a hard rate limit rule on them, 1 per minute vs. https://apidocs.hibob.com/reference/people#rate-limiting

I thought I would fix them (I was scanning through all of the KPIs), as it's quick. The solution is to use the new API HiBob exposes: https://apidocs.hibob.com/reference/get_profiles. I'm not aware of anyone in the team that has the bandwidth / focus to handle this, so need added to https://www.notion.so/mui-org/Operation-Engineer-c22287fb6cfa48c2958c66b330ae0a31.