### PR TITLE
[tools] Fix render deploy

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -7,7 +7,14 @@ services:
     name: mui-public-tools-public
     env: node
     rootDir: tools-public
-    buildCommand: corepack enable && pnpm install --frozen-lockfile && pnpm build
+    buildCommand: |
+      # Required per https://github.com/pnpm/pnpm/issues/9029#issuecomment-2629866277
+      npm install -g corepack@latest
+
+      corepack enable
+      pnpm --version
+      pnpm install --frozen-lockfile
+      pnpm build
     startCommand: pnpm start
     plan: starter
     previews:

--- a/tools-public/toolpad/pages/OverviewPage/page.yml
+++ b/tools-public/toolpad/pages/OverviewPage/page.yml
@@ -590,7 +590,7 @@ spec:
                           layout:
                             columnSize: 1
                           props:
-                            value: Missing gitHub label
+                            value: Missing GitHub label
                         - component: Text
                           name: text33
                           layout:


### PR DESCRIPTION
The build is broken: https://dashboard.render.com/web/srv-cgd3k7ceoogljtstv01g/deploys/dep-cuhncfdumphs73fn17ig?r=2025-02-05%4014%3A30%3A26%7E2025-02-05%4014%3A32%3A36.

<img width="916" alt="SCR-20250205-sjlj" src="https://github.com/user-attachments/assets/7da21a37-8c9d-4271-a925-0acbc6471254" />

See for context on what went wrong: https://github.com/pnpm/pnpm/issues/9029.