### PR TITLE
[infra] Adds reusable workflow "check target branch label"

### DIFF
--- a/.github/workflows/prs_check-target-branch-label.yml
+++ b/.github/workflows/prs_check-target-branch-label.yml
@@ -1,0 +1,36 @@
+name: Check for target branch labels
+
+on:
+  pull_request_target:
+    branches:
+      - 'v*.x'
+      - 'master'
+    types: ['labeled']
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  detect_cherry_pick_target:
+    runs-on: ubuntu-latest
+    name: Check target branch labels
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    if: ${{ github.event.label.name == 'needs cherry-pick' && github.event.pull_request.merged == false }}
+    steps:
+      - name: Check out mui-public repo
+        id: checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # Check this repository out, otherwise the script won't be available,
+          # as it otherwise checks out the repository where the workflow caller is located
+          repository: mui/mui-public
+      - name: Run checkTargetBranchLabel.js script
+        id: detect
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const script = require('./.github/workflows/scripts/prs/checkTargetBranchLabel.js')
+            await script({core, github, context})

--- a/.github/workflows/scripts/prs/checkTargetBranchLabel.js
+++ b/.github/workflows/scripts/prs/checkTargetBranchLabel.js
@@ -1,0 +1,69 @@
+// @ts-check
+const vBranchRegex = /^v\d{1,3}\.x$/;
+const transferLabels = ['cherry-pick'];
+
+/**
+ * @param {Object} params
+ * @param {import("@actions/core")} params.core
+ * @param {ReturnType<import("@actions/github").getOctokit>} params.github
+ * @param {import("@actions/github").context} params.context
+ */
+module.exports = async ({ core, context, github }) => {
+  try {
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const pullNumber = context.issue.number;
+
+    const pr = await github.rest.pull_request.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+
+    core.info(`>>> PR fetched: ${pr.id}`);
+
+    const targetLabels = pr.labels
+      .map((label) => label.name)
+      .filter((label) => vBranchRegex.test(label));
+
+    const comesFromVersionBranch = vBranchRegex.test(pr.head_ref);
+    const commentLines = [
+      '> [!NOTE]',
+      '> Thanks for tagging this PR with the "needs cherry-pick" label.',
+    ];
+
+    if (targetLabels.length > 0) {
+      core.info(`>>> Target labels found: ${targetLabels.join(', ')}`);
+      core.info('>>> No need for a comment! 👍');
+      return;
+    }
+
+    // there was no target branch present
+    core.info('>>> No target branch label found');
+    commentLines.push('> This PR does not have a target branch label. (e.g. `v7.x`)');
+    if (comesFromVersionBranch) {
+      commentLines.push(
+        '> Since this PR is coming from a version branch, the default target branch is `master`.',
+      );
+      commentLines.push(
+        '> If this PR should be cherry-picked to a different branch, please add the appropriate label.',
+      );
+    } else {
+      commentLines.push(
+        '> Please add the appropriate label to ensure the PR gets cherry-picked to the correct branch.',
+      );
+    }
+    commentLines.push('> Thanks! 🙏');
+
+    core.info(`>>> Creating explanatory comment on PR`);
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      body: commentLines.join('\n\n'),
+    });
+  } catch (error) {
+    core.error(`>>> Workflow failed with: ${error.message}`);
+    core.setFailed(error.message);
+  }
+};

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -14,7 +14,7 @@ module.exports = async ({ core, context, github }) => {
     const repo = context.repo.repo;
     const pullNumber = context.issue.number;
 
-    const pr = await github.rest.pull_request.get({
+    const pr = await github.rest.pulls.get({
       owner,
       repo,
       pull_number: pullNumber,


### PR DESCRIPTION
Add the new reusable workflow to check the existence of target labels on PRs with "needs cherry-pick" label