### PR TITLE
[core] Enhance debugging and author validation in status label handler

### DIFF
--- a/.github/workflows/scripts/issues/statusLabelHandler.js
+++ b/.github/workflows/scripts/issues/statusLabelHandler.js
@@ -26,8 +26,7 @@ module.exports = async ({ core, context, github }) => {
     core.info(`>>> Issue author: ${issueAuthor}`);
 
     // there is no comment when the issue gets closed, so we just assign null and continue with the action
-    const commentAuthor =
-      context.payload.action === 'closed' ? null : context.payload.comment.user.login;
+    const commentAuthor = context.payload.comment?.user.login;
     core.info(`>>> Comment author: ${commentAuthor}`);
 
     // return early if the author of the comment is not the same as the author of the issue

--- a/.github/workflows/scripts/issues/statusLabelHandler.js
+++ b/.github/workflows/scripts/issues/statusLabelHandler.js
@@ -22,7 +22,7 @@ module.exports = async ({ core, context, github }) => {
 
     core.debug(`>>> Issue data: ${JSON.stringify(issue.data)}`);
 
-    const issueAuthor = issue.data.user.login;
+    const issueAuthor = issue.data.user?.login;
     core.info(`>>> Issue author: ${issueAuthor}`);
 
     // there is no comment when the issue gets closed, so we just assign null and continue with the action

--- a/.github/workflows/scripts/issues/statusLabelHandler.js
+++ b/.github/workflows/scripts/issues/statusLabelHandler.js
@@ -27,7 +27,7 @@ module.exports = async ({ core, context, github }) => {
 
     // there is no comment when the issue gets closed, so we just assign null and continue with the action
     const commentAuthor =
-      context.payload.action === 'closed' ? context.payload.comment.user.login : null;
+      context.payload.action === 'closed' ? null : context.payload.comment.user.login;
     core.info(`>>> Comment author: ${commentAuthor}`);
 
     // return early if the author of the comment is not the same as the author of the issue

--- a/.github/workflows/scripts/issues/statusLabelHandler.js
+++ b/.github/workflows/scripts/issues/statusLabelHandler.js
@@ -25,10 +25,9 @@ module.exports = async ({ core, context, github }) => {
     const issueAuthor = issue.data.user.login;
     core.info(`>>> Issue author: ${issueAuthor}`);
 
+    // there is no comment when the issue gets closed, so we just assign null and continue with the action
     const commentAuthor =
-      context.payload.comment && context.payload.comment.user
-        ? context.payload.comment.user.login
-        : '';
+      context.payload.action === 'closed' ? context.payload.comment.user.login : null;
     core.info(`>>> Comment author: ${commentAuthor}`);
 
     // return early if the author of the comment is not the same as the author of the issue

--- a/.github/workflows/scripts/issues/statusLabelHandler.js
+++ b/.github/workflows/scripts/issues/statusLabelHandler.js
@@ -58,7 +58,7 @@ module.exports = async ({ core, context, github }) => {
     const purgedLabels = labels.filter(
       (label) => label !== maintainerLabel && label !== authorLabel,
     );
-    core.debug(`>>> Purged labels: ${JSON.stringify(purgedLabels)}`);
+    core.info(`>>> Purged labels: ${JSON.stringify(purgedLabels)}`);
 
     // check if the issue is closed or gets closed with this event
     const issueIsOrGetsClosed =


### PR DESCRIPTION
Fixes failing workflow runs when the payload for commenting is not present (e.g. when closing the issue)