### PR TITLE
[code-infra] Avoid installing twice in checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ commands:
             npm i --prefix=~/.local --global corepack@latest
             # See https://stackoverflow.com/a/73411601
             corepack enable --install-directory=~/bin pnpm
+            pnpm --version
 
   install_js:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
 default-job: &default-job
   working_directory: /tmp/mui
   docker:
-    - image: cimg/node:18.16
+    - image: cimg/node:20.17
 
 default-context: &default-context
   context:
@@ -35,7 +35,6 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - install_js
       - run:
           name: Should not have any git not staged
           command: git add -A && git diff --exit-code --staged
@@ -46,6 +45,7 @@ jobs:
             if [[ $(git diff --name-status master | grep -E 'pnpm-workspace\.yaml|pnpm-lock.yaml|package\.json') == "" ]];
             then
                 echo "no changes to dependencies detected, skipping..."
+                pnpm install
             else
                 pnpm dedupe --check
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ commands:
       - run:
           name: Install corepack
           command: |
-            npm i -g pnpm@latest
+            npm i --prefix=$HOME/.local --global corepack@latest
+            # See https://stackoverflow.com/a/73411601
+            corepack enable --install-directory ~/bin
 
   install_js:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - setuppnpm
+      - setup_pnpm
       - run:
           name: Should not have any git not staged
           command: git add -A && git diff --exit-code --staged
@@ -61,7 +61,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - setuppnpm
+      - setup_pnpm
       - install_js
       - run:
           name: Eslint
@@ -71,7 +71,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - setuppnpm
+      - setup_pnpm
       - install_js
       - run:
           name: '`pnpm prettier` changes committed?'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ commands:
           name: Install corepack
           command: |
             npm install --global corepack@latest
-            corepack enable
+            # See https://stackoverflow.com/a/73411601
+            corepack enable --install-directory ~/bin
       - run:
           name: View install environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,11 @@ commands:
       - run:
           name: Install corepack
           # See https://stackoverflow.com/a/73411601
-          command: corepack enable --install-directory ~/bin
+          command: |
+            npm install --global corepack@latest
+            corepack enable
+            corepack prepare pnpm@latest-10 --activate
+            pnpm config set store-dir .pnpm-store
       - run:
           name: View install environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ commands:
       - run:
           name: Install corepack
           command: |
-            npm i --prefix=~/.local --global corepack@latest
+            npm i --prefix=$HOME/.local --global corepack@latest
             # See https://stackoverflow.com/a/73411601
-            corepack enable --install-directory=~/bin pnpm
+            corepack enable --install-directory=$HOME/bin pnpm
             pnpm --version
 
   install_js:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,6 @@ commands:
           command: |
             npm install --global corepack@latest
             corepack enable
-            corepack prepare pnpm@latest-10 --activate
-            pnpm config set store-dir .pnpm-store
       - run:
           name: View install environment
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,9 @@ commands:
       - run:
           name: Install corepack
           command: |
-            npm i --prefix=$HOME/.local --global corepack@latest
+            npm i --prefix=~/.local --global corepack@latest
             # See https://stackoverflow.com/a/73411601
-            corepack enable --install-directory ~/bin
+            corepack enable --install-directory=~/bin pnpm
 
   install_js:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
           command: |
             npm i -g corepack@latest
             # See https://stackoverflow.com/a/73411601
-            corepack enable --install-directory ~/bin
+            corepack enable
 
   install_js:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ default-context: &default-context
     - org-global
 
 commands:
-  setup_corepack:
+  setup_pnpm:
     steps:
       - run:
           name: View install environment
@@ -26,6 +26,7 @@ commands:
       - run:
           name: Install corepack
           command: |
+            npm i -g corepack@latest
             # See https://stackoverflow.com/a/73411601
             corepack enable --install-directory ~/bin
 
@@ -40,7 +41,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - setup_corepack
+      - setuppnpm
       - run:
           name: Should not have any git not staged
           command: git add -A && git diff --exit-code --staged
@@ -60,7 +61,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - setup_corepack
+      - setuppnpm
       - install_js
       - run:
           name: Eslint
@@ -70,7 +71,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
-      - setup_corepack
+      - setuppnpm
       - install_js
       - run:
           name: '`pnpm prettier` changes committed?'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,7 @@ commands:
       - run:
           name: Install corepack
           command: |
-            npm i -g corepack@latest
-            # See https://stackoverflow.com/a/73411601
-            corepack enable
+            npm i -g pnpm@latest
 
   install_js:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,15 @@ commands:
   install_js:
     steps:
       - run:
-          name: Install corepack
-          command: |
-            npm install --global corepack@latest
-            # See https://stackoverflow.com/a/73411601
-            corepack enable --install-directory ~/bin
-      - run:
           name: View install environment
           command: |
             node --version
+            corepack --version
+      - run:
+          name: Install corepack
+          command: |
+            # See https://stackoverflow.com/a/73411601
+            corepack enable --install-directory ~/bin
       - run:
           name: Install js dependencies
           command: pnpm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ commands:
     steps:
       - run:
           name: Install corepack
-          # See https://stackoverflow.com/a/73411601
           command: |
             npm install --global corepack@latest
             corepack enable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ default-context: &default-context
     - org-global
 
 commands:
-  install_js:
+  setup_corepack:
     steps:
       - run:
           name: View install environment
@@ -28,6 +28,9 @@ commands:
           command: |
             # See https://stackoverflow.com/a/73411601
             corepack enable --install-directory ~/bin
+
+  install_js:
+    steps:
       - run:
           name: Install js dependencies
           command: pnpm install
@@ -37,6 +40,7 @@ jobs:
     <<: *default-job
     steps:
       - checkout
+      - setup_corepack
       - run:
           name: Should not have any git not staged
           command: git add -A && git diff --exit-code --staged
@@ -51,18 +55,22 @@ jobs:
             else
                 pnpm dedupe --check
             fi
+
   test_lint:
     <<: *default-job
     steps:
       - checkout
+      - setup_corepack
       - install_js
       - run:
           name: Eslint
           command: pnpm eslint:ci
+
   test_static:
     <<: *default-job
     steps:
       - checkout
+      - setup_corepack
       - install_js
       - run:
           name: '`pnpm prettier` changes committed?'
@@ -73,6 +81,7 @@ jobs:
           command: |
             pnpm update-netlify-ignore
             git add -A && git diff --exit-code --staged
+  
 workflows:
   version: 2
   pipeline:


### PR DESCRIPTION
Avoid running `pnpm install` in `checkout` since we're doing `pnpm dedupe` right after