### PR TITLE
[infra] Add condition to skip comment check for pull requests

### DIFF
--- a/.github/workflows/issues_status-label-handler.yml
+++ b/.github/workflows/issues_status-label-handler.yml
@@ -9,6 +9,7 @@ jobs:
   add-comment:
     runs-on: ubuntu-latest
     name: Check author permission and status labels
+    if: ${{ !github.event.issue.pull_request }}
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/issues_status-label-handler.yml` file. The change adds a condition to check if the event is not a pull request before proceeding with the job. 

* [`.github/workflows/issues_status-label-handler.yml`](diffhunk://#diff-0e8116178c69425e164d76127840e07db2db819a957b9c573dd946f2187551a7R12): Added a condition to check if the event is not a pull request (`if: ${{ !github.event.issue.pull_request }}`).