### PR TITLE
[code-infra] Exclude entrypoint from bundle analysis

### DIFF
--- a/packages/bundle-size-checker/src/worker.js
+++ b/packages/bundle-size-checker/src/worker.js
@@ -183,12 +183,6 @@ async function createWebpackConfig(entry, args) {
       },
       path: path.join(rootDir, 'build'),
     },
-    stats: {
-      excludeModules: (assetName) => {
-        console.log(`Excluding module: ${assetName}, ${assetName.includes(entrypointContent)}`);
-        return assetName.includes(entrypointContent);
-      },
-    },
     plugins: [
       new CompressionPlugin({
         filename: '[path][base][fragment].gz',
@@ -202,6 +196,12 @@ async function createWebpackConfig(entry, args) {
         // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
         reportFilename: `${entryName}.html`,
         logLevel: 'warn',
+        statsOptions: {
+          exclude: (assetName) => {
+            console.log(`Excluding module: ${assetName}, ${assetName.includes(entrypointContent)}`);
+            return assetName.includes(entrypointContent);
+          },
+        },
       }),
     ],
     // A context to the current dir, which has a node_modules folder with workspace dependencies

--- a/packages/bundle-size-checker/src/worker.js
+++ b/packages/bundle-size-checker/src/worker.js
@@ -183,6 +183,12 @@ async function createWebpackConfig(entry, args) {
       },
       path: path.join(rootDir, 'build'),
     },
+    stats: {
+      excludeModules: (assetName) => {
+        console.log(`Excluding module: ${assetName}, ${assetName.includes(entrypointContent)}`);
+        return assetName.includes(entrypointContent);
+      },
+    },
     plugins: [
       new CompressionPlugin({
         filename: '[path][base][fragment].gz',
@@ -196,16 +202,6 @@ async function createWebpackConfig(entry, args) {
         // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
         reportFilename: `${entryName}.html`,
         logLevel: 'warn',
-        statsOptions: {
-          excludeModules: (assetName) => {
-            console.log(`Excluding module: ${assetName}, ${assetName.includes(entrypointContent)}`);
-            return assetName.includes(entrypointContent);
-          },
-        },
-        excludeAssets: (assetName) => {
-          console.log(`Excluding asset: ${assetName}, ${assetName.includes(entrypointContent)}`);
-          return assetName.includes(entrypointContent);
-        },
       }),
     ],
     // A context to the current dir, which has a node_modules folder with workspace dependencies

--- a/packages/bundle-size-checker/src/worker.js
+++ b/packages/bundle-size-checker/src/worker.js
@@ -133,6 +133,8 @@ async function createWebpackConfig(entry, args) {
       ? entry.externals
       : (packageExternals ?? ['react', 'react-dom']);
 
+  const entrypointContent = Buffer.from(entryContent.trim()).toString('base64');
+
   /**
    * @type {import('webpack').Configuration}
    */
@@ -193,6 +195,7 @@ async function createWebpackConfig(entry, args) {
         // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
         reportFilename: `${entryName}.html`,
         logLevel: 'warn',
+        excludeAssets: (assetName) => assetName.includes(entrypointContent),
       }),
     ],
     // A context to the current dir, which has a node_modules folder with workspace dependencies
@@ -202,7 +205,7 @@ async function createWebpackConfig(entry, args) {
       // See https://github.com/webpack/webpack/issues/6437#issuecomment-874466638
       // See https://webpack.js.org/api/module-methods/#import
       // See https://webpack.js.org/api/loaders/#inline-matchresource
-      [entryName]: `./index.js!=!data:text/javascript;charset=utf-8;base64,${Buffer.from(entryContent.trim()).toString('base64')}`,
+      [entryName]: `./index.js!=!data:text/javascript;charset=utf-8;base64,${entrypointContent}`,
     },
     // TODO: 'browserslist:modern'
     // See https://github.com/webpack/webpack/issues/14203

--- a/packages/bundle-size-checker/src/worker.js
+++ b/packages/bundle-size-checker/src/worker.js
@@ -134,6 +134,7 @@ async function createWebpackConfig(entry, args) {
       : (packageExternals ?? ['react', 'react-dom']);
 
   const entrypointContent = Buffer.from(entryContent.trim()).toString('base64');
+  console.log(entrypointContent);
 
   /**
    * @type {import('webpack').Configuration}
@@ -195,7 +196,10 @@ async function createWebpackConfig(entry, args) {
         // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
         reportFilename: `${entryName}.html`,
         logLevel: 'warn',
-        excludeAssets: (assetName) => assetName.includes(entrypointContent),
+        excludeAssets: (assetName) => {
+          console.log(`Excluding asset: ${assetName}, ${assetName.includes(entrypointContent)}`);
+          return assetName.includes(entrypointContent);
+        },
       }),
     ],
     // A context to the current dir, which has a node_modules folder with workspace dependencies

--- a/packages/bundle-size-checker/src/worker.js
+++ b/packages/bundle-size-checker/src/worker.js
@@ -196,6 +196,12 @@ async function createWebpackConfig(entry, args) {
         // '[name].html' not supported: https://github.com/webpack-contrib/webpack-bundle-analyzer/issues/12
         reportFilename: `${entryName}.html`,
         logLevel: 'warn',
+        statsOptions: {
+          excludeModules: (assetName) => {
+            console.log(`Excluding module: ${assetName}, ${assetName.includes(entrypointContent)}`);
+            return assetName.includes(entrypointContent);
+          },
+        },
         excludeAssets: (assetName) => {
           console.log(`Excluding asset: ${assetName}, ${assetName.includes(entrypointContent)}`);
           return assetName.includes(entrypointContent);


### PR DESCRIPTION
This entrypoint is used to define which bundles to pull in, but we shouldn't count it in the size calculation