### PR TITLE
[infra] Remove cherry-pick issue write permission

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -15,7 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Detect cherry-pick targets
     permissions:
-      issues: write
       pull-requests: write
       contents: write
     if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
@@ -46,7 +45,6 @@ jobs:
       matrix:
         branch: ${{ fromJSON(needs.detect_cherry_pick_targets.outputs.targetBranches) }}
     permissions:
-      issues: write
       pull-requests: write
       contents: write
     needs: detect_cherry_pick_targets


### PR DESCRIPTION
I noticed this in #244, this permission seems wrong, I imagine GitHub Actions tokens works the same way as https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment

<img width="492" alt="SCR-20241117-onsv" src="https://github.com/user-attachments/assets/3cae6502-3088-480a-8e07-de0131e9c7b0">

I actually don't know if this even has an impact here, so going for: https://github.com/mui/mui-x/pull/15456. 
