### PR TITLE
[infra] Reduce Overdue ratio thresholds

### DIFF
--- a/tools-public/toolpad/pages/overdueRatio/page.yml
+++ b/tools-public/toolpad/pages/overdueRatio/page.yml
@@ -10,8 +10,8 @@ spec:
       layout:
         columnSize: 1
       props:
-        warning: 9
-        problem: 11
+        warning: 7
+        problem: 10
         lowerIsBetter: true
         value:
           $$jsExpression: |


### PR DESCRIPTION
## What

Improve this iframe:

<img width="392" alt="SCR-20241223-leyl" src="https://github.com/user-attachments/assets/356c927f-e1b4-4303-b69e-ed6fc8aebfc8" />

https://www.notion.so/mui-org/KPIs-Finance-165cbfe7b66080ec8ac3cf9d616518df?pvs=4#165cbfe7b660803b8009c7b0a26a6675

## Problems

1. Sync error threshold with https://www.notion.so/mui-org/KPIs-Finance-165cbfe7b66080ec8ac3cf9d616518df?pvs=4#165cbfe7b6608084b2deeab53843ef7e. I guess 10% is OK.
2. Now, it feels like we are always most of the time much below so we can tidy up the warning range.