### PR TITLE
[infra] Remove commentHandler and change label names

### DIFF
--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -10,84 +10,19 @@ const createEnumerationFromArray = (stringArray) =>
     : stringArray.map((s) => `\`${s}\``).join('');
 
 const typeLabels = [
-  'bug',
-  'regression', // a sub-type of bug but we flatten it.
-  'enhancement',
-  'new feature',
-  // Those are not "Types" labels, they are "Kind of work" labels, but we don't want to have to handle the overhead of
-  // setting “Types” labels with them.
-  'release',
-  'dependencies',
+  'type: release',
+  'type: bug',
+  'type: regression',
+  'type: dependencies',
+  'type: improvement',
+  'type: new feature',
+  'type: general',
 ];
 const labelRegex = new RegExp(`\\b(${typeLabels.join('|')})\\b`, 'i');
 
-const COMMENT_FIRST_LINE = {
-  NO_LABELS_COMMENT:
-    'Please add one type label to categorize the purpose of this PR appropriately:',
-  MULTIPLE_LABELS_COMMENT: 'Multiple type labels found:',
-  SUCCESS_COMMENT: 'Thanks for adding a type label to the PR! 👍',
-};
-
-/**
- * @param {Awaited<ReturnType<ReturnType<import("@actions/github").getOctokit>['rest']['issues']['listComments']>>['data']} comments
- */
-function containsAny(comments) {
-  return (
-    comments.find((comment) =>
-      Object.values(COMMENT_FIRST_LINE).some((startLine) => comment.body?.startsWith(startLine)),
-    ) ?? false
-  );
-}
-
-/**
- * @param {Object} params
- * @param {import("@actions/core")} params.core
- * @param {ReturnType<import("@actions/github").getOctokit>} params.github
- * @param {import("@actions/github").context} params.context
- * @param {Awaited<ReturnType<ReturnType<import("@actions/github").getOctokit>['rest']['issues']['listComments']>>['data']} params.comments
- */
-const createCommentHandler =
-  ({ core, context, github, comments }) =>
-  async (/** @type {string[]} */ commentLines) => {
-    const owner = context.repo.owner;
-    const repo = context.repo.repo;
-    const pullNumber = context.issue.number;
-
-    const commentFound = containsAny(comments);
-
-    if (commentFound) {
-      core.info(`>>> Updating existing comment on PR`);
-      core.info(`>>> Comment id: ${commentFound.id}`);
-
-      if (commentFound.body?.startsWith(commentLines[0])) {
-        core.info(`>>> PR already has the needed comment.`);
-        core.info(`>>> Exiting gracefully! 👍`);
-        return;
-      }
-
-      return await github.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: commentFound.id,
-        body: commentLines.join('\n\n'),
-      });
-    }
-
-    // only create a new comment if it's not the success comment
-    if (commentLines[0] === COMMENT_FIRST_LINE.SUCCESS_COMMENT) {
-      core.info(`>>> No need for a comment!`);
-      core.info(`>>> Exiting gracefully! 👍`);
-      return;
-    }
-
-    core.info(`>>> Creating explanatory comment on PR`);
-    return await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: pullNumber,
-      body: commentLines.join('\n\n'),
-    });
-  };
+const NO_LABELS_COMMENT =
+  'Please add one type label to categorize the purpose of this PR appropriately:';
+const MULTIPLE_LABELS_COMMENT = 'Multiple type labels found:';
 
 /**
  * @param {Object} params
@@ -120,51 +55,19 @@ module.exports = async ({ core, context, github }) => {
       per_page: 100,
     });
 
-    const commentHandler = createCommentHandler({
-      core,
-      context,
-      github,
-      comments: prComments,
-    });
-
-    // docs label is handled differently
-    if (typeLabelsFound.some((l) => l === 'docs')) {
-      core.info(`>>> 'docs' type label found`);
-
-      await commentHandler([COMMENT_FIRST_LINE.SUCCESS_COMMENT]);
-      return;
-    }
-
     if (typeLabelsFound.length === 0) {
       core.info(`>>> No type labels found`);
-
-      // Add a comment line explaining that a type label needs to be added
-      await commentHandler([
-        COMMENT_FIRST_LINE.NO_LABELS_COMMENT,
-        createEnumerationFromArray(typeLabels),
-      ]);
-
-      core.setFailed('>>> Failing workflow to prevent merge without passing this!');
+      core.setFailed(`>>> ${NO_LABELS_COMMENT} ${createEnumerationFromArray(typeLabels)}`);
       return;
     }
 
     if (typeLabelsFound.length > 1) {
       core.info(`>>> Multiple type labels found: ${typeLabelsFound.join(', ')}`);
-
-      // add a comment line explaining that only one type label is allowed
-      await commentHandler([
-        COMMENT_FIRST_LINE.MULTIPLE_LABELS_COMMENT,
-        typeLabelsFound.map((label) => `- ${label}`).join('\n'),
-        'Only one is allowed. Please remove the extra type labels to ensure the PR is categorized correctly.',
-      ]);
-
-      core.setFailed('>>> Failing workflow to prevent merge without passing this!');
+      core.setFailed(`>>> ${MULTIPLE_LABELS_COMMENT} ${typeLabelsFound.join(', ')}`);
       return;
     }
 
     core.info(`>>> Single type label found: ${typeLabelsFound[0]}`);
-
-    await commentHandler([COMMENT_FIRST_LINE.SUCCESS_COMMENT]);
   } catch (error) {
     core.error(`>>> Workflow failed with: ${error.message}`);
     core.setFailed(error.message);

--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -13,10 +13,11 @@ const typeLabels = [
   'type: release',
   'type: bug',
   'type: regression',
-  'type: dependencies',
   'type: improvement',
   'type: new feature',
   'type: general',
+  // only used by renovate bot so we can ignore the "type: " prefix here
+  'dependencies',
 ];
 const labelRegex = new RegExp(`\\b(${typeLabels.join('|')})\\b`, 'i');
 


### PR DESCRIPTION
* Removed the `createCommentHandler` function and its associated logic for managing comments on pull requests. The script now directly sets the workflow status without adding explanatory comments to pull requests. 

* Simplified error handling by replacing multi-line comments with direct `core.setFailed` calls, embedding the relevant messages and label data directly into the failure output. 

* Updated the `typeLabels` array to include more descriptive labels prefixed with `type:` (e.g., `type: bug`, `type: improvement`) for better categorization and searchability.