### PR TITLE
[code-infra] Add sanity check that replacement has actually happend

### DIFF
--- a/update-netlify-ignore.js
+++ b/update-netlify-ignore.js
@@ -55,10 +55,18 @@ try {
   const tomlContent = fs.readFileSync(tomlPath, 'utf8');
 
   // Replace the ignore line with our new command using relative paths
-  const updatedContent = tomlContent.replace(
-    /^\s*ignore\s*=.*$/m,
-    `  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ${relativePaths.join(' ')} pnpm-lock.yaml"`,
-  );
+  let didReplace = false;
+  const updatedContent = tomlContent.replace(/^\s*ignore\s*=.*$/m, () => {
+    didReplace = true;
+    return `  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ${relativePaths.join(' ')} pnpm-lock.yaml"`;
+  });
+
+  if (!didReplace) {
+    console.error(
+      `Error: No ignore line found in ${tomlPath}, please add one before running this script.`,
+    );
+    process.exit(1);
+  }
 
   // Write the updated file
   fs.writeFileSync(tomlPath, updatedContent);


### PR DESCRIPTION
The script would silently succeed if someone accidentally removed the ignore line from netlify.toml.

Need to do it this way because the end result will most of the time be identical to the input