### PR TITLE
[infra] Use pnpm pack to fix catalog resolution

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -31,4 +31,4 @@ jobs:
       - run: pnpm install
       - run: pnpm release:build
       - name: Publish packages to pkg.pr.new
-        run: pnpm dlx pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=publish-dir) --packageManager=pnpm --comment=off --peerDeps --template './examples/*'
+        run: pnpm dlx pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=publish-dir) --pnpm --packageManager=pnpm --comment=off --peerDeps --template './examples/*'


### PR DESCRIPTION
Companion PR that has the actual fix - https://github.com/mui/material-ui/pull/46563
which removed `publishConfig.directory` from the output package.json for this to work.

Note: This PR should be merged only after all repos are migrated to use latest monorepo once the above PR is merged.