### PR TITLE
[code-infra] Allow manual cherry pick inputs

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -2,6 +2,15 @@ name: Cherry pick onto target branches
 
 on:
   workflow_call:
+    inputs:
+      target_branch:
+        description: 'A target branch passed from the caller workflow'
+        required: false
+        type: string
+      pr_number:
+        description: 'The PR number to cherry-pick from'
+        required: false
+        type: string
 
 permissions: {}
 
@@ -12,7 +21,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true }}
+    if: ${{ (inputs.target_branch != '' && inputs.pr_number != '') || (contains(github.event.pull_request.labels.*.name, 'needs cherry-pick') && github.event.pull_request.merged == true)}}
     outputs:
       targetBranches: ${{ steps.detect.outputs.TARGET_BRANCHES }}
       reviewers: ${{ steps.detect.outputs.REVIEWERS }}
@@ -28,6 +37,9 @@ jobs:
       - name: Detect target
         id: detect
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const script = require('./.github/workflows/scripts/prs/detectTargetBranch.js');


### PR DESCRIPTION
This should allow us to call cherry pick automation with a dispatch call as well as pr merged.

I didn't opt to have a "on tag added" trigger, because it could re-trigger previously created cherrypicks if the PR had any. Making it manual is intentional

> Untested 😆 

Example of code on MUI-X

```yaml
name: Create cherry-pick PR
on:
  pull_request_target:
    branches: [master, next, 'v[0-9]+.x']
    types: [closed]
  workflow_dispatch:
    inputs:
      target_branch:
        description: 'A target branch passed from the caller workflow'
        required: true
        type: string
      pr_number:
        description: 'The PR number to cherry-pick from'
        required: true
        type: string

permissions: {}

jobs:
  create_pr:
    name: Create cherry-pick PR
    uses: mui/mui-public/.github/workflows/prs_create-cherry-pick-pr.yml@master
    permissions:
      contents: write
      pull-requests: write
    with:
      target_branch: ${{ inputs.target_branch }}
      pr_number: ${{ inputs.pr_number }}

```