### PR TITLE
[infra] Enforce type labels on PRs

### DIFF
--- a/.github/workflows/prs_check-if-pr-has-type-label.yml
+++ b/.github/workflows/prs_check-if-pr-has-type-label.yml
@@ -1,0 +1,31 @@
+name: Check PR for type labels
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  detect_cherry_pick_target:
+    runs-on: ubuntu-latest
+    name: Check PR type labels
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: write
+    if: ${{ github.event.pull_request.merged == false }}
+    steps:
+      - name: Check out mui-public repo
+        id: checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # Check this repository out, otherwise the script won't be available,
+          # as it otherwise checks out the repository where the workflow caller is located
+          repository: mui/mui-public
+      - name: Run checkTypeLabel.js script
+        id: detect
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const script = require('./.github/workflows/scripts/prs/checkTypeLabel.js');
+            await script({core, github, context});

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -9,7 +9,14 @@ const createEnumerationFromArray = (stringArray) =>
       `\`${stringArray.slice(-1)}\``
     : stringArray.map((s) => `\`${s}\``).join('');
 
-const typeLabels = ['bug', 'regression', 'maintenance', 'enhancement', 'new feature'];
+const typeLabels = [
+  'bug',
+  'regression',
+  'maintenance',
+  'enhancement',
+  'new feature',
+  'dependencies',
+];
 const labelRegex = new RegExp(`\\b(${typeLabels.join('|')})\\b`, 'i');
 
 /**

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -1,0 +1,74 @@
+// @ts-check
+const createEnumerationFromArray = (stringArray) =>
+  stringArray.length > 1
+    ? stringArray
+        .slice(0, -1)
+        .map((s) => `\`${s}\``)
+        .join(', ') +
+      ' or ' +
+      `\`${stringArray.slice(-1)}\``
+    : stringArray.map((s) => `\`${s}\``).join('');
+
+const typeLabels = ['bug', 'regression', 'maintenance', 'enhancement', 'new feature'];
+const labelRegex = new RegExp(`\\b(${typeLabels.join('|')})\\b`, 'i');
+
+/**
+ * @param {Object} params
+ * @param {import("@actions/core")} params.core
+ * @param {ReturnType<import("@actions/github").getOctokit>} params.github
+ * @param {import("@actions/github").context} params.context
+ */
+module.exports = async ({ core, context, github }) => {
+  try {
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+    const pullNumber = context.issue.number;
+
+    const { data: pr } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+
+    core.info(`>>> PR fetched: ${pr.number}`);
+
+    const typeLabelsFound = pr.labels
+      ?.map((label) => label.name)
+      .filter((labelName) => labelRegex.test(labelName));
+
+    const commentLines = [];
+
+    if (typeLabelsFound.length === 0) {
+      core.info(`>>> No type labels found`);
+
+      // Add a comment line explaining that a type label needs to be added
+      commentLines.push(
+        'Please add one type label to categorize the purpose of this PR appropriately:',
+      );
+      commentLines.push(createEnumerationFromArray(typeLabels));
+    } else if (typeLabelsFound.length > 1) {
+      core.info(`>>> Multiple type labels found: ${typeLabelsFound.join(', ')}`);
+
+      // add a comment line explaining that only one type label is allowed
+      commentLines.push(`Multiple type labels found: ${typeLabelsFound.join(', ')}`);
+      commentLines.push(
+        'Only one is allowed. Please remove the extra type labels to ensure the PR is categorized correctly.',
+      );
+    } else {
+      core.info(`>>> Single type label found: ${typeLabelsFound[0]}`);
+      core.info(`>>> Exiting gracefully! 👍`);
+      return;
+    }
+
+    core.info(`>>> Creating explanatory comment on PR`);
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pullNumber,
+      body: commentLines.join('\n\n'),
+    });
+  } catch (error) {
+    core.error(`>>> Workflow failed with: ${error.message}`);
+    core.setFailed(error.message);
+  }
+};

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -67,6 +67,7 @@ module.exports = async ({ core, context, github }) => {
       issue_number: pullNumber,
       body: commentLines.join('\n\n'),
     });
+    core.setFailed('>>> Failing workflow to prevent merge without passing this!');
   } catch (error) {
     core.error(`>>> Workflow failed with: ${error.message}`);
     core.setFailed(error.message);

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -13,9 +13,9 @@ const typeLabels = [
   'bug',
   'regression',
   'maintenance',
+  'dependencies',
   'enhancement',
   'new feature',
-  'dependencies',
 ];
 const labelRegex = new RegExp(`\\b(${typeLabels.join('|')})\\b`, 'i');
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and a supporting script to ensure that pull requests have appropriate type labels. The most important changes include the creation of the workflow file and the implementation of the script to check for type labels.

New workflow for checking PR type labels:

* [`.github/workflows/prs_check-if-pr-has-type-label.yml`](diffhunk://#diff-adcf5b5fffef44caa3ceff40940b89c3870a96429acef30fb876e316b733bbc1R1-R31): Added a new workflow to check if pull requests have appropriate type labels. This workflow runs on a PR event and uses the `actions/checkout` and `actions/github-script` actions to execute the label checking script.

Implementation of the label checking script:

* [`.github/workflows/scripts/prs/checkTypeLabel.js`](diffhunk://#diff-361998ca54b30aa96846c66027233605002330c9bcceaca8a419381e01658d7bR1-R82): Added a script that verifies the presence of type labels on pull requests. The script checks for specific labels, creates comments on the PR if the labels are missing or incorrect, and fails the workflow to prevent merging without proper labels.

PRs should be labeled according to their purpose. `release`, `bug`/`regression` and `enhancement`/`new feature` should be self explanatory. `maintenance` is meant to categorize refactors, cleanups and structural changes. `dependencies` is similar, but not quite the same. We could potentially combine the two into one.