### PR TITLE
Do not assign `displayName` to non-functions

### DIFF
--- a/packages/babel-plugin-display-name/src/index.js
+++ b/packages/babel-plugin-display-name/src/index.js
@@ -239,6 +239,19 @@ function addDisplayNamesToFunctionComponent(t, path) {
 
     // const componentIdentifier = <Element />
     if (parentPath.isVariableDeclarator()) {
+      // Ternary expression
+      if (t.isConditionalExpression(parentPath.node.init)) {
+        const { consequent, alternate } = parentPath.node.init;
+        const isConsequentFunction =
+          t.isArrowFunctionExpression(consequent) || t.isFunctionExpression(consequent);
+        const isAlternateFunction =
+          t.isArrowFunctionExpression(alternate) || t.isFunctionExpression(alternate);
+
+        // Only add display name if variable is a function
+        if (!isConsequentFunction || !isAlternateFunction) {
+          return false;
+        }
+      }
       assignmentPath = parentPath.parentPath;
       componentIdentifiers.unshift({
         id: /** @type {babel.types.Expression} */ (parentPath.node.id),

--- a/packages/babel-plugin-display-name/src/index.test.js
+++ b/packages/babel-plugin-display-name/src/index.test.js
@@ -1045,4 +1045,14 @@ describe('babelDisplayNamePlugin', () => {
       if (process.env.NODE_ENV !== "production") Foo.displayName = "Foo";"
     `);
   });
+
+  it(`shouldn't add display name to variables that are not functions`, () => {
+    expect(
+      transformWithAllowedCallees(`
+      const Test = true ? () => <img/> : (undefined);
+      `),
+    ).toMatchInlineSnapshot(`
+      "const Test = true ? () => React.createElement("img", null) : undefined;"
+    `);
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/mui/mui-x/issues/18174

It tries assigning `displayName` to a variable, even if it's undefined.

https://github.com/mui/mui-x/blob/9ba4aa36e4e69d55d8187b2297e2cf9b41337800/packages/x-data-grid-premium/src/components/GridPremiumToolbar.tsx#L43-L53

<img width="753" src="https://github.com/user-attachments/assets/9eddeea7-82ef-41e5-8b57-3b963201548c" />

In this example, `additionalExportMenuItems` is not a React component, but a function that returns a JSX Element and is called directly.
So `displayName` is not necessary here.
It seems impossible to know whether this function is a React component, but at least we can make sure that both paths of a ternary operator are functions.