### PR TITLE
Rename Toolpad repo

### DIFF
--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -20,7 +20,8 @@ module.exports = async ({ core, context, github }) => {
 
     const repositoryMap = {
       'mui-x': 'x',
-      'toolpad': 'toolpad',
+      'mui-toolpad': 'toolpad',
+      toolpad: 'toolpad',
       'material-ui': 'material-ui',
       'base-ui': 'base-ui',
       'pigment-css': 'pigment-css',

--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -20,7 +20,7 @@ module.exports = async ({ core, context, github }) => {
 
     const repositoryMap = {
       'mui-x': 'x',
-      'mui-toolpad': 'toolpad',
+      'toolpad': 'toolpad',
       'material-ui': 'material-ui',
       'base-ui': 'base-ui',
       'pigment-css': 'pigment-css',


### PR DESCRIPTION
Closes https://github.com/mui/toolpad/issues/4261

It could be improved with:

* check and error if it can't find a productId
* pass product ID as a variable instead from the repo instead
