### PR TITLE
[internal] Fix author field in package.json

### DIFF
--- a/packages/babel-plugin-display-name/package.json
+++ b/packages/babel-plugin-display-name/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/babel-plugin-display-name"
   },
   "main": "src/index.js",
-  "author": "mui",
+  "author": "MUI Team",
   "files": [
     "src/index.js"
   ],


### PR DESCRIPTION
Copy the same value as the other packages.

Side note, we could argue that we shouldn't have this field in the first place, but at least, it has the merit of being clear.