### PR TITLE
[tools] Link to the right npm page

### DIFF
--- a/tools-public/toolpad/pages/npmVersion/page.yml
+++ b/tools-public/toolpad/pages/npmVersion/page.yml
@@ -14,12 +14,13 @@ spec:
         columnSize: 1
       props:
         mode: markdown
-        value: >-
-          ## Downloads in the last 7 days
+        value:
+          $$jsExpression: >-
+            `## Downloads in the last 7 days
 
 
-          Same data as in
-          https://www.npmjs.com/package/react-dom?activeTab=versions.
+            Same data as in
+            https://www.npmjs.com/package/${textField.value}?activeTab=versions.`
     - component: TextField
       name: textField
       layout:


### PR DESCRIPTION
Before:
<img width="643" alt="SCR-20241203-klvv" src="https://github.com/user-attachments/assets/cb8a1e30-2b73-43fc-b765-21e2d64991aa">

After:
<img width="614" alt="SCR-20241203-kmfj" src="https://github.com/user-attachments/assets/d600f8d6-6109-4c25-bae6-8719bb4f8e75">

https://mui-public-tools-public-pr-253.onrender.com/prod/pages/npmVersion