### PR TITLE
[code-infra] Shareable renovate preset

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "name": "renovate-mui-config",
+  "description": "Renovate configuration for MUI repositories.",
+  "automerge": false,
+  "commitMessageAction": "Bump",
+  "commitMessageExtra": "to {{newValue}}",
+  "commitMessageTopic": "{{depName}}",
+  "dependencyDashboard": true,
+  "rebaseWhen": "conflicted",
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": "before 6:00am on the first day of the month"
+  },
+  "postUpdateOptions": ["pnpmDedupe"],
+  "prConcurrentLimit": 30,
+  "prHourlyLimit": 0,
+  "rangeStrategy": "bump",
+  "schedule": "on sunday before 6:00am",
+  "timezone": "UTC",
+  "ignorePaths": ["examples/**"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
+      "groupName": "babel",
+      "matchPackageNames": ["^@babel/", "^@types/babel"]
+    },
+    {
+      "groupName": "Infra packages",
+      "matchPackageNames": ["@mui/internal-*"],
+      "followTag": "canary",
+      "schedule": null
+    },
+    {
+      "groupName": "core-js",
+      "matchPackageNames": ["core-js"],
+      "allowedVersions": "< 2.0.0"
+    },
+    {
+      "groupName": "Emotion",
+      "matchPackageNames": ["@emotion/*"]
+    },
+    {
+      "groupName": "React",
+      "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom"]
+    },
+    {
+      "groupName": "Playwright",
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "matchDepTypes": ["action"],
+      "pinDigests": true
+    },
+    {
+      "groupName": "@definitelytyped tools",
+      "matchPackageNames": ["@definitelytyped/*"]
+    },
+    {
+      "groupName": "Testing libraries",
+      "matchPackageNames": ["@testing-library/*"]
+    },
+    {
+      "groupName": "node",
+      "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
+      "enabled": false
+    },
+    {
+      "groupName": "tseslint",
+      "matchPackageNames": ["typescript-eslint", "@typescript-eslint/*"]
+    }
+  ]
+}

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -46,7 +46,14 @@
     },
     {
       "groupName": "React",
-      "matchPackageNames": ["react", "react-dom", "react-is", "@types/react", "@types/react-dom"]
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "react-is",
+        "@types/react",
+        "@types/react-dom",
+        "@types/react-is"
+      ]
     },
     {
       "groupName": "Playwright",
@@ -75,12 +82,22 @@
       "enabled": false
     },
     {
-      "groupName": "tseslint",
-      "matchPackageNames": ["typescript-eslint", "@typescript-eslint/*"]
+      "groupName": "eslint",
+      "matchPackageNames": [
+        "eslint",
+        "eslint-*",
+        "typescript-eslint",
+        "@typescript-eslint/*",
+        "@types/eslint-*"
+      ]
     },
     {
       "groupName": "Vite & Vitest",
-      "matchPackageNames": ["@vitejs/**", "/vitest/", "esbuild"]
+      "matchPackageNames": ["vite", "@vitejs/**", "/vitest/", "esbuild", "^vitest$", "^@vitest/"]
+    },
+    {
+      "automerge": true,
+      "matchPackageNames": ["@types/**"]
     }
   ]
 }

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Renovate configuration for MUI repositories.",
+  "extends": [":semanticCommitsDisabled"],
   "automerge": false,
   "commitMessageAction": "Bump",
   "commitMessageExtra": "to {{newValue}}",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -51,12 +51,14 @@
         "react-is",
         "@types/react",
         "@types/react-dom",
-        "@types/react-is"
+        "@types/react-is",
+        "use-sync-external-store",
+        "@types/use-sync-external-store"
       ]
     },
     {
       "groupName": "Playwright",
-      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"]
+      "matchPackageNames": ["@playwright/*", "playwright", "mcr.microsoft.com/playwright"]
     },
     {
       "groupName": "GitHub Actions",
@@ -77,6 +79,7 @@
     },
     {
       "groupName": "node",
+      "matchDatasources": ["docker", "node-version"],
       "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
       "enabled": false
     },

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -19,7 +19,6 @@
   "rangeStrategy": "bump",
   "schedule": "on sunday before 6:00am",
   "timezone": "UTC",
-  "ignorePaths": ["examples/**"],
   "packageRules": [
     {
       "matchDepTypes": ["peerDependencies"],
@@ -27,7 +26,7 @@
     },
     {
       "groupName": "babel",
-      "matchPackageNames": ["^@babel/", "^@types/babel"]
+      "matchPackageNames": ["^@babel/", "^@types/babel", "^babel-"]
     },
     {
       "groupName": "Infra packages",
@@ -94,10 +93,6 @@
     {
       "groupName": "Vite & Vitest",
       "matchPackageNames": ["vite", "@vitejs/**", "/vitest/", "esbuild", "^vitest$", "^@vitest/"]
-    },
-    {
-      "automerge": true,
-      "matchPackageNames": ["@types/**"]
     }
   ]
 }

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -31,7 +31,7 @@
     },
     {
       "groupName": "Infra packages",
-      "matchPackageNames": ["@mui/internal-*"],
+      "matchPackageNames": ["@mui/internal-*", "@mui/docs"],
       "followTag": "canary",
       "schedule": null
     },
@@ -58,7 +58,8 @@
     },
     {
       "matchDepTypes": ["action"],
-      "pinDigests": true
+      "pinDigests": true,
+      "automerge": true
     },
     {
       "groupName": "@definitelytyped tools",
@@ -76,6 +77,10 @@
     {
       "groupName": "tseslint",
       "matchPackageNames": ["typescript-eslint", "@typescript-eslint/*"]
+    },
+    {
+      "groupName": "Vite & Vitest",
+      "matchPackageNames": ["@vitejs/**", "/vitest/", "esbuild"]
     }
   ]
 }

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "name": "renovate-mui-config",
   "description": "Renovate configuration for MUI repositories.",
   "automerge": false,
   "commitMessageAction": "Bump",


### PR DESCRIPTION
This config will be extended in the downstream repos using -

```json
{
  "extends": ["github>mui/mui-public//renovate/default"]
}
```

See - https://docs.renovatebot.com/config-presets/#github
Companion PRs -

1. https://github.com/mui/material-ui/pull/46483
2. https://github.com/mui/mui-x/pull/18683
3. https://github.com/mui/base-ui/pull/2257