### PR TITLE
[infra] Added workflow to handle stale issues and PRs

### DIFF
--- a/.github/workflows/general_handle-stale-issues-and-prs.yml
+++ b/.github/workflows/general_handle-stale-issues-and-prs.yml
@@ -16,8 +16,8 @@ jobs:
           operations-per-run: 50
 
           # stale issue handling
-          stale-issue-message: 'This issue is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in another 5 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          stale-issue-message: 'This issue has been inactive for 7 days. Please remove the stale label or leave a comment to keep it open. Otherwise, it will be closed in 5 days.'
+          close-issue-message: 'This issue has been closed due to 5 days of inactivity after being marked stale.'
           # labeling "stale" after 7 days and closing after additional 5 days
           days-before-issue-stale: 7
           days-before-issue-close: 5
@@ -25,8 +25,8 @@ jobs:
           only-issue-labels: 'status: waiting for maintainer'
 
           # stale PR handling
-          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
-          close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
+          stale-pr-message: 'This pull request has been inactive for 30 days. Please remove the stale label or leave a comment to keep it open. Otherwise, it will be closed in 15 days.'
+          close-pr-message: 'This pull request has been closed due to 15 days of inactivity after being marked stale.'
           # labeling "stale" after 30 days and closing after additional 15 days
           days-before-pr-stale: 30
           days-before-pr-close: 15

--- a/.github/workflows/general_handle-stale-issues-and-prs.yml
+++ b/.github/workflows/general_handle-stale-issues-and-prs.yml
@@ -1,0 +1,34 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_call:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      # only needed for delete-branch option (which we are currently not using)
+      # contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 50
+
+          # stale issue handling
+          stale-issue-message: 'This issue is stale because it has been open 7 days with no activity. Remove stale label or comment or this will be closed in another 5 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          # labeling "stale" after 7 days and closing after additional 5 days
+          days-before-issue-stale: 7
+          days-before-issue-close: 5
+          # only run on issues with the waiting for maintainer label
+          only-issue-labels: 'status: waiting for maintainer'
+
+          # stale PR handling
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
+          close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
+          # labeling "stale" after 30 days and closing after additional 15 days
+          days-before-pr-stale: 30
+          days-before-pr-close: 15
+          # do not run this on draft PRs
+          exempt-draft-pr: true


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests. The workflow is designed to label and close issues and pull requests that have been inactive for a specified period.

It is ment to be used with a CRON job on the repos. 
I plan to also add a manual trigger (at least for the first few days) to run this occasionally to mark and close old PRs and issues!

On a side note: I changed the threshold times we previously discussed.

Key changes:

* Added a new GitHub Actions workflow file `.github/workflows/general_handle-stale-issues-and-prs.yml` to handle stale issues and pull requests.
  * Issues will be labeled as "stale" after 7 days of inactivity and closed after an additional 5 days if no activity occurs.
  * Pull requests will be labeled as "stale" after 30 days of inactivity and closed after an additional 15 days if no activity occurs.
  * The workflow excludes draft pull requests from being marked as stale.