### PR TITLE
[internal] Pin all GitHub action versions

### DIFF
--- a/.github/workflows/branch-monitor.yml
+++ b/.github/workflows/branch-monitor.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Monitor branch status
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const branchName = process.env.GITHUB_REF_NAME;

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -14,11 +14,11 @@ jobs:
       id-token: write # Required for provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,14 @@ jobs:
       id-token: write # Required for provenance
     steps:
       - name: Checkout specific SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Set up pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
           # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies


### PR DESCRIPTION
I was looking at the https://github.com/mui/mui-public/security/code-scanning alerts, after upgrading the GitHub organization to the Team plan, to enforce security checks in all the repositories. I saw a couple of quick-wins. This should help reliability to replicate issues and help a bit with supply chain security propagation.