### PR TITLE
[core] Change the GitHub label on security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: npm
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: /
+    schedule:
+      interval: yearly
+    # https://stackoverflow.com/questions/64047526/how-to-get-dependabot-to-trigger-for-security-updates-only
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+      - security


### PR DESCRIPTION
https://github.com/mui/mui-public/pull/309 is confusing

<img width="349" alt="SCR-20250430-pcmw" src="https://github.com/user-attachments/assets/bb0f0d16-4cb7-4d35-bac3-9291c041a25f" />
