### PR TITLE
[code-infra] Create dev dependencies group

### DIFF
--- a/renovate/base.json
+++ b/renovate/base.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate base configuration included before any preset.",
+  "packageRules": [
+    {
+      "groupName": "code-infra:devDependencies",
+      "matchDepTypes": ["devDependencies"]
+    }
+  ]
+}

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Renovate configuration for MUI repositories.",
   "extends": [
+    "github>mui/mui-public//renovate/base",
     ":semanticCommitsDisabled",
     "group:definitelyTyped",
     "config:recommended",


### PR DESCRIPTION
create a preset we use to create package rules before any preset. add a dev dependencies.

To note: this can cause issues when a dependency is both a dev and normal dependency somewhere.