### PR TITLE
[infra] Fix workflow permission

### DIFF
--- a/.github/workflows/prs_check-if-pr-has-type-label.yml
+++ b/.github/workflows/prs_check-if-pr-has-type-label.yml
@@ -6,11 +6,10 @@ on:
 permissions: {}
 
 jobs:
-  detect_cherry_pick_target:
+  check_type_label:
     runs-on: ubuntu-latest
     name: Check PR type labels
     permissions:
-      issues: write
       pull-requests: write
       contents: write
     if: ${{ github.event.pull_request.merged == false }}


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration to rename a job and adjust its permissions.

Workflow configuration updates:

* [`.github/workflows/prs_check-if-pr-has-type-label.yml`](diffhunk://#diff-adcf5b5fffef44caa3ceff40940b89c3870a96429acef30fb876e316b733bbc1L9-L13): Renamed the job from `detect_cherry_pick_target` to `check_type_label` and removed the `issues: write` permission.