### PR TITLE
[infra] Automate publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,12 @@ jobs:
           fetch-depth: 0
       - name: Set up pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - name: Use Node.js 20.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
-          cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+          node-version: '22'
+          # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+          cache: 'pnpm'
       - run: pnpm release:prepare
       - run: pnpm release:build
       - run: pnpm dlx pkg-pr-new publish $(pnpm -s pkg-pr-new-packages) --pnpm --comment=off --peerDeps --compact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,34 +28,34 @@ jobs:
     permissions:
       contents: read
       id-token: write # Required for provenance
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
           version: '10.6.2'
-          
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        
+
       - name: Build packages
         run: pnpm run release:build
-        
+
       - name: Publish packages (automatic on push)
         if: github.event_name == 'push'
         run: node scripts/publish.mjs --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          
+
       - name: Publish packages (manual trigger)
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '22'
+          # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+          cache: 'pnpm'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,74 @@
+name: Publish Packages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Run in dry-run mode (no actual publishing)'
+        required: false
+        default: false
+        type: boolean
+      canary_only:
+        description: 'Only publish canary versions'
+        required: false
+        default: false
+        type: boolean
+      provenance:
+        description: 'Enable provenance'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # Required for provenance
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.6.2'
+          
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Build packages
+        run: pnpm run release:build
+        
+      - name: Publish packages (automatic on push)
+        if: github.event_name == 'push'
+        run: node scripts/publish.mjs --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          
+      - name: Publish packages (manual trigger)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          if [ "${{ inputs.canary_only }}" = "true" ]; then
+            ARGS="$ARGS --canary-only"
+          fi
+          if [ "${{ inputs.provenance }}" = "true" ]; then
+            ARGS="$ARGS --provenance"
+          fi
+          node scripts/publish.mjs $ARGS
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@next/eslint-plugin-next": "^14.2.4",
+    "execa": "^7.2.0",
     "vitest": "^3.1.3"
   },
   "packageManager": "pnpm@10.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^14.2.4
         version: 14.2.4
+      execa:
+        specifier: ^7.2.0
+        version: 7.2.0
       vitest:
         specifier: ^3.1.3
         version: 3.1.3(@types/node@22.14.0)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.1)

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -168,7 +168,7 @@ async function publishPackage(packagePath, tag, options = {}) {
 async function publishRegularVersions(packages, packageVersionInfo, options = {}) {
   console.log('\n📦 Checking for unpublished regular versions...');
 
-  // run sequentially to avoid any rate limniting issues
+  // run sequentially to avoid any rate limiting issues
   for (const pkg of packages) {
     const { currentVersionExists } = packageVersionInfo.get(pkg.name);
 

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -126,41 +126,7 @@ async function writePackageJson(packagePath, packageJson) {
   await fs.writeFile(path.join(packagePath, 'package.json'), content);
 }
 
-/**
- * Update dependencies to point to canary versions
- */
-function updateDependenciesToCanary(dependencies, canaryVersions) {
-  if (!dependencies) {
-    return dependencies;
-  }
 
-  const updated = { ...dependencies };
-
-  for (const [depName, depVersion] of Object.entries(dependencies)) {
-    if (canaryVersions.has(depName)) {
-      updated[depName] = canaryVersions.get(depName);
-    } else if (depVersion === 'workspace:*') {
-      if (!canaryVersions.has(depName)) {
-        throw new Error(
-          `Cannot resolve workspace dependency "${depName}" - no canary version available`,
-        );
-      }
-      updated[depName] = canaryVersions.get(depName);
-    }
-  }
-
-  return updated;
-}
-
-/**
- * Publish a package
- */
-async function publishPackage(packagePath, tag, options = {}) {
-  const { provenance = false, dryRun = false } = options;
-  const provenanceArgs = provenance ? ['--provenance'] : [];
-
-  await runCmd({ cwd: packagePath, dryRun })`pnpm publish --tag ${tag} ${provenanceArgs}`;
-}
 
 /**
  * Publish regular versions that don't exist on npm
@@ -168,19 +134,32 @@ async function publishPackage(packagePath, tag, options = {}) {
 async function publishRegularVersions(packages, packageVersionInfo, options = {}) {
   console.log('\n📦 Checking for unpublished regular versions...');
 
-  // run sequentially to avoid any rate limiting issues
-  for (const pkg of packages) {
+  const packagesToPublish = packages.filter(pkg => {
     const { currentVersionExists } = packageVersionInfo.get(pkg.name);
-
     if (!currentVersionExists) {
-      console.log(`📤 Publishing ${pkg.name}@${pkg.version}...`);
-      // eslint-disable-next-line no-await-in-loop
-      await publishPackage(pkg.path, 'latest', options);
-      console.log(`✅ Published ${pkg.name}@${pkg.version}`);
+      console.log(`📤 Will publish ${pkg.name}@${pkg.version}`);
+      return true;
     } else {
       console.log(`⏭️  ${pkg.name}@${pkg.version} already exists, skipping`);
+      return false;
     }
+  });
+
+  if (packagesToPublish.length === 0) {
+    console.log('No packages need to be published');
+    return;
   }
+
+  // Use pnpm recursive publish with filters for specific packages
+  const filterArgs = packagesToPublish.map(pkg => `--filter=${pkg.name}`);
+  const provenanceArgs = options.provenance ? ['--provenance'] : [];
+  
+  console.log(`Publishing ${packagesToPublish.length} packages...`);
+  await runCmd(options)`pnpm -r publish --tag=latest ${filterArgs} ${provenanceArgs}`;
+  
+  packagesToPublish.forEach(pkg => {
+    console.log(`✅ Published ${pkg.name}@${pkg.version}`);
+  });
 }
 
 /**
@@ -219,28 +198,6 @@ async function publishCanaryVersions(packages, packageVersionInfo, options = {})
       gitSha,
     };
 
-    // Update dependencies to point to canary versions
-    if (updatedPackageJson.dependencies) {
-      updatedPackageJson.dependencies = updateDependenciesToCanary(
-        originalPackageJson.dependencies,
-        canaryVersions,
-      );
-    }
-
-    if (updatedPackageJson.devDependencies) {
-      updatedPackageJson.devDependencies = updateDependenciesToCanary(
-        originalPackageJson.devDependencies,
-        canaryVersions,
-      );
-    }
-
-    if (updatedPackageJson.peerDependencies) {
-      updatedPackageJson.peerDependencies = updateDependenciesToCanary(
-        originalPackageJson.peerDependencies,
-        canaryVersions,
-      );
-    }
-
     await writePackageJson(pkg.path, updatedPackageJson);
 
     console.log(`📝 Updated ${pkg.name} package.json for canary release`);
@@ -254,16 +211,20 @@ async function publishCanaryVersions(packages, packageVersionInfo, options = {})
     originalPackageJsons.set(pkg.name, originalPackageJson);
   }
 
-  // Third pass: publish all canary versions sequentially to avoid rate limits
+  // Third pass: publish all canary versions using recursive publish
   let publishSuccess = false;
   try {
-    for (const pkg of packages) {
+    const filterArgs = packages.map(pkg => `--filter=${pkg.name}`);
+    const provenanceArgs = options.provenance ? ['--provenance'] : [];
+    const gitChecksArgs = ['--no-git-checks'];
+    
+    console.log('📤 Publishing all canary versions...');
+    await runCmd(options)`pnpm -r publish --tag=canary ${filterArgs} ${provenanceArgs} ${gitChecksArgs}`;
+    
+    packages.forEach(pkg => {
       const canaryVersion = canaryVersions.get(pkg.name);
-      console.log(`📤 Publishing ${pkg.name}@${canaryVersion} with canary tag...`);
-      // eslint-disable-next-line no-await-in-loop
-      await publishPackage(pkg.path, 'canary', options);
       console.log(`✅ Published ${pkg.name}@${canaryVersion}`);
-    }
+    });
     publishSuccess = true;
   } finally {
     // Always restore original package.json files in parallel

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -126,23 +126,20 @@ async function writePackageJson(packagePath, packageJson) {
   await fs.writeFile(path.join(packagePath, 'package.json'), content);
 }
 
-
-
 /**
  * Publish regular versions that don't exist on npm
  */
 async function publishRegularVersions(packages, packageVersionInfo, options = {}) {
   console.log('\n📦 Checking for unpublished regular versions...');
 
-  const packagesToPublish = packages.filter(pkg => {
+  const packagesToPublish = packages.filter((pkg) => {
     const { currentVersionExists } = packageVersionInfo.get(pkg.name);
     if (!currentVersionExists) {
       console.log(`📤 Will publish ${pkg.name}@${pkg.version}`);
       return true;
-    } else {
-      console.log(`⏭️  ${pkg.name}@${pkg.version} already exists, skipping`);
-      return false;
     }
+    console.log(`⏭️  ${pkg.name}@${pkg.version} already exists, skipping`);
+    return false;
   });
 
   if (packagesToPublish.length === 0) {
@@ -151,13 +148,13 @@ async function publishRegularVersions(packages, packageVersionInfo, options = {}
   }
 
   // Use pnpm recursive publish with filters for specific packages
-  const filterArgs = packagesToPublish.map(pkg => `--filter=${pkg.name}`);
+  const filterArgs = packagesToPublish.map((pkg) => `--filter=${pkg.name}`);
   const provenanceArgs = options.provenance ? ['--provenance'] : [];
-  
+
   console.log(`Publishing ${packagesToPublish.length} packages...`);
   await runCmd(options)`pnpm -r publish --tag=latest ${filterArgs} ${provenanceArgs}`;
-  
-  packagesToPublish.forEach(pkg => {
+
+  packagesToPublish.forEach((pkg) => {
     console.log(`✅ Published ${pkg.name}@${pkg.version}`);
   });
 }
@@ -214,14 +211,16 @@ async function publishCanaryVersions(packages, packageVersionInfo, options = {})
   // Third pass: publish all canary versions using recursive publish
   let publishSuccess = false;
   try {
-    const filterArgs = packages.map(pkg => `--filter=${pkg.name}`);
+    const filterArgs = packages.map((pkg) => `--filter=${pkg.name}`);
     const provenanceArgs = options.provenance ? ['--provenance'] : [];
     const gitChecksArgs = ['--no-git-checks'];
-    
+
     console.log('📤 Publishing all canary versions...');
-    await runCmd(options)`pnpm -r publish --tag=canary ${filterArgs} ${provenanceArgs} ${gitChecksArgs}`;
-    
-    packages.forEach(pkg => {
+    await runCmd(
+      options,
+    )`pnpm -r publish --tag=canary ${filterArgs} ${provenanceArgs} ${gitChecksArgs}`;
+
+    packages.forEach((pkg) => {
       const canaryVersion = canaryVersions.get(pkg.name);
       console.log(`✅ Published ${pkg.name}@${canaryVersion}`);
     });
@@ -232,7 +231,6 @@ async function publishCanaryVersions(packages, packageVersionInfo, options = {})
     const restorePromises = packages.map(async (pkg) => {
       const originalPackageJson = originalPackageJsons.get(pkg.name);
       await writePackageJson(pkg.path, originalPackageJson);
-      console.log(`✅ Restored ${pkg.name}/package.json`);
     });
 
     await Promise.all(restorePromises);

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import { $ } from 'execa';
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Get all workspace packages that are public
+ */
+async function getWorkspacePackages() {
+  const result = await $`pnpm ls -r --parseable --depth -1`;
+  const packagePaths = result.stdout.trim().split('\n').filter(Boolean);
+  
+  // Read all package.json files in parallel
+  const packageJsonPromises = packagePaths.map(async (packagePath) => {
+    const packageJsonPath = path.join(packagePath, 'package.json');
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
+    return { packagePath, packageJson };
+  });
+  
+  const packageResults = await Promise.all(packageJsonPromises);
+  
+  // Filter out private packages
+  const publicPackages = packageResults
+    .filter(({ packageJson }) => !packageJson.private)
+    .map(({ packagePath, packageJson }) => ({
+      name: packageJson.name,
+      version: packageJson.version,
+      path: packagePath,
+      packageJson
+    }));
+  
+  return publicPackages;
+}
+
+/**
+ * Check if a specific version exists on npm registry
+ */
+async function checkNpmVersion(packageName, version) {
+  try {
+    const result = await $`npm view ${packageName}@${version} version`;
+    return result.stdout.trim() === version;
+  } catch (error) {
+    return false; // Version doesn't exist
+  }
+}
+
+/**
+ * Get the latest canary version for a package
+ */
+async function getLatestCanaryVersion(packageName, baseVersion) {
+  try {
+    const result = await $`npm view ${packageName} versions --json`;
+    const versions = JSON.parse(result.stdout);
+    
+    const canaryVersions = versions
+      .filter(v => v.startsWith(`${baseVersion}-canary.`))
+      .map(v => {
+        const match = v.match(/canary\.(\d+)$/);
+        return { version: v, number: match ? parseInt(match[1], 10) : 0 };
+      })
+      .sort((a, b) => b.number - a.number);
+    
+    return canaryVersions[0]?.version || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+/**
+ * Get the next canary number
+ */
+function getNextCanaryNumber(latestCanaryVersion) {
+  if (!latestCanaryVersion) return 0;
+  
+  const match = latestCanaryVersion.match(/canary\.(\d+)$/);
+  return match ? parseInt(match[1], 10) + 1 : 0;
+}
+
+/**
+ * Get current git SHA
+ */
+async function getCurrentGitSha() {
+  const result = await $`git rev-parse HEAD`;
+  return result.stdout.trim();
+}
+
+/**
+ * Read package.json from a directory
+ */
+async function readPackageJson(packagePath) {
+  const content = await fs.readFile(path.join(packagePath, 'package.json'), 'utf8');
+  return JSON.parse(content);
+}
+
+/**
+ * Write package.json to a directory
+ */
+async function writePackageJson(packagePath, packageJson) {
+  const content = JSON.stringify(packageJson, null, 2) + '\n';
+  await fs.writeFile(path.join(packagePath, 'package.json'), content);
+}
+
+/**
+ * Update dependencies to point to canary versions
+ */
+function updateDependenciesToCanary(dependencies, canaryVersions) {
+  if (!dependencies) return dependencies;
+  
+  const updated = { ...dependencies };
+  
+  for (const [depName, depVersion] of Object.entries(dependencies)) {
+    if (canaryVersions.has(depName)) {
+      updated[depName] = canaryVersions.get(depName);
+    } else if (depVersion === 'workspace:*') {
+      // Check if this is a workspace dependency that has a canary version
+      const workspacePackageName = Object.keys(Object.fromEntries(canaryVersions))
+        .find(name => name.includes(depName) || depName.includes(name));
+      
+      if (workspacePackageName && canaryVersions.has(workspacePackageName)) {
+        updated[depName] = canaryVersions.get(workspacePackageName);
+      }
+    }
+  }
+  
+  return updated;
+}
+
+/**
+ * Publish a package
+ */
+async function publishPackage(packagePath, tag, dryRun = false) {
+  if (dryRun) {
+    console.log(`[DRY RUN] Would execute: pnpm publish --tag ${tag} in ${packagePath}`);
+    return;
+  }
+  
+  await $({ cwd: packagePath })`pnpm publish --tag ${tag}`;
+}
+
+/**
+ * Publish regular versions that don't exist on npm
+ */
+async function publishRegularVersions(packages, dryRun = false) {
+  console.log('\n📦 Checking for unpublished regular versions...');
+  
+  for (const pkg of packages) {
+    const versionExists = await checkNpmVersion(pkg.name, pkg.version);
+    
+    if (!versionExists) {
+      console.log(`📤 Publishing ${pkg.name}@${pkg.version}...`);
+      await publishPackage(pkg.path, 'latest', dryRun);
+      console.log(`✅ Published ${pkg.name}@${pkg.version}`);
+    } else {
+      console.log(`⏭️  ${pkg.name}@${pkg.version} already exists, skipping`);
+    }
+  }
+}
+
+/**
+ * Publish canary versions with updated dependencies
+ */
+async function publishCanaryVersions(packages, dryRun = false) {
+  console.log('\n🔥 Publishing canary versions...');
+  
+  const gitSha = await getCurrentGitSha();
+  const canaryVersions = new Map();
+  const originalPackageJsons = new Map();
+  
+  // First pass: determine all canary version numbers
+  for (const pkg of packages) {
+    const latestCanary = await getLatestCanaryVersion(pkg.name, pkg.version);
+    const nextCanaryNumber = getNextCanaryNumber(latestCanary);
+    const canaryVersion = `${pkg.version}-canary.${nextCanaryNumber}`;
+    
+    canaryVersions.set(pkg.name, canaryVersion);
+    console.log(`🏷️  ${pkg.name}: ${canaryVersion}`);
+  }
+  
+  // Second pass: update package.json files with canary versions and dependencies
+  for (const pkg of packages) {
+    const originalPackageJson = await readPackageJson(pkg.path);
+    originalPackageJsons.set(pkg.name, originalPackageJson);
+    
+    const canaryVersion = canaryVersions.get(pkg.name);
+    const updatedPackageJson = {
+      ...originalPackageJson,
+      version: canaryVersion,
+      gitSha: gitSha
+    };
+    
+    // Update dependencies to point to canary versions
+    if (updatedPackageJson.dependencies) {
+      updatedPackageJson.dependencies = updateDependenciesToCanary(
+        originalPackageJson.dependencies,
+        canaryVersions
+      );
+    }
+    
+    if (updatedPackageJson.devDependencies) {
+      updatedPackageJson.devDependencies = updateDependenciesToCanary(
+        originalPackageJson.devDependencies,
+        canaryVersions
+      );
+    }
+    
+    if (updatedPackageJson.peerDependencies) {
+      updatedPackageJson.peerDependencies = updateDependenciesToCanary(
+        originalPackageJson.peerDependencies,
+        canaryVersions
+      );
+    }
+    
+    if (!dryRun) {
+      await writePackageJson(pkg.path, updatedPackageJson);
+    }
+    
+    console.log(`📝 Updated ${pkg.name} package.json for canary release`);
+  }
+  
+  // Third pass: publish all canary versions
+  let publishSuccess = false;
+  try {
+    for (const pkg of packages) {
+      const canaryVersion = canaryVersions.get(pkg.name);
+      console.log(`📤 Publishing ${pkg.name}@${canaryVersion} with canary tag...`);
+      await publishPackage(pkg.path, 'canary', dryRun);
+      console.log(`✅ Published ${pkg.name}@${canaryVersion}`);
+    }
+    publishSuccess = true;
+  } finally {
+    // Always restore original package.json files
+    if (!dryRun) {
+      console.log('\n🔄 Restoring original package.json files...');
+      for (const pkg of packages) {
+        const originalPackageJson = originalPackageJsons.get(pkg.name);
+        await writePackageJson(pkg.path, originalPackageJson);
+        console.log(`✅ Restored ${pkg.name}/package.json`);
+      }
+    }
+  }
+  
+  if (publishSuccess) {
+    console.log('\n🎉 All canary versions published successfully!');
+  }
+}
+
+/**
+ * Main publishing function
+ */
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const canaryOnly = args.includes('--canary-only');
+  
+  if (dryRun) {
+    console.log('🧪 Running in DRY RUN mode - no actual publishing will occur\n');
+  }
+  
+  console.log('🔍 Discovering workspace packages...');
+  const packages = await getWorkspacePackages();
+  
+  if (packages.length === 0) {
+    console.log('⚠️  No public packages found in workspace');
+    return;
+  }
+  
+  console.log(`📋 Found ${packages.length} public packages:`);
+  packages.forEach(pkg => {
+    console.log(`   • ${pkg.name}@${pkg.version}`);
+  });
+  
+  if (!canaryOnly) {
+    await publishRegularVersions(packages, dryRun);
+  }
+  
+  await publishCanaryVersions(packages, dryRun);
+  
+  console.log('\n🏁 Publishing complete!');
+}
+
+// Run the script
+main();

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -1,8 +1,31 @@
 #!/usr/bin/env node
 
+/* eslint-disable no-console */
+
 import { $ } from 'execa';
 import fs from 'fs/promises';
 import path from 'path';
+
+/**
+ * Wrapper for $ that supports dry run mode
+ */
+function runCmd(options = {}) {
+  const { dryRun = false, ...execaOptions } = options;
+
+  if (dryRun) {
+    return function dryRunExec(templateStrings, ...values) {
+      // Reconstruct the command string
+      let command = templateStrings[0];
+      for (let i = 0; i < values.length; i += 1) {
+        command += String(values[i]) + templateStrings[i + 1];
+      }
+      console.log(`[DRY RUN] Would execute: ${command}`);
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+  }
+
+  return $(execaOptions);
+}
 
 /**
  * Get all workspace packages that are public
@@ -10,16 +33,16 @@ import path from 'path';
 async function getWorkspacePackages() {
   const result = await $`pnpm ls -r --parseable --depth -1`;
   const packagePaths = result.stdout.trim().split('\n').filter(Boolean);
-  
+
   // Read all package.json files in parallel
   const packageJsonPromises = packagePaths.map(async (packagePath) => {
     const packageJsonPath = path.join(packagePath, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
     return { packagePath, packageJson };
   });
-  
+
   const packageResults = await Promise.all(packageJsonPromises);
-  
+
   // Filter out private packages
   const publicPackages = packageResults
     .filter(({ packageJson }) => !packageJson.private)
@@ -27,43 +50,43 @@ async function getWorkspacePackages() {
       name: packageJson.name,
       version: packageJson.version,
       path: packagePath,
-      packageJson
+      packageJson,
     }));
-  
+
   return publicPackages;
 }
 
 /**
- * Check if a specific version exists on npm registry
+ * Get package version info from registry
  */
-async function checkNpmVersion(packageName, version) {
+async function getPackageVersionInfo(packageName, baseVersion) {
   try {
-    const result = await $`npm view ${packageName}@${version} version`;
-    return result.stdout.trim() === version;
-  } catch (error) {
-    return false; // Version doesn't exist
-  }
-}
-
-/**
- * Get the latest canary version for a package
- */
-async function getLatestCanaryVersion(packageName, baseVersion) {
-  try {
-    const result = await $`npm view ${packageName} versions --json`;
+    const result = await $`pnpm view ${packageName} versions --json`;
     const versions = JSON.parse(result.stdout);
-    
+
+    // Check if current version exists
+    const currentVersionExists = versions.includes(baseVersion);
+
+    // Find latest canary version
     const canaryVersions = versions
-      .filter(v => v.startsWith(`${baseVersion}-canary.`))
-      .map(v => {
+      .filter((v) => v.startsWith(`${baseVersion}-canary.`))
+      .map((v) => {
         const match = v.match(/canary\.(\d+)$/);
         return { version: v, number: match ? parseInt(match[1], 10) : 0 };
       })
       .sort((a, b) => b.number - a.number);
-    
-    return canaryVersions[0]?.version || null;
+
+    const latestCanaryVersion = canaryVersions[0]?.version || null;
+
+    return {
+      currentVersionExists,
+      latestCanaryVersion,
+    };
   } catch (error) {
-    return null;
+    return {
+      currentVersionExists: false,
+      latestCanaryVersion: null,
+    };
   }
 }
 
@@ -71,8 +94,10 @@ async function getLatestCanaryVersion(packageName, baseVersion) {
  * Get the next canary number
  */
 function getNextCanaryNumber(latestCanaryVersion) {
-  if (!latestCanaryVersion) return 0;
-  
+  if (!latestCanaryVersion) {
+    return 0;
+  }
+
   const match = latestCanaryVersion.match(/canary\.(\d+)$/);
   return match ? parseInt(match[1], 10) + 1 : 0;
 }
@@ -97,7 +122,7 @@ async function readPackageJson(packagePath) {
  * Write package.json to a directory
  */
 async function writePackageJson(packagePath, packageJson) {
-  const content = JSON.stringify(packageJson, null, 2) + '\n';
+  const content = `${JSON.stringify(packageJson, null, 2)}\n`;
   await fs.writeFile(path.join(packagePath, 'package.json'), content);
 }
 
@@ -105,51 +130,52 @@ async function writePackageJson(packagePath, packageJson) {
  * Update dependencies to point to canary versions
  */
 function updateDependenciesToCanary(dependencies, canaryVersions) {
-  if (!dependencies) return dependencies;
-  
+  if (!dependencies) {
+    return dependencies;
+  }
+
   const updated = { ...dependencies };
-  
+
   for (const [depName, depVersion] of Object.entries(dependencies)) {
     if (canaryVersions.has(depName)) {
       updated[depName] = canaryVersions.get(depName);
     } else if (depVersion === 'workspace:*') {
-      // Check if this is a workspace dependency that has a canary version
-      const workspacePackageName = Object.keys(Object.fromEntries(canaryVersions))
-        .find(name => name.includes(depName) || depName.includes(name));
-      
-      if (workspacePackageName && canaryVersions.has(workspacePackageName)) {
-        updated[depName] = canaryVersions.get(workspacePackageName);
+      if (!canaryVersions.has(depName)) {
+        throw new Error(
+          `Cannot resolve workspace dependency "${depName}" - no canary version available`,
+        );
       }
+      updated[depName] = canaryVersions.get(depName);
     }
   }
-  
+
   return updated;
 }
 
 /**
  * Publish a package
  */
-async function publishPackage(packagePath, tag, dryRun = false) {
-  if (dryRun) {
-    console.log(`[DRY RUN] Would execute: pnpm publish --tag ${tag} in ${packagePath}`);
-    return;
-  }
-  
-  await $({ cwd: packagePath })`pnpm publish --tag ${tag}`;
+async function publishPackage(packagePath, tag, options = {}) {
+  const { provenance = false, dryRun = false } = options;
+  const provenanceArgs = provenance ? ['--provenance'] : [];
+
+  await runCmd({ cwd: packagePath, dryRun })`pnpm publish --tag ${tag} ${provenanceArgs}`;
 }
 
 /**
  * Publish regular versions that don't exist on npm
  */
-async function publishRegularVersions(packages, dryRun = false) {
+async function publishRegularVersions(packages, packageVersionInfo, options = {}) {
   console.log('\n📦 Checking for unpublished regular versions...');
-  
+
+  // run sequentially to avoid any rate limniting issues
   for (const pkg of packages) {
-    const versionExists = await checkNpmVersion(pkg.name, pkg.version);
-    
-    if (!versionExists) {
+    const { currentVersionExists } = packageVersionInfo.get(pkg.name);
+
+    if (!currentVersionExists) {
       console.log(`📤 Publishing ${pkg.name}@${pkg.version}...`);
-      await publishPackage(pkg.path, 'latest', dryRun);
+      // eslint-disable-next-line no-await-in-loop
+      await publishPackage(pkg.path, 'latest', options);
       console.log(`✅ Published ${pkg.name}@${pkg.version}`);
     } else {
       console.log(`⏭️  ${pkg.name}@${pkg.version} already exists, skipping`);
@@ -160,102 +186,97 @@ async function publishRegularVersions(packages, dryRun = false) {
 /**
  * Publish canary versions with updated dependencies
  */
-async function publishCanaryVersions(packages, dryRun = false) {
+async function publishCanaryVersions(packages, packageVersionInfo, options = {}) {
   console.log('\n🔥 Publishing canary versions...');
-  
+
   const gitSha = await getCurrentGitSha();
   const canaryVersions = new Map();
   const originalPackageJsons = new Map();
-  
-  // First pass: determine all canary version numbers in parallel
-  const canaryVersionPromises = packages.map(async (pkg) => {
-    const latestCanary = await getLatestCanaryVersion(pkg.name, pkg.version);
-    const nextCanaryNumber = getNextCanaryNumber(latestCanary);
+
+  // First pass: determine all canary version numbers
+  const canaryResults = packages.map((pkg) => {
+    const { latestCanaryVersion } = packageVersionInfo.get(pkg.name);
+    const nextCanaryNumber = getNextCanaryNumber(latestCanaryVersion);
     const canaryVersion = `${pkg.version}-canary.${nextCanaryNumber}`;
-    
+
     console.log(`🏷️  ${pkg.name}: ${canaryVersion}`);
     return { pkg, canaryVersion };
   });
-  
-  const canaryResults = await Promise.all(canaryVersionPromises);
-  
+
   // Build the canary versions map
   for (const { pkg, canaryVersion } of canaryResults) {
     canaryVersions.set(pkg.name, canaryVersion);
   }
-  
+
   // Second pass: read and update package.json files in parallel
   const packageUpdatePromises = packages.map(async (pkg) => {
     const originalPackageJson = await readPackageJson(pkg.path);
-    
+
     const canaryVersion = canaryVersions.get(pkg.name);
     const updatedPackageJson = {
       ...originalPackageJson,
       version: canaryVersion,
-      gitSha: gitSha
+      gitSha,
     };
-    
+
     // Update dependencies to point to canary versions
     if (updatedPackageJson.dependencies) {
       updatedPackageJson.dependencies = updateDependenciesToCanary(
         originalPackageJson.dependencies,
-        canaryVersions
+        canaryVersions,
       );
     }
-    
+
     if (updatedPackageJson.devDependencies) {
       updatedPackageJson.devDependencies = updateDependenciesToCanary(
         originalPackageJson.devDependencies,
-        canaryVersions
+        canaryVersions,
       );
     }
-    
+
     if (updatedPackageJson.peerDependencies) {
       updatedPackageJson.peerDependencies = updateDependenciesToCanary(
         originalPackageJson.peerDependencies,
-        canaryVersions
+        canaryVersions,
       );
     }
-    
-    if (!dryRun) {
-      await writePackageJson(pkg.path, updatedPackageJson);
-    }
-    
+
+    await writePackageJson(pkg.path, updatedPackageJson);
+
     console.log(`📝 Updated ${pkg.name} package.json for canary release`);
     return { pkg, originalPackageJson };
   });
-  
+
   const updateResults = await Promise.all(packageUpdatePromises);
-  
+
   // Build the original package.json map
   for (const { pkg, originalPackageJson } of updateResults) {
     originalPackageJsons.set(pkg.name, originalPackageJson);
   }
-  
+
   // Third pass: publish all canary versions sequentially to avoid rate limits
   let publishSuccess = false;
   try {
     for (const pkg of packages) {
       const canaryVersion = canaryVersions.get(pkg.name);
       console.log(`📤 Publishing ${pkg.name}@${canaryVersion} with canary tag...`);
-      await publishPackage(pkg.path, 'canary', dryRun);
+      // eslint-disable-next-line no-await-in-loop
+      await publishPackage(pkg.path, 'canary', options);
       console.log(`✅ Published ${pkg.name}@${canaryVersion}`);
     }
     publishSuccess = true;
   } finally {
     // Always restore original package.json files in parallel
-    if (!dryRun) {
-      console.log('\n🔄 Restoring original package.json files...');
-      const restorePromises = packages.map(async (pkg) => {
-        const originalPackageJson = originalPackageJsons.get(pkg.name);
-        await writePackageJson(pkg.path, originalPackageJson);
-        console.log(`✅ Restored ${pkg.name}/package.json`);
-      });
-      
-      await Promise.all(restorePromises);
-    }
+    console.log('\n🔄 Restoring original package.json files...');
+    const restorePromises = packages.map(async (pkg) => {
+      const originalPackageJson = originalPackageJsons.get(pkg.name);
+      await writePackageJson(pkg.path, originalPackageJson);
+      console.log(`✅ Restored ${pkg.name}/package.json`);
+    });
+
+    await Promise.all(restorePromises);
   }
-  
+
   if (publishSuccess) {
     console.log('\n🎉 All canary versions published successfully!');
   }
@@ -268,30 +289,51 @@ async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
   const canaryOnly = args.includes('--canary-only');
-  
+  const provenance = args.includes('--provenance');
+
+  const options = { dryRun, provenance };
+
   if (dryRun) {
     console.log('🧪 Running in DRY RUN mode - no actual publishing will occur\n');
   }
-  
+
+  if (provenance) {
+    console.log('🔐 Provenance enabled - packages will include provenance information\n');
+  }
+
   console.log('🔍 Discovering workspace packages...');
   const packages = await getWorkspacePackages();
-  
+
   if (packages.length === 0) {
     console.log('⚠️  No public packages found in workspace');
     return;
   }
-  
+
   console.log(`📋 Found ${packages.length} public packages:`);
-  packages.forEach(pkg => {
+  packages.forEach((pkg) => {
     console.log(`   • ${pkg.name}@${pkg.version}`);
   });
-  
-  if (!canaryOnly) {
-    await publishRegularVersions(packages, dryRun);
+
+  // Fetch version info for all packages in parallel
+  console.log('\n🔍 Fetching package version information...');
+  const versionInfoPromises = packages.map(async (pkg) => {
+    const versionInfo = await getPackageVersionInfo(pkg.name, pkg.version);
+    return { packageName: pkg.name, versionInfo };
+  });
+
+  const versionInfoResults = await Promise.all(versionInfoPromises);
+  const packageVersionInfo = new Map();
+
+  for (const { packageName, versionInfo } of versionInfoResults) {
+    packageVersionInfo.set(packageName, versionInfo);
   }
-  
-  await publishCanaryVersions(packages, dryRun);
-  
+
+  if (!canaryOnly) {
+    await publishRegularVersions(packages, packageVersionInfo, options);
+  }
+
+  await publishCanaryVersions(packages, packageVersionInfo, options);
+
   console.log('\n🏁 Publishing complete!');
 }
 


### PR DESCRIPTION
* publish npm packages from master branch if their current versions are unpublished.
* publish canary version of all packages for every master branch commit
* add npm provenance

this allows us to set up renovatebot on dependent repos to bump internal dependencies on every change