### PR TITLE
[infra] Adds input to manually define operations

### DIFF
--- a/.github/workflows/general_handle-stale-issues-and-prs.yml
+++ b/.github/workflows/general_handle-stale-issues-and-prs.yml
@@ -1,6 +1,12 @@
 name: 'Close stale issues and PRs'
 on:
   workflow_call:
+    inputs:
+      operations:
+        description: 'The number of operations to use (should not exceed 500)'
+        default: 50
+        required: false
+        type: number
 
 jobs:
   stale:
@@ -13,7 +19,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          operations-per-run: 50
+          operations-per-run: ${{ inputs.operations }}
 
           # stale issue handling
           stale-issue-message: 'This issue has been inactive for 7 days. Please remove the stale label or leave a comment to keep it open. Otherwise, it will be closed in 5 days.'
@@ -21,8 +27,8 @@ jobs:
           # labeling "stale" after 7 days and closing after additional 5 days
           days-before-issue-stale: 7
           days-before-issue-close: 5
-          # only run on issues with the waiting for maintainer label
-          only-issue-labels: 'status: waiting for maintainer'
+          # only run on issues with the waiting for author label
+          only-issue-labels: 'status: waiting for author'
 
           # stale PR handling
           stale-pr-message: 'This pull request has been inactive for 30 days. Please remove the stale label or leave a comment to keep it open. Otherwise, it will be closed in 15 days.'


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/general_handle-stale-issues-and-prs.yml` file to make the workflow more flexible and accurate. The most important changes include adding an input parameter for the number of operations and modifying the label used for identifying stale issues.

Enhancements to workflow flexibility and accuracy:

* [`.github/workflows/general_handle-stale-issues-and-prs.yml`](diffhunk://#diff-86a66f90da56f7c560ad4538035cc569747092cb2bb1de111acb8786da2dc175R4-R9): Added an input parameter `operations` to allow customization of the number of operations per run, with a default value of 50.
* [`.github/workflows/general_handle-stale-issues-and-prs.yml`](diffhunk://#diff-86a66f90da56f7c560ad4538035cc569747092cb2bb1de111acb8786da2dc175L16-R31): Updated the `operations-per-run` step to use the new `operations` input parameter.
* [`.github/workflows/general_handle-stale-issues-and-prs.yml`](diffhunk://#diff-86a66f90da56f7c560ad4538035cc569747092cb2bb1de111acb8786da2dc175L16-R31): Changed the label for identifying stale issues from `status: waiting for maintainer` to `status: waiting for author` to better reflect the issue's status.