### PR TITLE
Replace KaTeX arrows with emoji in bundle size reports

### DIFF
--- a/packages/bundle-size-checker/src/renderMarkdownReport.js
+++ b/packages/bundle-size-checker/src/renderMarkdownReport.js
@@ -7,15 +7,6 @@
 import { calculateSizeDiff } from './sizeDiff.js';
 import { fetchSnapshot } from './fetchSnapshot.js';
 import { displayPercentFormatter, byteSizeChangeFormatter } from './formatUtils.js';
-/**
- *
- * @param {'▲' | '▼'} symbol
- * @param {KatexColor} color
- * @returns
- */
-function formatSymbol(symbol, color) {
-  return `<sup>\${\\tiny{\\color{${color}}${symbol}}}$</sup>`;
-}
 
 /**
  * Generates a symbol based on the relative change value.
@@ -24,16 +15,16 @@ function formatSymbol(symbol, color) {
  */
 function getChangeIcon(relative) {
   if (relative === null) {
-    return formatSymbol('▲', 'orangered');
+    return '🔺';
   }
   if (relative === -1) {
-    return formatSymbol('▼', 'cornflowerblue');
+    return '▼';
   }
   if (relative < 0) {
-    return formatSymbol('▼', 'green');
+    return '▼';
   }
   if (relative > 0) {
-    return formatSymbol('▲', 'red');
+    return '🔺';
   }
   return ' ';
 }


### PR DESCRIPTION
## Summary
- Replace complex KaTeX-styled arrow symbols with simple emoji 🔺 and plain ▼ symbols in bundle size markdown reports
- Remove the `formatSymbol` function and its KaTeX formatting dependency

🤖 Generated with [Claude Code](https://claude.ai/code)