### PR TITLE
[code-infra] Improve display of bundle size diff

### DIFF
--- a/tools-public/toolpad/pages/bundleSizes/page.yml
+++ b/tools-public/toolpad/pages/bundleSizes/page.yml
@@ -8,9 +8,9 @@ spec:
     - name: baseRef
       value: master
     - name: baseCommit
-      value: 66e13f6e354e2e4e174462c1f839c9bceb772b8b
+      value: a25a365a4c66738f358ecd745bf3727c0ca9d5b6
     - name: circleCIBuildNumber
-      value: '487681'
+      value: '759455'
   content:
     - component: Text
       name: text
@@ -24,6 +24,7 @@ spec:
       name: dataGrid
       layout:
         columnSize: 1
+        height: 572
       props:
         rows:
           $$jsExpression: |
@@ -67,7 +68,7 @@ spec:
               preset: bytes
             headerName: Gzip
         height: 534
-        density: standard
+        density: compact
   queries:
     - name: bundleSizes
       query:


### PR DESCRIPTION
I got frustrated with the UX of the table while working on https://github.com/mui/material-ui/pull/44075.

Before: https://tools-public.mui.com/prod/pages/bundleSizes?circleCIBuildNumber=759455&baseRef=master&baseCommit=a25a365a4c66738f358ecd745bf3727c0ca9d5b6&prNumber=44075

<img width="1458" alt="SCR-20241012-ltxz" src="https://github.com/user-attachments/assets/831168c6-ffdb-4c6a-9873-5bb2bda7941b">

After: https://mui-public-tools-public-pr-211.onrender.com/prod/pages/bundleSizes?circleCIBuildNumber=759455&baseRef=master&baseCommit=a25a365a4c66738f358ecd745bf3727c0ca9d5b6&prNumber=44075

<img width="1193" alt="SCR-20241012-mbbo" src="https://github.com/user-attachments/assets/696e0faf-fb70-4516-9ccb-6d942ca8fc47">

Side notes:

- It's impossible to search because of the virtualization: https://github.com/mui/mui-x/issues/5082
- Density mode feels wrong: https://github.com/mui/toolpad/issues/4242
- There is no way to have a full height data grid, so I went with having a larger height.