### PR TITLE
[internal] Enforce GITHUB_TOKEN default read only permission

### DIFF
--- a/.github/workflows/branch-monitor.yml
+++ b/.github/workflows/branch-monitor.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: ['master']
 
+permissions: {}
+
 env:
   ISSUE_NUMBER: ${{ vars.MONITOR_ISSUE_NUMBER }}
 

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -18,6 +18,8 @@ on:
         required: false
         default: false
 
+permissions: {}
+
 jobs:
   pkg-releases:
     name: pkg.pr.new releases

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -6,6 +6,8 @@ on:
       - master
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/mui/mui-public/security/code-scanning there are a bunch of security alerts. This PR fixes the false-positives of this kind: https://github.com/mui/mui-public/security/code-scanning/26. Our GitHub organization is configured with https://github.com/organizations/mui/settings/actions

<img width="932" height="253" alt="SCR-20250812-najo" src="https://github.com/user-attachments/assets/0b2dd73b-07aa-41c3-a111-7231764dbf45" />

so this PR doesn't help with security directly, what it helps with is increase the signal-to-noise ratio, so we can only have true-positives.

For the root problem, there is already: https://github.com/ossf/scorecard/issues/2556.