### PR TITLE
[infra] Update stale action version and add permissions section

### DIFF
--- a/.github/workflows/general_handle-stale-issues-and-prs.yml
+++ b/.github/workflows/general_handle-stale-issues-and-prs.yml
@@ -8,6 +8,8 @@ on:
         required: false
         type: number
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -17,7 +19,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           operations-per-run: ${{ inputs.operations }}
 


### PR DESCRIPTION
Review remarks from @oliviertassinari about the [top-level action permissions](https://github.com/mui/mui-public/pull/288#discussion_r2019792828) (thanks for pointing that out) and the [pinned version](https://github.com/mui/mui-public/pull/288#discussion_r2020273621) of the `actions/stale` action.