### PR TITLE
[code-infra] Throw if private: false is set

### DIFF
--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -134,12 +134,6 @@ async function writePackageJson({ packageJson, bundles, outputDir, cwd, addTypes
   delete packageJson.devDependencies;
   delete packageJson.imports;
 
-  if (packageJson.private === false) {
-    throw new Error(
-      `Remove the field "private": false from "${packageJson.name}" package.json. This is redundant.`,
-    );
-  }
-
   packageJson.type = packageJson.type || 'commonjs';
 
   /**
@@ -306,6 +300,11 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     if (!buildDirBase) {
       throw new Error(
         'No build directory specified in package.json. Specify it in the "publishConfig.directory" field.',
+      );
+    }
+    if (packageJson.private === false) {
+      throw new Error(
+        `Remove the field "private": false from "${packageJson.name}" package.json. This is redundant.`,
       );
     }
     const buildDir = path.join(cwd, buildDirBase);

--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -299,7 +299,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     const buildDirBase = packageJson.publishConfig?.directory;
     if (!buildDirBase) {
       throw new Error(
-        'No build directory specified in package.json. Specify it in the "publishConfig.directory" field.',
+        `No build directory specified in "${packageJson.name}" package.json. Specify it in the "publishConfig.directory" field.`,
       );
     }
     if (packageJson.private === false) {

--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -134,6 +134,12 @@ async function writePackageJson({ packageJson, bundles, outputDir, cwd, addTypes
   delete packageJson.devDependencies;
   delete packageJson.imports;
 
+  if (packageJson.private === false) {
+    throw new Error(
+      `Remove the field "private": false from "${packageJson.name}" package.json. This is redundant.`,
+    );
+  }
+
   packageJson.type = packageJson.type || 'commonjs';
 
   /**


### PR DESCRIPTION
https://github.com/mui/base-ui/pull/2566#pullrequestreview-3148172478 "The is anyways removed from the published package.json", it's not, proof: https://unpkg.com/@base-ui-components/react@1.0.0-beta.2/package.json, but now, it will be :).

You can test this like this:

```diff
diff --git a/packages/docs-infra/package.json b/packages/docs-infra/package.json
index a0648f1..8b2ac35 100644
--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mui/internal-docs-infra",
   "version": "0.1.0",
+  "private": false,
   "author": "MUI Team",
   "description": "MUI Infra - internal documentation creation tools.",
   "keywords": [
```

`pnpm --filter ./packages/docs-infra build`