### PR TITLE
[infra] Improve cherry-pick workflow

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -22,6 +22,7 @@ jobs:
     outputs:
       targetBranches: ${{ steps.detect.outputs.TARGET_BRANCHES }}
       reviewers: ${{ steps.detect.outputs.REVIEWERS }}
+      labels: ${{ steps.detect.outputs.LABELS }}
     steps:
       - name: Check out mui-public repo
         id: checkout
@@ -59,10 +60,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
         with:
+          # the action will run for each value in matrix.branch
           branch: ${{ matrix.branch }}
           body: 'Cherry-pick of #{old_pull_request_id}'
           cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
           title: '{old_title} (@${{ github.event.pull_request.user.login }})'
+          # assigning the original reviewers to the new PR
           reviewers: ${{ needs.detect_cherry_pick_targets.outputs.reviewers }}
-          labels: |
-            cherry-pick
+          # instead of inheriting labels (including target branch label, etc.), we filter and set the labels explicitly
+          inherit_labels: false
+          labels: ${{ needs.detect_cherry_pick_targets.outputs.labels }}

--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -1,4 +1,4 @@
-name: Cherry pick onto target branch
+name: Cherry pick onto target branches
 
 on:
   pull_request_target:
@@ -11,17 +11,17 @@ on:
 permissions: {}
 
 jobs:
-  detect_cherry_pick_target:
+  detect_cherry_pick_targets:
     runs-on: ubuntu-latest
-    name: Detect cherry-pick target branch
+    name: Detect cherry-pick targets
     permissions:
       issues: write
       pull-requests: write
       contents: write
     if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
     outputs:
-      targetBranch: ${{ steps.detect.outputs.TARGET_BRANCH }}
-      transferLabels: ${{ steps.detect.outputs.TRANSFER_LABELS }}
+      targetBranches: ${{ steps.detect.outputs.TARGET_BRANCHES }}
+      reviewers: ${{ steps.detect.outputs.REVIEWERS }}
     steps:
       - name: Check out mui-public repo
         id: checkout
@@ -40,12 +40,15 @@ jobs:
   open_cherry_pick_pr:
     runs-on: ubuntu-latest
     name: Open cherry-pick PR with target branch
+    if: needs.detect_cherry_pick_targets.outputs.targetBranches != ''
+    strategy:
+      matrix:
+        branch: ${{ needs.detect_cherry_pick_targets.outputs.targetBranches }}
     permissions:
       issues: write
       pull-requests: write
       contents: write
-    needs: detect_cherry_pick_target
-    if: needs.detect_cherry_pick_target.outputs.targetBranch != ''
+    needs: detect_cherry_pick_targets
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -56,8 +59,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
         with:
-          branch: ${{ needs.detect_cherry_pick_target.outputs.targetBranch }}
+          branch: ${{ matrix.branch }}
           body: 'Cherry-pick of #{old_pull_request_id}'
           cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
           title: '{old_title} (@${{ github.event.pull_request.user.login }})'
-          labels: ${{ needs.detect_cherry_pick_target.outputs.transferLabels }}
+          reviewers: ${{ needs.detect_cherry_pick_targets.outputs.reviewers }}
+          labels: |
+            cherry-pick

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -65,7 +65,7 @@ module.exports = async ({ core, context, github }) => {
       owner,
       repo,
       issue_number: pullNumber,
-      name: label,
+      name: 'needs cherry-pick',
     });
 
     core.info(`>>> Creating explanatory comment on PR`);

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -26,7 +26,9 @@ module.exports = async ({ core, context, github }) => {
 
     // filter the target labels from the original PR
     const targetLabels = prLabels.filter((label) => vBranchRegex.test(label));
-    const otherLabels = prLabels.filter((label) => !vBranchRegex.test(label));
+    const otherLabels = prLabels.filter(
+      (label) => label !== 'needs cherry-pick' && !vBranchRegex.test(label),
+    );
 
     if (targetLabels.length === 0) {
       // there was no target branch present

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -1,6 +1,6 @@
 // @ts-check
 const vBranchRegex = /^v\d{1,3}\.x$/;
-const transferLabels = ['cherry-pick'];
+const targetBranches = [];
 
 /**
  * @param {Object} params
@@ -22,90 +22,63 @@ module.exports = async ({ core, context, github }) => {
 
     core.info(`>>> PR fetched: ${pr.number}`);
 
+    // filter the target labels from the original PR
     const targetLabels = pr.labels
-      ?.map((label) => label.name)
+      .map((label) => label.name)
       .filter((label) => vBranchRegex.test(label));
 
     if (targetLabels.length === 0) {
       // there was no target branch present
-      core.info('>>> No target branch label found');
+      core.info('>>> No target label found');
 
       if (vBranchRegex.test(pr.head_ref)) {
         // the branch this is coming from is a version branch, so the cherry-pick target should be master
         core.info('>>> Head Ref is a version branch, setting `master` as target');
-        core.setOutput('TARGET_BRANCH', 'master');
-        core.setOutput('TRANSFER_LABELS', transferLabels.join(','));
+        core.setOutput('TARGET_BRANCHES', 'master');
         return;
       }
 
-      core.setOutput('TARGET_BRANCH', '');
-      core.setOutput('TRANSFER_LABELS', transferLabels.join(','));
+      // the PR is not coming from a version branch
+      core.setOutput('TARGET_BRANCHES', '');
       return;
     }
 
     core.info(`>>> Target labels found: ${targetLabels.join(', ')}`);
-    let target = '';
 
-    // there was a target branch label present
-    // filter the highest available target number and remove the others from the PR when present
-    if (targetLabels.length > 1) {
-      core.info(`>>> Multiple target labels found.`);
-      targetLabels.sort((a, b) => {
-        const aNum = parseInt(a.match(/\d+/)[0], 10);
-        const bNum = parseInt(b.match(/\d+/)[0], 10);
-        return bNum - aNum;
-      });
+    // get a list of the original reviewers
+    const reviewers = pr.requested_reviewers.map((reviewer) => reviewer.login);
+    core.info(`>>> Reviewers from original PR: ${reviewers.join(', ')}`);
 
-      target = targetLabels.shift();
-
-      core.info(`>>> Sorting and setting the highest as 'TARGET_BRANCH' output.`);
-      core.setOutput('TARGET_BRANCH', target);
-
-      // since we have multiple targets we need to add the "needs cherry-pick" label
-      // this makes this workflow de-facto recursive
-      transferLabels.push('needs cherry-pick');
-
-      // add the other targets to the transfer labels
-      transferLabels.push(...targetLabels);
-      core.setOutput('TRANSFER_LABELS', transferLabels.join(','));
-
-      // the others will be removed from the PR
-      core.info(`>>> Removing the other target labels from the PR`);
-      for (const label of targetLabels) {
-        await github.rest.issues.removeLabel({
-          owner,
-          repo,
-          issue_number: pullNumber,
-          name: label,
-        });
-      }
-
-      core.info(`>>> Creating explanatory comment on PR`);
-      await github.rest.issues.createComment({
+    // the others will be removed from the PR
+    core.info(`>>> Removing target labels from the original PR`);
+    for (const label of targetLabels) {
+      await github.rest.issues.removeLabel({
         owner,
         repo,
         issue_number: pullNumber,
-        body: [
-          `The target branch for the cherry-pick PR has been set to \`${target}\`.`,
-          `Branches that will be created after merging are: ${targetLabels.join(', ')}`,
-          `Thank you!`,
-        ].join('\n\n'),
+        name: label,
       });
-      return;
     }
 
-    core.info(`>>> Removing the "needs cherry-pick" label from the PR`);
+    core.info(`>>> Removing "needs cherry-pick" label from the original PR`);
     await github.rest.issues.removeLabel({
       owner,
       repo,
       issue_number: pullNumber,
-      name: 'needs cherry-pick',
+      name: label,
     });
 
-    target = targetLabels[0];
-    core.info(`>>> Setting found 'TARGET_BRANCH' output.`);
-    core.setOutput('TARGET_BRANCH', target);
-    core.setOutput('TRANSFER_LABELS', transferLabels.join(','));
+    core.info(`>>> Creating explanatory comment on PR`);
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      body: `Cherry-pick PRs will be created targeting branches: ${targetLabels.join(', ')}`,
+    });
+
+    // set the target branches as output to be used as an input for the next step
+    core.setOutput('TARGET_BRANCHES', targetLabels.join(','));
+    core.setOutput('REVIEWERS', reviewers.join(','));
   } catch (error) {
     core.error(`>>> Workflow failed with: ${error.message}`);
     core.setFailed(error.message);


### PR DESCRIPTION
This handles 2 things:
1. switches to a matrix approach to prevent consecutive PRs being opened. Now this workflow will not run a number of times for each PR merged, but rather once opening several cherry-pick PRs at once (if multiple targets are needed)
2. add the reviewers from the original PR to the cherry-pick PR to improve workflow even more