### PR TITLE
[infra] Changed branch name format

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -73,7 +73,7 @@ jobs:
           branch: ${{ matrix.branch }}
           token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
           body: 'Cherry-pick of #{old_pull_request_id}'
-          cherry-pick-branch: ${{ format('cherry-pick-{0}', github.event.number) }}
+          cherry-pick-branch: ${{ format('cherry-pick-{0}-to-{1}', github.event.number, matrix.branch) }}
           title: '{old_title} (@${{ github.event.pull_request.user.login }})'
           # assigning the original reviewers to the new PR
           reviewers: ${{ needs.detect_cherry_pick_targets.outputs.reviewers }}


### PR DESCRIPTION
changed the branch name format to make them unique in matrix runs. Previously, when creating multiple cherry-pick branches it was trying to create branches with the same name and failed

Came up in https://github.com/mui/mui-x/pull/17051