### PR TITLE
[infra] Refactor status label handling

### DIFF
--- a/.github/workflows/scripts/issues/statusLabelHandler.js
+++ b/.github/workflows/scripts/issues/statusLabelHandler.js
@@ -18,46 +18,43 @@ module.exports = async ({ core, context, github }) => {
       issue_number: issueNumber,
     });
 
+    const issueAuthor = issue.data.user.login;
+    const commentAuthor = context.payload.comment.user.login;
+
+    // return early if the author of the comment is not the same as the author of the issue
+    if (issueAuthor !== commentAuthor) {
+      core.info('>>> Comment is not from the issue author. Exiting.');
+      return;
+    }
+
     const labels = issue.data.labels.map((label) => label.name);
 
     const maintainerLabel = 'status: waiting for maintainer';
     const authorLabel = 'status: waiting for author';
 
-    if (context.payload.action === 'closed') {
-      core.info('>>> Issue was closed. Removing both labels and exiting.');
-      await github.rest.issues.update({
-        owner,
-        repo,
-        issue_number: issueNumber,
-        labels: labels.filter((label) => label !== maintainerLabel && label !== authorLabel),
-      });
+    // no need to update when the label is already present on the issue
+    if (labels.includes(maintainerLabel)) {
+      core.info(`>>> '${maintainerLabel}' label already present. Exiting.`);
       return;
     }
 
-    const issueAuthor = issue.data.user.login;
-    const commentAuthor = context.payload.comment.user.login;
+    // remove maintainerLabel and authorLabel from labels
+    const purgedLabels = labels.filter(
+      (label) => label !== maintainerLabel && label !== authorLabel,
+    );
+    // check if the issue is closed or gets closed with this event
+    const issueIsOrGetsClosed =
+      context.payload.action === 'closed' || issue.data.state === 'closed';
+    // add maintainerLabel when issue is not/won't be closed
+    const labelsForUpdate = issueIsOrGetsClosed ? purgedLabels : [...purgedLabels, maintainerLabel];
 
-    if (issueAuthor !== commentAuthor) {
-      core.info('>>> Comment is not from the issue author. Exiting.');
-      return;
-    }
-    const newLabels = labels.filter((label) => label !== authorLabel);
-    newLabels.push(maintainerLabel);
-
-    const updateParams = {
+    core.info(`>>> Updating issue with new labels`);
+    await github.rest.issues.update({
       owner,
       repo,
       issue_number: issueNumber,
-      labels: newLabels,
-    };
-
-    if (issue.data.state === 'closed') {
-      core.info('>>> Reopening the issue');
-      updateParams.state = 'open';
-    }
-
-    core.info(`>>> Updating issue with new labels and state if necessary`);
-    await github.rest.issues.update(updateParams);
+      labels: labelsForUpdate,
+    });
   } catch (error) {
     core.error(`>>> Workflow failed with: ${error.message}`);
     core.setFailed(error.message);


### PR DESCRIPTION
- added a new early return
- moved one early return up to prevent unnecessary execution
- trimmed down logic to only call update once, when needed
- removed the 'reopening' path