### PR TITLE
Add version overrides script

### DIFF
--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -21,6 +21,7 @@ import { resolveVersionSpec, findDependencyVersion } from './pnpm.mjs';
  * @returns {Promise<void>}
  */
 async function handler(versions) {
+  console.log('cwd:', process.cwd());
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -1,73 +1,26 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
 /**
- * Given a version specifier (dist-tag, range, exact version) fetch the exact
- * version and make sure this version is used throughout the repository.
- *
- * If you work on this file:
- * WARNING: This script can only use built-in modules since it has to run before
- * `pnpm install`
+ * @typedef {Object} Args
+ * @property {string} [react] - React version specifier
+ * @property {string} [typescript] - TypeScript version specifier
  */
+
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { spawn } from 'child_process';
+import * as semver from 'semver';
+import { $ } from 'execa';
+import { resolveVersionSpec, findDependencyVersion } from './pnpm.mjs';
 
 /**
- * Run a shell command
- * @param {string} cmdString - The full command string, e.g. 'pnpm install'
- * @param {object} [options] - Optional spawn options.
- * @returns {Promise<number>} - Resolves with exit code 0, rejects otherwise.
+ * Main function to set version overrides
+ * @param {Args} versions - Version configuration
+ * @returns {Promise<void>}
  */
-function execute(cmdString, stream) {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cmdString, {
-      shell: true,
-      stdio: 'pipe',
-    });
-
-    let output = '';
-
-    child.stdout.on('data', (chunk) => {
-      if (stream) {
-        process.stdout.write(chunk);
-      }
-      output += chunk.toString();
-    });
-
-    let stderr = '';
-    child.stderr.on('data', (chunk) => {
-      if (stream) {
-        process.stderr.write(chunk);
-      }
-      stderr += chunk.toString();
-    });
-
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve(output.trim());
-      } else {
-        reject(
-          Object.assign(new Error(`Command failed: ${cmdString}\n${stderr}`), { code, stderr }),
-        );
-      }
-    });
-  });
-}
-
-function getMajor(version) {
-  const [major] = version.split('.');
-  return Number(major);
-}
-
-async function resolveVersionSpec(pkg, specifier) {
-  return execute(`pnpm info ${pkg}@${specifier} version`);
-}
-
-async function findDependencyVersion(pkg, specifier, dependency) {
-  const spec = await execute(`pnpm info ${pkg}@${specifier} dependencies.${dependency}`);
-  return resolveVersionSpec(dependency, spec);
-}
-
-async function main(versions) {
+async function handler(versions) {
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {
@@ -76,7 +29,7 @@ async function main(versions) {
     overrides['react-is'] = await resolveVersionSpec('react-is', versions.react);
     overrides.scheduler = await findDependencyVersion('react-dom', versions.react, 'scheduler');
 
-    const reactMajor = getMajor(overrides.react);
+    const reactMajor = semver.major(overrides.react);
     if (reactMajor === 17) {
       overrides['@testing-library/react'] = await resolveVersionSpec(
         '@testing-library/react',
@@ -100,13 +53,24 @@ async function main(versions) {
     return;
   }
 
-  await execute(`pnpm dedupe`, { stdio: 'inherit' });
+  await $({ stdio: 'inherit' })`pnpm dedupe`;
 }
 
-main({
-  react: process.env.REACT_VERSION,
-  typescript: process.env.TYPESCRIPT_VERSION,
-}).catch((error) => {
-  console.error(error);
-  process.exit(1);
+export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
+  command: 'set-version-overrides',
+  describe: 'Set version overrides for React and TypeScript throughout the repository',
+  builder: (yargs) => {
+    return yargs
+      .option('react', {
+        type: 'string',
+        description: 'React version specifier (dist-tag, range, or exact version)',
+        default: process.env.REACT_VERSION,
+      })
+      .option('typescript', {
+        type: 'string',
+        description: 'TypeScript version specifier (dist-tag, range, or exact version)',
+        default: process.env.TYPESCRIPT_VERSION,
+      });
+  },
+  handler,
 });

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -24,6 +24,7 @@ async function handler(versions) {
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {
+    console.log(`Resolving overrides for React version: ${versions.react}`);
     overrides.react = await resolveVersionSpec('react', versions.react);
     overrides['react-dom'] = await resolveVersionSpec('react-dom', versions.react);
     overrides['react-is'] = await resolveVersionSpec('react-is', versions.react);
@@ -39,15 +40,17 @@ async function handler(versions) {
   }
 
   if (versions.typescript && versions.typescript !== 'stable') {
+    console.log(`Resolving overrides for TypeScript version: ${versions.typescript}`);
     overrides.typescript = await resolveVersionSpec('typescript', versions.typescript);
   }
 
   const packageJsonPath = path.resolve(process.cwd(), 'package.json');
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
+  packageJson.resolutions ??= {};
   Object.assign(packageJson.resolutions, overrides);
   await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
 
-  console.log(`Using versions: ${JSON.stringify(overrides, null, 2)}`);
+  console.log(`Using overrides: ${JSON.stringify(overrides, null, 2)}`);
 
   if (Object.keys(overrides).length <= 0) {
     return;

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -24,6 +24,7 @@ async function handler(versions) {
   console.log('cwd:', process.cwd());
   console.log('pnpm version:', (await $`pnpm --version`).stdout);
   console.log('pnpm location:', (await $`which pnpm`).stdout);
+  console.log('env:', (await $`env`).stdout);
   console.log('PATH:', process.env.PATH);
   const overrides = {};
 
@@ -61,7 +62,7 @@ async function handler(versions) {
   Object.assign(packageJson.resolutions, overrides);
   await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
 
-  await $({ stdio: 'inherit', env: process.env })`pnpm dedupe`;
+  await $({ stdio: 'inherit', shell: true })`pnpm dedupe`;
 }
 
 export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -44,17 +44,18 @@ async function handler(versions) {
     overrides.typescript = await resolveVersionSpec('typescript', versions.typescript);
   }
 
+  if (Object.keys(overrides).length <= 0) {
+    console.log('No version overrides specified, skipping.');
+    return;
+  }
+
+  console.log(`Using overrides: ${JSON.stringify(overrides, null, 2)}`);
+
   const packageJsonPath = path.resolve(process.cwd(), 'package.json');
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
   packageJson.resolutions ??= {};
   Object.assign(packageJson.resolutions, overrides);
   await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
-
-  console.log(`Using overrides: ${JSON.stringify(overrides, null, 2)}`);
-
-  if (Object.keys(overrides).length <= 0) {
-    return;
-  }
 
   await $({ stdio: 'inherit' })`pnpm dedupe`;
 }

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -22,6 +22,7 @@ import { resolveVersionSpec, findDependencyVersion } from './pnpm.mjs';
  */
 async function handler(versions) {
   console.log('cwd:', process.cwd());
+  console.log('pnpm version:', await $`pnpm --version`);
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -22,7 +22,7 @@ import { resolveVersionSpec, findDependencyVersion } from './pnpm.mjs';
  */
 async function handler(versions) {
   console.log('cwd:', process.cwd());
-  console.log('pnpm version:', await $`pnpm --version`);
+  console.log('pnpm version:', (await $`pnpm --version`).stdout);
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -24,6 +24,7 @@ async function handler(versions) {
   console.log('cwd:', process.cwd());
   console.log('pnpm version:', (await $`pnpm --version`).stdout);
   console.log('pnpm location:', (await $`which pnpm`).stdout);
+  console.log('PATH:', process.env.PATH);
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {
@@ -60,7 +61,7 @@ async function handler(versions) {
   Object.assign(packageJson.resolutions, overrides);
   await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
 
-  await $({ stdio: 'inherit' })`pnpm dedupe`;
+  await $({ stdio: 'inherit', env: process.env })`pnpm dedupe`;
 }
 
 export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -1,0 +1,112 @@
+/**
+ * Given a version specifier (dist-tag, range, exact version) fetch the exact
+ * version and make sure this version is used throughout the repository.
+ *
+ * If you work on this file:
+ * WARNING: This script can only use built-in modules since it has to run before
+ * `pnpm install`
+ */
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { spawn } from 'child_process';
+
+/**
+ * Run a shell command
+ * @param {string} cmdString - The full command string, e.g. 'pnpm install'
+ * @param {object} [options] - Optional spawn options.
+ * @returns {Promise<number>} - Resolves with exit code 0, rejects otherwise.
+ */
+function execute(cmdString, stream) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmdString, {
+      shell: true,
+      stdio: 'pipe',
+    });
+
+    let output = '';
+
+    child.stdout.on('data', (chunk) => {
+      if (stream) {
+        process.stdout.write(chunk);
+      }
+      output += chunk.toString();
+    });
+
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      if (stream) {
+        process.stderr.write(chunk);
+      }
+      stderr += chunk.toString();
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(output.trim());
+      } else {
+        reject(
+          Object.assign(new Error(`Command failed: ${cmdString}\n${stderr}`), { code, stderr }),
+        );
+      }
+    });
+  });
+}
+
+function getMajor(version) {
+  const [major] = version.split('.');
+  return Number(major);
+}
+
+async function resolveVersionSpec(pkg, specifier) {
+  return execute(`pnpm info ${pkg}@${specifier} version`);
+}
+
+async function findDependencyVersion(pkg, specifier, dependency) {
+  const spec = await execute(`pnpm info ${pkg}@${specifier} dependencies.${dependency}`);
+  return resolveVersionSpec(dependency, spec);
+}
+
+async function main(versions) {
+  const overrides = {};
+
+  if (versions.react && versions.react !== 'stable') {
+    overrides.react = await resolveVersionSpec('react', versions.react);
+    overrides['react-dom'] = await resolveVersionSpec('react-dom', versions.react);
+    overrides['react-is'] = await resolveVersionSpec('react-is', versions.react);
+    overrides.scheduler = await findDependencyVersion('react-dom', versions.react, 'scheduler');
+
+    const reactMajor = getMajor(overrides.react);
+    if (reactMajor === 17) {
+      overrides['@testing-library/react'] = await resolveVersionSpec(
+        '@testing-library/react',
+        '^12.1.0',
+      );
+    }
+  }
+
+  if (versions.typescript && versions.typescript !== 'stable') {
+    overrides.typescript = await resolveVersionSpec('typescript', versions.typescript);
+  }
+
+  const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
+  Object.assign(packageJson.resolutions, overrides);
+  await fs.writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
+
+  console.log(`Using versions: ${JSON.stringify(overrides, null, 2)}`);
+
+  if (Object.keys(overrides).length <= 0) {
+    return;
+  }
+
+  await execute(`pnpm dedupe`, { stdio: 'inherit' });
+}
+
+main({
+  react: process.env.REACT_VERSION,
+  typescript: process.env.TYPESCRIPT_VERSION,
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -1,13 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-console */
-
-/**
- * @typedef {Object} Args
- * @property {string} [react] - React version specifier
- * @property {string} [typescript] - TypeScript version specifier
- */
-
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -16,19 +8,21 @@ import { $ } from 'execa';
 import { resolveVersionSpec, findDependencyVersion } from './pnpm.mjs';
 
 /**
+ * @typedef {Object} Args
+ * @property {string} [react] - React version specifier
+ * @property {string} [typescript] - TypeScript version specifier
+ */
+
+/**
  * Main function to set version overrides
  * @param {Args} versions - Version configuration
  * @returns {Promise<void>}
  */
 async function handler(versions) {
-  console.log('cwd:', process.cwd());
-  console.log('pnpm version:', (await $`pnpm --version`).stdout);
-  console.log('pnpm location:', (await $`which pnpm`).stdout);
-  console.log('env:', (await $`env`).stdout);
-  console.log('PATH:', process.env.PATH);
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {
+    // eslint-disable-next-line no-console
     console.log(`Resolving overrides for React version: ${versions.react}`);
     overrides.react = await resolveVersionSpec('react', versions.react);
     overrides['react-dom'] = await resolveVersionSpec('react-dom', versions.react);
@@ -45,15 +39,18 @@ async function handler(versions) {
   }
 
   if (versions.typescript && versions.typescript !== 'stable') {
+    // eslint-disable-next-line no-console
     console.log(`Resolving overrides for TypeScript version: ${versions.typescript}`);
     overrides.typescript = await resolveVersionSpec('typescript', versions.typescript);
   }
 
   if (Object.keys(overrides).length <= 0) {
+    // eslint-disable-next-line no-console
     console.log('No version overrides specified, skipping.');
     return;
   }
 
+  // eslint-disable-next-line no-console
   console.log(`Using overrides: ${JSON.stringify(overrides, null, 2)}`);
 
   const packageJsonPath = path.resolve(process.cwd(), 'package.json');

--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -23,6 +23,7 @@ import { resolveVersionSpec, findDependencyVersion } from './pnpm.mjs';
 async function handler(versions) {
   console.log('cwd:', process.cwd());
   console.log('pnpm version:', (await $`pnpm --version`).stdout);
+  console.log('pnpm location:', (await $`which pnpm`).stdout);
   const overrides = {};
 
   if (versions.react && versions.react !== 'stable') {

--- a/packages/code-infra/src/cli/index.mjs
+++ b/packages/code-infra/src/cli/index.mjs
@@ -6,6 +6,7 @@ import cmdPublishCanary from './cmdPublishCanary.mjs';
 import cmdListWorkspaces from './cmdListWorkspaces.mjs';
 import cmdJsonLint from './cmdJsonLint.mjs';
 import cmdArgosPush from './cmdArgosPush.mjs';
+import cmdSetVersionOverrides from './cmdSetVersionOverrides.mjs';
 
 yargs()
   .command(cmdPublish)
@@ -13,6 +14,7 @@ yargs()
   .command(cmdListWorkspaces)
   .command(cmdJsonLint)
   .command(cmdArgosPush)
+  .command(cmdSetVersionOverrides)
   .demandCommand(1, 'You need at least one command before moving on')
   .help()
   .parse(hideBin(process.argv));

--- a/packages/code-infra/src/cli/pnpm.mjs
+++ b/packages/code-infra/src/cli/pnpm.mjs
@@ -168,6 +168,30 @@ export async function getCurrentGitSha() {
 }
 
 /**
+ * Resolve a version specifier to an exact version
+ * @param {string} pkg - Package name
+ * @param {string} specifier - Version specifier (dist-tag, range, exact version)
+ * @returns {Promise<string>} Exact version string
+ */
+export async function resolveVersionSpec(pkg, specifier) {
+  const result = await $`pnpm info ${pkg}@${specifier} version`;
+  return result.stdout.trim();
+}
+
+/**
+ * Find the version of a dependency for a specific package version
+ * @param {string} pkg - Package name
+ * @param {string} specifier - Version specifier for the package
+ * @param {string} dependency - Dependency name to look up
+ * @returns {Promise<string>} Exact version string of the dependency
+ */
+export async function findDependencyVersion(pkg, specifier, dependency) {
+  const result = await $`pnpm info ${pkg}@${specifier} dependencies.${dependency}`;
+  const spec = result.stdout.trim();
+  return resolveVersionSpec(dependency, spec);
+}
+
+/**
  * Get the maximum semver version between two versions
  * @param {string} a
  * @param {string} b


### PR DESCRIPTION
Porting https://github.com/mui/material-ui/blob/348eb570a48100c0024b9d35f07be6a30efcded0/scripts/useReactVersion.mjs

We will inverse the flow though to first install, then run this script. The total runtime is a few seconds slower but the DX is a lot better.