### PR TITLE
[core] Set caching headers for mui-frontend-public

### DIFF
--- a/apps/code-infra-dashboard/public/_headers
+++ b/apps/code-infra-dashboard/public/_headers
@@ -1,0 +1,15 @@
+/assets/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  # Block usage in iframes.
+  X-Frame-Options: SAMEORIGIN
+  # Force the browser to trust the Content-Type header
+  # https://stackoverflow.com/questions/18337630/what-is-x-content-type-options-nosniff
+  X-Content-Type-Options: nosniff
+  X-XSS-Protection: 1; mode=block
+  Referrer-Policy: strict-origin-when-cross-origin
+  # TODO: progressively reduce the CSP scopes
+  # Start with a wildcard, using https://github.com/mui/toolpad/blob/f4c4eb046b352e4fc00729c3bed605e671b040c4/packages/toolpad-studio/src/server/index.ts#L241
+  Content-Security-Policy: default-src * data: mediastream: blob: filesystem: about: ws: wss: 'unsafe-eval' 'wasm-unsafe-eval' 'unsafe-inline'; script-src * data: blob: 'unsafe-inline' 'unsafe-eval'; script-src-elem * data: blob: 'unsafe-inline'; connect-src * data: blob: 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; media-src * data: blob: 'unsafe-inline'; frame-src * data: blob: ; style-src * data: blob: 'unsafe-inline'; font-src * data: blob: 'unsafe-inline'; frame-ancestors *;


### PR DESCRIPTION
I'm amazed that Vite has no docs for this: https://github.com/vitejs/vite/blob/1fe07d3716012992dd7b2e78d8380add0b606a97/docs/public/_headers#L1; but 🤷‍♂️

Preview: https://deploy-preview-333--mui-frontend-public.netlify.app/size-comparison/mui/material-ui/diff?circleCIBuildNumber=826971&baseRef=master&baseCommit=52ceb5804c12eaf401c033433afc72d3ee88bd5c&prNumber=46176

and it works: https://deploy-preview-333--mui-frontend-public.netlify.app/assets/index-oW5KvyZt.js.