### PR TITLE
[infra] Grants write permissions for actions

### DIFF
--- a/.github/workflows/issues_status-label-handler.yml
+++ b/.github/workflows/issues_status-label-handler.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      actions: write
     steps:
       - name: Check out mui-public repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/issues_status-label-handler.yml` file to update the permissions for the GitHub Actions workflow.

The actions permission is needed to delete the previous cache and create a new one, since the cache is immutable.

Permissions update:

* [`.github/workflows/issues_status-label-handler.yml`](diffhunk://#diff-0e8116178c69425e164d76127840e07db2db819a957b9c573dd946f2187551a7R15): Added `actions: write` permission to the `permissions` section.