### PR TITLE
[infra] Fixed the if condition in type label script

### DIFF
--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -74,7 +74,7 @@ const createCommentHandler =
     }
 
     // only create a new comment if it's not the success comment
-    if (commentLines[0] !== COMMENT_FIRST_LINE.SUCCESS_COMMENT) {
+    if (commentLines[0] === COMMENT_FIRST_LINE.SUCCESS_COMMENT) {
       core.info(`>>> No need for a comment!`);
       core.info(`>>> Exiting gracefully! 👍`);
       return;


### PR DESCRIPTION
This pull request includes a minor change to the `checkTypeLabel.js` script in the `.github/workflows/scripts/prs` directory. The change ensures that a new comment is only created if the first line of the comment is the success comment.

* Modified the condition in `createCommentHandler` to check if the first line of the comment is the success comment, preventing unnecessary comments. (`.github/workflows/scripts/prs/checkTypeLabel.js`)