### PR TITLE
[code-infra] Support running GitHub Actions with cherry-pick

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -11,6 +11,12 @@ on:
         description: 'The PR number to cherry-pick from'
         required: false
         type: string
+    secrets:
+      token:
+        # Needed when the repository uses GitHub actions https://github.com/orgs/community/discussions/55906
+        # We usually use CircleCI but not always.
+        description: 'The github token to use for the API calls. You can use the GITHUB_TOKEN secret'
+        required: false
 
 permissions: {}
 
@@ -67,6 +73,7 @@ jobs:
         with:
           # the action will run for each value in matrix.branch
           branch: ${{ matrix.branch }}
+          token: ${{ secrets.token }}
           body: 'Cherry-pick of #{old_pull_request_id}'
           cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
           title: '{old_title} (@${{ github.event.pull_request.user.login }})'


### PR DESCRIPTION
I noticed on https://github.com/mui/material-ui/pull/45226 that the GitHub Actions didn't trigger:

<img width="522" alt="SCR-20250205-ukqa" src="https://github.com/user-attachments/assets/e11ccbcf-5f14-4e54-bd2c-4327a3fc878d" />

Looking closer, I can link this back to a limitation that GitHub has to limit circular dependencies of actions https://github.com/orgs/community/discussions/55906. 

MUI X doesn't fall into this case, but Material UI does.

Oh ok, it's another to do it: https://github.com/mui/material-ui/pull/45100/commits, push extra commits, not great DX though.

My thought is that we can use https://www.notion.so/mui-org/Accounts-945f0ccb9f7749ccb9e84b9eb9b13ec7?pvs=4#5939440218e844b982761a0634b3b992 create a PAT, and use that for Material UI.