### PR TITLE
[code-infra] Use vite output ti calculate sizes

### DIFF
--- a/packages/bundle-size-checker/src/viteBuilder.js
+++ b/packages/bundle-size-checker/src/viteBuilder.js
@@ -173,12 +173,11 @@ function walkDependencyTree(chunkKey, manifest, visited = new Set()) {
 
 /**
  * Process vite output to extract bundle sizes
- * @param {string} outDir - The output directory
- * @param {string} entryName - The entry name
  * @param {import('vite').Rollup.RollupOutput['output']} output - The Vite output
+ * @param {string} entryName - The entry name
  * @returns {Promise<Map<string, { parsed: number, gzip: number }>>} - Map of bundle names to size information
  */
-async function processBundleSizes(outDir, entryName, output) {
+async function processBundleSizes(output, entryName) {
   const chunksByFileName = new Map(output.map((chunk) => [chunk.fileName, chunk]));
 
   // Read the manifest file to find the generated chunks
@@ -232,7 +231,6 @@ async function processBundleSizes(outDir, entryName, output) {
 export async function getViteSizes(entry, args) {
   // Create vite configuration
   const { configuration } = await createViteConfig(entry, args);
-  const outDir = path.join(rootDir, 'build', entry.id);
 
   // Run vite build
   const { output } = /** @type {import('vite').Rollup.RollupOutput} */ (await build(configuration));
@@ -242,5 +240,5 @@ export async function getViteSizes(entry, args) {
   }
 
   // Process the output to get bundle sizes
-  return processBundleSizes(outDir, entry.id, output);
+  return processBundleSizes(output, entry.id);
 }

--- a/packages/bundle-size-checker/src/viteBuilder.js
+++ b/packages/bundle-size-checker/src/viteBuilder.js
@@ -4,7 +4,6 @@ import * as zlib from 'zlib';
 import { promisify } from 'util';
 import { build, transformWithEsbuild } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
-import * as timers from 'timers/promises';
 
 const gzipAsync = promisify(zlib.gzip);
 
@@ -176,14 +175,20 @@ function walkDependencyTree(chunkKey, manifest, visited = new Set()) {
  * Process vite output to extract bundle sizes
  * @param {string} outDir - The output directory
  * @param {string} entryName - The entry name
+ * @param {import('vite').Rollup.RollupOutput['output']} output - The Vite output
  * @returns {Promise<Map<string, { parsed: number, gzip: number }>>} - Map of bundle names to size information
  */
-async function processBundleSizes(outDir, entryName) {
+async function processBundleSizes(outDir, entryName, output) {
+  const chunksByFileName = new Map(output.map((chunk) => [chunk.fileName, chunk]));
+
   // Read the manifest file to find the generated chunks
-  const manifestPath = path.join(outDir, '.vite/manifest.json');
-  const manifestContent = await fs.readFile(manifestPath, 'utf8');
+  const manifestContent = chunksByFileName.get('.vite/manifest.json');
+  if (manifestContent?.type !== 'asset') {
+    throw new Error(`Manifest file not found in output for entry: ${entryName}`);
+  }
+
   /** @type {Manifest} */
-  const manifest = JSON.parse(manifestContent);
+  const manifest = JSON.parse(String(manifestContent.source));
 
   // Find the main entry point JS file in the manifest
   const mainEntry = manifest['virtual:entry.tsx'];
@@ -198,8 +203,11 @@ async function processBundleSizes(outDir, entryName) {
   // Process each chunk in the dependency tree in parallel
   const chunkPromises = Array.from(allChunks, async (chunkKey) => {
     const chunk = manifest[chunkKey];
-    const filePath = path.join(outDir, chunk.file);
-    const fileContent = await fs.readFile(filePath, 'utf8');
+    const outputChunk = chunksByFileName.get(chunk.file);
+    if (outputChunk?.type !== 'chunk') {
+      throw new Error(`Output chunk not found for ${chunk.file}`);
+    }
+    const fileContent = outputChunk.code;
 
     // Calculate sizes
     const parsed = Buffer.byteLength(fileContent);
@@ -216,28 +224,6 @@ async function processBundleSizes(outDir, entryName) {
 }
 
 /**
- * @param {string} folderPath
- */
-async function waitForFolder(folderPath, timeout = 2000, interval = 50, startTime = Date.now()) {
-  try {
-    const stat = await fs.stat(folderPath);
-    if (stat.isDirectory()) {
-      return true;
-    }
-  } catch {
-    // Folder doesn't exist yet
-  }
-
-  await timers.setTimeout(interval);
-
-  if (Date.now() - startTime >= timeout) {
-    throw new Error(`Timeout: Folder "${folderPath}" did not appear within ${timeout}ms`);
-  }
-
-  return waitForFolder(folderPath, timeout, interval, startTime);
-}
-
-/**
  * Get sizes for a vite bundle
  * @param {ObjectEntry} entry - The entry configuration
  * @param {CommandLineArgs} args - Command line arguments
@@ -249,10 +235,12 @@ export async function getViteSizes(entry, args) {
   const outDir = path.join(rootDir, 'build', entry.id);
 
   // Run vite build
-  await build(configuration);
-
-  await waitForFolder(outDir);
+  const { output } = /** @type {import('vite').Rollup.RollupOutput} */ (await build(configuration));
+  const manifestChunk = output.find((chunk) => chunk.fileName === '.vite/manifest.json');
+  if (!manifestChunk) {
+    throw new Error(`Manifest file not found in output for entry: ${entry.id}`);
+  }
 
   // Process the output to get bundle sizes
-  return processBundleSizes(outDir, entry.id);
+  return processBundleSizes(outDir, entry.id, output);
 }

--- a/packages/bundle-size-checker/src/viteBuilder.js
+++ b/packages/bundle-size-checker/src/viteBuilder.js
@@ -181,13 +181,18 @@ async function processBundleSizes(output, entryName) {
   const chunksByFileName = new Map(output.map((chunk) => [chunk.fileName, chunk]));
 
   // Read the manifest file to find the generated chunks
-  const manifestContent = chunksByFileName.get('.vite/manifest.json');
-  if (manifestContent?.type !== 'asset') {
+  const manifestChunk = chunksByFileName.get('.vite/manifest.json');
+  if (manifestChunk?.type !== 'asset') {
     throw new Error(`Manifest file not found in output for entry: ${entryName}`);
   }
 
+  const manifestContent =
+    typeof manifestChunk.source === 'string'
+      ? manifestChunk.source
+      : new TextDecoder().decode(manifestChunk.source);
+
   /** @type {Manifest} */
-  const manifest = JSON.parse(String(manifestContent.source));
+  const manifest = JSON.parse(manifestContent);
 
   // Find the main entry point JS file in the manifest
   const mainEntry = manifest['virtual:entry.tsx'];

--- a/test/bundle-size/package.json
+++ b/test/bundle-size/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "description": "Bundle size measurement workspace for MUI packages",
   "scripts": {
-    "check": "NODE_OPTIONS=\"--max-old-space-size=4096\" bundle-size-checker --output ../size-snapshot.json"
+    "check": "NODE_OPTIONS=\"--max-old-space-size=4096\" bundle-size-checker --output ../size-snapshot.json --vite"
   },
   "devDependencies": {
     "@mui/internal-bundle-size-checker": "workspace:*"


### PR DESCRIPTION
Can't reproduce reliably, but it looks like sometimes the vite build promise resolves while not all fs operations are fully flushed. ~Testing this hypothesis by adding a short waiting mechanism.~ We can just operate on the vite output instead of trying to read the file system. All necessary info is available.

Example workflow: https://app.circleci.com/pipelines/github/mui/material-ui/158165/workflows/a4b52c56-c4c0-46f5-b8b5-fd63dee00c5f/jobs/846106