### PR TITLE
[infra] Enhance closing message logic for customer feedback

### DIFF
--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -41,8 +41,13 @@ module.exports = async ({ core, context, github }) => {
 
     core.info(`>>> Author permission level: ${userPermission.data.permission}`);
 
+    // checks if the issue was created from a customer with commercial support (pro, premium or priority plan)
+    const isPaidSupport = issue.labels.some((label) =>
+      /\b(pro|premium|priority)\b/i.test(label.name),
+    );
+
     // Only ask for feedback if the user is not an admin or has at least write access (from a team membership)
-    if (!['admin', 'write'].includes(userPermission.data.permission)) {
+    if (!['admin', 'write'].includes(userPermission.data.permission) && isPaidSupport) {
       commentLines.push('> [!NOTE]');
       commentLines.push(
         `> @${issue.data.user.login} How did we do? Your experience with our support team matters to us. If you have a moment, please share your thoughts in this short [Support Satisfaction survey](https://tally.mui.com/support-satisfaction-survey?issue=${issueNumber}&productId=${repositoryMap[repo]}).`,

--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -46,7 +46,7 @@ module.exports = async ({ core, context, github }) => {
       /\b(pro|premium|priority)\b/i.test(label.name),
     );
 
-    // Only ask for feedback if the user is not an admin or has at least write access (from a team membership)
+    // Only ask for feedback if the user is not an admin or doesn't have write access (from a team membership)
     if (!['admin', 'write'].includes(userPermission.data.permission) && isPaidSupport) {
       commentLines.push('> [!NOTE]');
       commentLines.push(

--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -41,7 +41,7 @@ module.exports = async ({ core, context, github }) => {
 
     core.info(`>>> Author permission level: ${userPermission.data.permission}`);
 
-    // checks if the issue was created from a customer with commercial support (pro, premium or priority plan)
+    // checks if the issue was created by a customer with commercial support (pro, premium, or priority plan)
     const isPaidSupport = issue.labels.some((label) =>
       /\b(pro|premium|priority)\b/i.test(label.name),
     );


### PR DESCRIPTION
Related to https://github.com/mui/mui-x/issues/16655#issuecomment-2673113182 and .

Add a check to ensure feedback requests are targeted at issues from paying customers with specific support plans. This change helps focus survey prompts on users with commercial support, improving feedback relevance.

I am not so sure if we should ditch the feedback from community members all together ... it feels wrong and we do get valuable feedback from them. On the other hand I am curious if this will increase conversion rate though. 🤷🏼 

Help with #156.