### PR TITLE
[support-infra] No general label

### DIFF
--- a/.github/workflows/scripts/prs/checkTypeLabel.js
+++ b/.github/workflows/scripts/prs/checkTypeLabel.js
@@ -15,7 +15,6 @@ const typeLabels = [
   'type: regression',
   'type: improvement',
   'type: new feature',
-  'type: general',
   // only used by renovate bot so we can ignore the "type: " prefix here
   'dependencies',
 ];


### PR DESCRIPTION
Convert https://www.notion.so/mui-org/Labeling-in-GitHub-1f1cbfe7b66081d8b18de652877d671e?source=copy_link#209cbfe7b66080d19ed8d323fa9a5fd4 to practice. Instead, proposed using "all components" and rename "core" to "internal" but definitely not a type.