### PR TITLE
[infra] Fix the closing message workflow

### DIFF
--- a/.github/workflows/scripts/issues/addClosingMessage.js
+++ b/.github/workflows/scripts/issues/addClosingMessage.js
@@ -42,7 +42,7 @@ module.exports = async ({ core, context, github }) => {
     core.info(`>>> Author permission level: ${userPermission.data.permission}`);
 
     // checks if the issue was created by a customer with commercial support (pro, premium, or priority plan)
-    const isPaidSupport = issue.labels.some((label) =>
+    const isPaidSupport = issue.data.labels.some((label) =>
       /\b(pro|premium|priority)\b/i.test(label.name),
     );
 


### PR DESCRIPTION
This pull request includes a minor change to the `addClosingMessage.js` script in the GitHub workflows. The change updates the property used to access issue labels to ensure the correct data is being referenced.

* [`.github/workflows/scripts/issues/addClosingMessage.js`](diffhunk://#diff-49c99cf6a373f8f1c4914a6873976f1e72230993ebc15ae6d934222646d66868L45-R45): Modified the `isPaidSupport` variable to access `issue.data.labels` instead of `issue.labels`.