### PR TITLE
[tools] Improve the about export

### DIFF
--- a/tools-public/toolpad/pages/muicomabout/page.yml
+++ b/tools-public/toolpad/pages/muicomabout/page.yml
@@ -18,18 +18,25 @@ spec:
         height: 632
       props:
         rows:
-          $$jsExpression: |
-            queryAbout.rows
+          $$jsExpression: |-
+            queryAbout.rows.map((row) => ({
+              ...row,
+              twitter: row.twitter ? `https://x.com/${row.twitter}` : null,
+              github: row.github ? `https://github.com/${row.github}` : null,
+            }))
         columns:
           - field: name
             type: string
             width: 175
+            headerName: Name
           - field: title
             type: string
             width: 246
+            headerName: Title
           - field: about
             type: string
             width: 472
+            headerName: About
           - field: location
             type: string
             width: 296

--- a/tools-public/toolpad/resources/queryAbout.ts
+++ b/tools-public/toolpad/resources/queryAbout.ts
@@ -22,7 +22,7 @@ export async function queryAbout() {
       showInactive: false,
       humanReadable: 'REPLACE',
       fields: [
-        'root.fullName',
+        'root.displayName', // 'root.fullName', is the legal name, use the preferred name instead.
         'address.country',
         'address.city',
         'work.title',
@@ -59,13 +59,13 @@ export async function queryAbout() {
     .map((employee) => {
       const country = countryFix[employee.address.country] || employee.address.country;
       return {
-        name: employee.fullName,
+        name: employee.displayName,
         title: employee.work.title,
-        about: employee.about?.custom?.field_1690557141686,
-        location: `${employee.address.city} - ${country}`,
+        location: `${employee.address.city}, ${country}`,
         locationCountry: countryToISO[country],
-        twitter: employee.about?.socialData?.twitter,
-        github: employee.about?.custom?.field_1682954415714,
+        about: employee.about?.custom?.field_1690557141686,
+        twitter: employee.about?.socialData?.twitter?.replace('https://www.twitter.com/', ''),
+        github: employee.about?.custom?.field_1682954415714?.replace('https://github.com/', ''),
         // ...employee,
       };
     });


### PR DESCRIPTION
This helps to keep https://www.notion.so/mui-org/XXX-s-onboarding-c980eff81a1e405bb36476d0cf22b5e6?pvs=4#9e8f853698cd4a819ea5cdcb33c588f5 up to date.

Before: https://tools-public.mui.com/prod/pages/muicomabout
After: https://mui-public-tools-public-pr-254.onrender.com/prod/pages/muicomabout

This is used in https://github.com/mui/material-ui/blob/9057a52a6a229ef710bd324882b9d2be1a49b01f/docs/src/components/about/Team.tsx#L25