### PR TITLE
[code-infra] Remove `downlevelIteration`

### DIFF
--- a/apps/code-infra-dashboard/README.md
+++ b/apps/code-infra-dashboard/README.md
@@ -10,5 +10,5 @@ Bugfixes and feature suggestions are greatly appreciated. Though this project is
 
 ```bash
 pnpm install
-pnpm -F @apps/code-infra-dashboard dev
+pnpm -F  @app/code-infra-dashboard dev
 ```

--- a/apps/code-infra-dashboard/README.md
+++ b/apps/code-infra-dashboard/README.md
@@ -9,6 +9,6 @@ Collection of helpers useful when working on [MUI](https://github.com/mui).
 Bugfixes and feature suggestions are greatly appreciated. Though this project is highly opinionated so feature requests from external contributors likely won't be accepted if no core member has a use for them.
 
 ```bash
-$ pnpm --ignore-workspace install
-$ pnpm -F code-infra-dashboard dev
+pnpm install
+pnpm -F @apps/code-infra-dashboard dev
 ```

--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -2,14 +2,14 @@
   publish = "build"
 
   # Default build command.
-  command = "pnpm -F @apps/code-infra-dashboard build"
+  command = "pnpm -F  @app/code-infra-dashboard build"
 
   # Decide when to build Netlify
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/code-infra-dashboard packages/bundle-size-checker pnpm-lock.yaml"
 
 [dev]
   framework = "#custom"
-  command = "pnpm -F @apps/code-infra-dashboard start"
+  command = "pnpm -F  @app/code-infra-dashboard start"
   targetPort = 3000
 
 [build.environment]

--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -2,14 +2,14 @@
   publish = "build"
 
   # Default build command.
-  command = "pnpm -F code-infra-dashboard build"
+  command = "pnpm -F @apps/code-infra-dashboard build"
 
   # Decide when to build Netlify
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/code-infra-dashboard packages/bundle-size-checker pnpm-lock.yaml"
 
 [dev]
   framework = "#custom"
-  command = "pnpm -F code-infra-dashboard start"
+  command = "pnpm -F @apps/code-infra-dashboard start"
   targetPort = 3000
 
 [build.environment]

--- a/apps/code-infra-dashboard/package.json
+++ b/apps/code-infra-dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "code-infra-dashboard",
+  "name": "@apps/code-infra-dashboard",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -31,7 +31,7 @@
     "dev": "pnpm --package netlify-cli@15 dlx netlify dev",
     "preview": "vite preview",
     "test": "echo 'No tests yet' && exit 1",
-    "test:types": "tsc"
+    "typescript": "tsc"
   },
   "browserslist": {
     "production": [

--- a/apps/code-infra-dashboard/package.json
+++ b/apps/code-infra-dashboard/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@apps/code-infra-dashboard",
+  "name": " @app/code-infra-dashboard",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/apps/code-infra-dashboard/tsconfig.json
+++ b/apps/code-infra-dashboard/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -14,8 +14,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
-    "downlevelIteration": true
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint:ci": "eslint . --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",
     "prettier": "pretty-quick --ignore-path .eslintignore",
     "prettier:all": "prettier --write . --ignore-path .eslintignore",
-    "update-netlify-ignore": "node ./update-netlify-ignore.js @apps/code-infra-dashboard",
+    "update-netlify-ignore": "node ./update-netlify-ignore.js  @app/code-infra-dashboard",
     "test": "vitest",
     "release:prepare": "pnpm install && pnpm release:build",
     "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --no-private",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "eslint:ci": "eslint . --report-unused-disable-directives --ext .js,.ts,.tsx --max-warnings 0",
     "prettier": "pretty-quick --ignore-path .eslintignore",
     "prettier:all": "prettier --write . --ignore-path .eslintignore",
-    "update-netlify-ignore": "node ./update-netlify-ignore.js code-infra-dashboard",
+    "update-netlify-ignore": "node ./update-netlify-ignore.js @apps/code-infra-dashboard",
     "test": "vitest",
     "release:prepare": "pnpm install && pnpm release:build",
     "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --no-private",


### PR DESCRIPTION
Increase the target instead, the audience of this app will be on modern browsers

I'm also renaming the `code-infra-dashboard` package to `@app/code-infra-dashboard` to be more in line with how packages are named in the core repo in this folder