### PR TITLE
[code-infra] Create renovate group for Next.js and `eslint-plugin-next`

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -100,6 +100,10 @@
     {
       "matchPackageNames": ["eslint-config-prettier"],
       "allowedVersions": ">=10.1.8"
+    },
+    {
+      "groupName": "next",
+      "matchPackageNames": ["next", "@next/eslint-plugin-next"]
     }
   ]
 }


### PR DESCRIPTION
Create renovate group for Next.js and eslint-plugin-next since they are released together.

See source commit in provenance:
- [`next`](https://www.npmjs.com/package/next)
- [`@next/eslint-plugin-next`](https://www.npmjs.com/package/@next/eslint-plugin-next)