### PR TITLE
[infra] Add mjs and mts to import resolver extensions

### DIFF
--- a/packages/babel-plugin-resolve-imports/index.js
+++ b/packages/babel-plugin-resolve-imports/index.js
@@ -39,7 +39,7 @@ function pathToNodeImportSpecifier(importPath) {
 module.exports = function plugin({ types: t }, { outExtension }) {
   /** @type {Map<string, string>} */
   const cache = new Map();
-  const extensions = ['.ts', '.tsx', '.js', '.jsx'];
+  const extensions = ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx'];
   const extensionsSet = new Set(extensions);
 
   /**


### PR DESCRIPTION
Necessary if we want to fix the type declarations for .mjs files. For https://github.com/mui/mui-x/issues/17503#issuecomment-3031634156