### PR TITLE
[internal] Fix sanitizeS3TagString()

### DIFF
--- a/packages/bundle-size-checker/src/uploadSnapshot.js
+++ b/packages/bundle-size-checker/src/uploadSnapshot.js
@@ -20,7 +20,7 @@ async function getCurrentCommitSHA() {
  */
 function sanitizeS3TagString(str) {
   // Replace disallowed characters with underscore
-  const safe = str.replace(/[^a-zA-Z0-9 +-=.:/@]+/g, '_');
+  const safe = str.replace(/[^a-zA-Z0-9 +\-=.:/@]+/g, '_');
   // Truncate to max lengths (256 for value)
   const maxLen = 256;
   return safe.length > maxLen ? safe.substring(0, maxLen) : safe;


### PR DESCRIPTION
Fix https://github.com/mui/mui-public/security/code-scanning/35

Before:
```js
','.replace(/[^a-zA-Z0-9 +-=.:/@]+/g, '_') => ','
```

After:
```jsx
','.replace(/[^a-zA-Z0-9 +\-=.:/@]+/g, '_') => '_'
```

The ASCII table: https://www.ascii-code.com/. A fun read on this one: https://web.archive.org/web/20221222190604/https://pboyd.io/posts/comma-dash-dot/.