### PR TITLE
[infra] Add `default` condition to the built package.json

### DIFF
--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -209,6 +209,20 @@ async function writePackageJson({ packageJson, bundles, outputDir, cwd, addTypes
     }
   });
 
+  // default condition should come last
+  Object.keys(newExports).forEach((key) => {
+    const exportVal = newExports[key];
+    if (exportVal && typeof exportVal === 'object' && (exportVal.import || exportVal.require)) {
+      const defaultExport = exportVal.import || exportVal.require;
+      if (exportVal.import) {
+        delete exportVal.import;
+      } else if (exportVal.require) {
+        delete exportVal.require;
+      }
+      exportVal.default = defaultExport;
+    }
+  });
+
   packageJson.exports = newExports;
 
   await fs.writeFile(


### PR DESCRIPTION
This will help with the new `docs-infra` [package](https://github.com/mui/mui-public/pull/379) where `turbopack` looks for the `default` condition when importing using 
a string path in next.config.

When both cjs and esm builds are present -

```txt
"./*": {
  "require": {
    "types": "./*/index.d.ts",
    "default": "./*/index.js"
  },
  "default": {
    "types": "./esm/*/index.d.ts",
    "default": "./esm/*/index.js"
  }
},
```

Only cjs build

```txt
"exports": {
  "./package.json": "./package.json",
  "./*": {
    "default": {
      "types": "./*/index.d.ts",
      "default": "./*/index.js"
    }
  }
}
```

Only ESM build

```txt
"exports": {
  "./package.json": "./package.json",
  "./*": {
    "default": {
      "types": "./esm/*/index.d.ts",
      "default": "./esm/*/index.js"
    }
  }
}
```