### PR TITLE
[code-infra] Fix error on `list-workspaces` command

### DIFF
--- a/packages/code-infra/src/cli/cmdListWorkspaces.mjs
+++ b/packages/code-infra/src/cli/cmdListWorkspaces.mjs
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 /**
- * @typedef {import('./pnpm.mjs').Package} Package
+ * @typedef {import('./pnpm.mjs').PublicPackage} PublicPackage
  */
 
 import * as fs from 'fs/promises';
@@ -30,7 +30,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       .option('output', {
         type: 'string',
         choices: ['json', 'path', 'name', 'publish-dir'],
-        default: 'name',
+        default: 'path',
         description:
           'Output format: name (package names), path (package paths), publish-dir (publish directories), or json (full JSON)',
       })
@@ -42,49 +42,44 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
   handler: async (argv) => {
     const { publicOnly = false, output = 'name', sinceRef } = argv;
 
-    try {
-      // Get packages using our helper function
-      const packages = await getWorkspacePackages({ sinceRef, publicOnly });
+    // Get packages using our helper function
+    const packages = await getWorkspacePackages({ sinceRef, publicOnly });
 
-      if (output === 'json') {
-        // Serialize packages to JSON
-        console.log(JSON.stringify(packages, null, 2));
-      } else if (output === 'path') {
-        // Print package paths
-        packages.forEach((pkg) => {
-          console.log(pkg.path);
-        });
-      } else if (output === 'publish-dir') {
-        // TODO: Remove this option once https://github.com/stackblitz-labs/pkg.pr.new/issues/389 is resolved
-        // Print publish directories (package.json publishConfig.directory or package path)
-        const publishDirs = await Promise.all(
-          packages.map(async (pkg) => {
-            const packageJsonPath = path.join(pkg.path, 'package.json');
-            const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
-            const packageJson = JSON.parse(packageJsonContent);
+    if (output === 'json') {
+      // Serialize packages to JSON
+      console.log(JSON.stringify(packages, null, 2));
+    } else if (output === 'path') {
+      // Print package paths
+      packages.forEach((pkg) => {
+        console.log(pkg.path);
+      });
+    } else if (output === 'publish-dir') {
+      // TODO: Remove this option once https://github.com/stackblitz-labs/pkg.pr.new/issues/389 is resolved
+      // Print publish directories (package.json publishConfig.directory or package path)
+      const publishDirs = await Promise.all(
+        packages.map(async (pkg) => {
+          const packageJsonPath = path.join(pkg.path, 'package.json');
+          const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
+          const packageJson = JSON.parse(packageJsonContent);
 
-            if (packageJson.publishConfig?.directory) {
-              return path.join(pkg.path, packageJson.publishConfig.directory);
-            }
+          if (packageJson.publishConfig?.directory) {
+            return path.join(pkg.path, packageJson.publishConfig.directory);
+          }
 
-            return pkg.path;
-          }),
-        );
+          return pkg.path;
+        }),
+      );
 
-        publishDirs.forEach((dir) => {
-          console.log(dir);
-        });
-      } else if (output === 'name') {
-        // Print package names (default)
-        packages.forEach((pkg) => {
-          console.log(pkg.name);
-        });
-      } else {
-        throw new Error(`Unsupported output format: ${output}`);
-      }
-    } catch (/** @type {any} */ error) {
-      console.error('Error listing workspaces:', error.message);
-      process.exit(1);
+      publishDirs.forEach((dir) => {
+        console.log(dir);
+      });
+    } else if (output === 'name') {
+      // Print package names (default)
+      packages.forEach((pkg) => {
+        console.log(pkg.name);
+      });
+    } else {
+      throw new Error(`Unsupported output format: ${output}`);
     }
   },
 });

--- a/packages/code-infra/src/cli/cmdPublish.mjs
+++ b/packages/code-infra/src/cli/cmdPublish.mjs
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 /**
- * @typedef {import('./pnpm.mjs').Package} Package
+ * @typedef {import('./pnpm.mjs').PublicPackage} PublicPackage
  * @typedef {import('./pnpm.mjs').PublishOptions} PublishOptions
  */
 
@@ -207,7 +207,7 @@ async function validateGitHubRelease(version) {
 
 /**
  * Publish packages to npm
- * @param {Package[]} packages - Packages to publish
+ * @param {PublicPackage[]} packages - Packages to publish
  * @param {PublishOptions} options - Publishing options
  * @returns {Promise<void>}
  */
@@ -282,6 +282,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
 
     // Get all packages
     console.log('🔍 Discovering all workspace packages...');
+
     const allPackages = await getWorkspacePackages({ publicOnly: true });
 
     if (allPackages.length === 0) {

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -3,7 +3,7 @@
 /* eslint-disable no-console */
 
 /**
- * @typedef {import('./pnpm.mjs').Package} Package
+ * @typedef {import('./pnpm.mjs').PublicPackage} PublicPackage
  * @typedef {import('./pnpm.mjs').VersionInfo} VersionInfo
  * @typedef {import('./pnpm.mjs').PublishOptions} PublishOptions
  */
@@ -67,8 +67,8 @@ async function createCanaryTag(dryRun = false) {
 
 /**
  * Publish canary versions with updated dependencies
- * @param {Package[]} packagesToPublish - Packages that need canary publishing
- * @param {Package[]} allPackages - All workspace packages
+ * @param {PublicPackage[]} packagesToPublish - Packages that need canary publishing
+ * @param {PublicPackage[]} allPackages - All workspace packages
  * @param {Map<string, VersionInfo>} packageVersionInfo - Version info map
  * @param {PublishOptions} [options={}] - Publishing options
  * @returns {Promise<void>}

--- a/packages/code-infra/src/cli/pnpm.mjs
+++ b/packages/code-infra/src/cli/pnpm.mjs
@@ -49,6 +49,19 @@ import * as semver from 'semver';
 
 /**
  * Get workspace packages with optional filtering
+ *
+ * @overload
+ * @param {{ publicOnly: true } & GetWorkspacePackagesOptions} [options={}] - Options for filtering packages
+ * @returns {Promise<PublicPackage[]>} Array of packages
+ *
+ * @overload
+ * @param {{ publicOnly?: false | undefined } & GetWorkspacePackagesOptions} [options={}] - Options for filtering packages
+ * @returns {Promise<PrivatePackage[]>} Array of packages
+ *
+ * @overload
+ * @param {GetWorkspacePackagesOptions} [options={}] - Options for filtering packages
+ * @returns {Promise<(PrivatePackage | PublicPackage)[]>} Array of packages
+ *
  * @param {GetWorkspacePackagesOptions} [options={}] - Options for filtering packages
  * @returns {Promise<(PrivatePackage | PublicPackage)[]>} Array of packages
  */


### PR DESCRIPTION
We would error when not called with --public-only as some of our workspaces are unnamed. Instead of the name/vrsion check, we treat unnamed and unversiononed packages as private, which is what npm does as well