### PR TITLE
[infra] Improve CSAT engagmenet message

### DIFF
--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -44,10 +44,7 @@ module.exports = async ({ core, context, github }) => {
     if (!['admin', 'write'].includes(userPermission.data.permission)) {
       commentLines.push('> [!NOTE]');
       commentLines.push(
-        `> @${issue.data.user.login} We value your feedback! How was your experience with our support team?`,
-      );
-      commentLines.push(
-        `> We'd love to hear your thoughts in this brief [Support Satisfaction survey](https://tally.mui.com/support-satisfaction-survey?issue=${issueNumber}&productId=${repositoryMap[repo]}). Your insights help us improve!`,
+        `> @${issue.data.user.login} How did we do? Your experience with our support team matters to us. If you have a moment, please share your thoughts in this short [Support Satisfaction survey](https://tally.mui.com/support-satisfaction-survey?issue=${issueNumber}&productId=${repositoryMap[repo]}).`,
       );
     }
 

--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -44,10 +44,10 @@ module.exports = async ({ core, context, github }) => {
     if (!['admin', 'write'].includes(userPermission.data.permission)) {
       commentLines.push('> [!NOTE]');
       commentLines.push(
-        `> We value your feedback @${issue.data.user.login}! How was your experience with our support team?`,
+        `> @${issue.data.user.login} We value your feedback! How was your experience with our support team?`,
       );
       commentLines.push(
-        `> We'd love to hear your thoughts in this brief [Support Satisfaction survey](https://tally.so/r/w4r5Mk?issue=${issueNumber}&productId=${repositoryMap[repo]}). Your insights help us improve!`,
+        `> We'd love to hear your thoughts in this brief [Support Satisfaction survey](https://tally.mui.com/support-satisfaction-survey?issue=${issueNumber}&productId=${repositoryMap[repo]}). Your insights help us improve!`,
       );
     }
 


### PR DESCRIPTION
I'm following up on https://github.com/mui/mui-public/pull/203#issuecomment-2358020779. With the extra weeks of data, it now looks clear that the new notification message converts a lot less. See https://tally.so/forms/w4r5Mk/submissions. 0 feedback for x in September vs. 11 in August.

This PR restores the previous message, I don't see why we changed it, I resonate a lot more with the previous message template, e.g. https://github.com/mui/mui-x/issues/14291#issuecomment-2317907184.

I have also updated the link to feels more official: https://tally.mui.com/support-satisfaction-survey.