### PR TITLE
[infra] Set write permission in publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write # Required for pushing tags
       id-token: write # Required for provenance
 
     steps:


### PR DESCRIPTION
It needs to be able to push tags to mark commits that have been published as canary