### PR TITLE
[infra] try without comment

### DIFF
--- a/.github/workflows/prs_check-if-pr-has-type-label.yml
+++ b/.github/workflows/prs_check-if-pr-has-type-label.yml
@@ -6,11 +6,10 @@ on:
 permissions: {}
 
 jobs:
-  detect_cherry_pick_target:
+  check_type_label:
     runs-on: ubuntu-latest
     name: Check PR type labels
     permissions:
-      issues: write
       pull-requests: write
       contents: write
     if: ${{ github.event.pull_request.merged == false }}

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -68,13 +68,16 @@ module.exports = async ({ core, context, github }) => {
       return;
     }
 
-    core.info(`>>> Creating explanatory comment on PR`);
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: pullNumber,
-      body: commentLines.join('\n\n'),
-    });
+    core.info(`>>> No type labels found.`);
+    core.info(`>>> Comment: \n"${commentLines.join('\n\n')}"`);
+    // core.info(`>>> Creating explanatory comment on PR`);
+    // await github.rest.issues.createComment({
+    //   owner,
+    //   repo,
+    //   issue_number: pullNumber,
+    //   body: commentLines.join('\n\n'),
+    // });
+
     core.setFailed('>>> Failing workflow to prevent merge without passing this!');
   } catch (error) {
     core.error(`>>> Workflow failed with: ${error.message}`);


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and associated script to check for type labels on pull requests. The most important changes include renaming the job in the workflow file and modifying the script to log comments instead of creating them.

Changes to GitHub Actions workflow:

* [`.github/workflows/prs_check-if-pr-has-type-label.yml`](diffhunk://#diff-adcf5b5fffef44caa3ceff40940b89c3870a96429acef30fb876e316b733bbc1L9-L13): Renamed the job from `detect_cherry_pick_target` to `check_type_label` and removed unnecessary permissions for `issues`.

Modifications to the script:

* [`.github/workflows/scripts/prs/checkTypeLabel.js`](diffhunk://#diff-361998ca54b30aa96846c66027233605002330c9bcceaca8a419381e01658d7bL71-R80): Updated the script to log comments instead of creating them on the pull request, and added logging to indicate when no type labels are found.