### PR TITLE
[infra] Some fixes to auto canary publishing

### DIFF
--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -85,11 +85,11 @@ async function getPackageVersionInfo(packageName, baseVersion) {
 
     // Get canary dist-tag to find latest canary version
     const canaryResult = await $`pnpm view ${packageName} dist-tags.canary`;
-    const canaryVersion = canaryResult.stdout.trim();
+    const latestCanaryVersion = semver.valid(canaryResult.stdout.trim());
 
     return {
       currentVersionExists,
-      latestCanaryVersion: semver.valid(canaryVersion),
+      latestCanaryVersion,
     };
   } catch (error) {
     return {

--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -84,22 +84,12 @@ async function getPackageVersionInfo(packageName, baseVersion) {
     }
 
     // Get canary dist-tag to find latest canary version
-    let latestCanaryVersion = null;
-    try {
-      const canaryResult = await $`pnpm view ${packageName} dist-tags.canary`;
-      const canaryTag = canaryResult.stdout.trim();
-
-      // Check if canary tag matches our base version pattern
-      if (canaryTag && canaryTag.startsWith(`${baseVersion}-canary.`)) {
-        latestCanaryVersion = canaryTag;
-      }
-    } catch {
-      // No canary dist-tag found, that's fine
-    }
+    const canaryResult = await $`pnpm view ${packageName} dist-tags.canary`;
+    const canaryVersion = canaryResult.stdout.trim();
 
     return {
       currentVersionExists,
-      latestCanaryVersion,
+      latestCanaryVersion: semver.valid(canaryVersion),
     };
   } catch (error) {
     return {
@@ -240,6 +230,16 @@ async function publishRegularVersions(packages, packageVersionInfo, options = {}
 }
 
 /**
+ * Get the maximum semver version between two versions
+ * @param {string} a
+ * @param {string} b
+ * @returns {string} The maximum semver version
+ */
+function semverMax(a, b) {
+  return semver.gt(a, b) ? a : b;
+}
+
+/**
  * Publish canary versions with updated dependencies
  * @param {Package[]} packagesToPublish - Packages that need canary publishing
  * @param {Package[]} allPackages - All workspace packages
@@ -277,8 +277,9 @@ async function publishCanaryVersions(
 
     if (changedPackageNames.has(pkg.name)) {
       // Generate new canary version for changed packages
-      const baseVersion =
-        versionInfo.latestCanaryVersion || semver.inc(pkg.version, 'patch') || '0.0.0';
+      const baseVersion = versionInfo.latestCanaryVersion
+        ? semverMax(versionInfo.latestCanaryVersion, pkg.version)
+        : pkg.version;
       const canaryVersion = semver.inc(baseVersion, 'prerelease', 'canary');
       canaryVersions.set(pkg.name, canaryVersion);
       console.log(`🏷️  ${pkg.name}: ${canaryVersion} (new)`);


### PR DESCRIPTION
* `semver.inc()` also increments patch when incrementing prerelease if necessary, so avoid double patch increment
* Make sure `latestCanaryVersion` gets passed correctly, remove outdated check against base version. Instead use `semver` to compare and select base version to start incrementing from.