### PR TITLE
[infra] Fix when version command returns array

### DIFF
--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -42,7 +42,10 @@ async function processPackageOverride(packageSpec) {
     overrides.react = await resolveVersion(packageSpec);
     overrides['react-dom'] = await resolveVersion(`react-dom@${version}`);
     overrides['react-is'] = await resolveVersion(`react-is@${version}`);
-    overrides.scheduler = await findDependencyVersionFromSpec(`react-dom@${version}`, 'scheduler');
+    overrides.scheduler = await findDependencyVersionFromSpec(
+      `react-dom@${overrides['react-dom']}`,
+      'scheduler',
+    );
 
     const reactMajor = semver.major(overrides.react);
     if (reactMajor === 17) {

--- a/packages/code-infra/src/cli/pnpm.mjs
+++ b/packages/code-infra/src/cli/pnpm.mjs
@@ -173,8 +173,9 @@ export async function getCurrentGitSha() {
  * @returns {Promise<string>} Exact version string
  */
 export async function resolveVersion(packageSpec) {
-  const result = await $`pnpm info ${packageSpec} version`;
-  return result.stdout.trim();
+  const result = await $`pnpm info ${packageSpec} version --json`;
+  const versions = JSON.parse(result.stdout);
+  return typeof versions === 'string' ? versions : versions[versions.length - 1];
 }
 
 /**


### PR DESCRIPTION
`pnpm info <pkg> version` can return multiple

Also find scheduler dependency based on resolved react-dom