### PR TITLE
[infra] Fix multiple comments issue

### DIFF
--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -10,7 +10,6 @@ const createEnumerationFromArray = (stringArray) =>
     : stringArray.map((s) => `\`${s}\``).join('');
 
 const typeLabels = [
-  'docs',
   'release',
   'bug',
   'regression',

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -22,7 +22,7 @@ const typeLabels = [
 const labelRegex = new RegExp(`\\b(${typeLabels.join('|')})\\b`, 'i');
 
 function containsAny(str, substrings) {
-  return substrings.some((sub) => str?.includes(sub));
+  return str ? substrings.some((sub) => str?.includes(sub)) : false;
 }
 
 const COMMENT_STARTS = [

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -58,6 +58,10 @@ module.exports = async ({ core, context, github }) => {
       ),
     );
 
+    const multipleCommentFound = prComments?.find((c) =>
+      c.body.includes('Multiple type labels found: '),
+    );
+
     const commentLines = [];
 
     if (typeLabelsFound.length === 0) {
@@ -76,6 +80,12 @@ module.exports = async ({ core, context, github }) => {
       commentLines.push(createEnumerationFromArray(typeLabels));
     } else if (typeLabelsFound.length > 1) {
       core.info(`>>> Multiple type labels found: ${typeLabelsFound.join(', ')}`);
+
+      if (multipleCommentFound) {
+        core.info(`>>> PR already has the multiple type label comment.`);
+        core.info(`>>> Exiting gracefully! 👍`);
+        return;
+      }
 
       // add a comment line explaining that only one type label is allowed
       commentLines.push(`Multiple type labels found: ${typeLabelsFound.join(', ')}`);


### PR DESCRIPTION
This pull request includes several changes to the `checkTypeLabel.js` script to enhance its functionality and improve its handling of multiple type labels in pull requests. The most important changes include removing an unnecessary type label, adding logic to check for existing comments about multiple type labels, and exiting gracefully if such a comment is already present.

Enhancements to `checkTypeLabel.js` script:

* Removed the `'docs'` type label from the `typeLabels` array, as it is no longer needed.
* Added logic to find existing comments that mention multiple type labels in the `prComments` array.
* Implemented a check to exit gracefully if a comment about multiple type labels is already present, preventing duplicate comments.