### PR TITLE
[support-infra] Update status labels GitHub Actions

### DIFF
--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -1,0 +1,21 @@
+name: Issue status label handler
+
+on:
+  issue_comment:
+    # on 'issue_comment.created' we check if the comment comes from the author and remove the "status: waiting for author" label
+    # additionally we reopen the issue when it is closed and the author comments on it
+    types: [created]
+  issues:
+    # on 'issues.closed' events we simply remove the "status: waiting for author" or "status: waiting for maintainer" label
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  statusHandling:
+    permissions:
+      contents: read
+      issues: write
+      actions: write
+    name: Handle status labels
+    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@master

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,35 +1,19 @@
 name: No response
 
-# `issues`.`closed`, `issue_comment`.`created`, and `scheduled` event types are required for this Action
-# to work properly.
 on:
-  issues:
-    types: [closed]
-  issue_comment:
-    types: [created]
+  workflow_dispatch:
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # These runs in our repos are spread evenly throughout the day to avoid hitting rate limits.
+    # If you change this schedule, consider changing the remaining repositories as well.
+    # Runs at 3 am, 3 pm
+    - cron: '0 3,15 * * *'
 
 permissions: {}
 
 jobs:
   noResponse:
-    runs-on: ubuntu-latest
     permissions:
-      contents: read
       issues: write
-    steps:
-      - uses: MBilalShafi/no-response-add-label@629add01d7b6f8e120811f978c42703736098947 # v0.0.6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Number of days of inactivity before an Issue is closed for lack of response
-          daysUntilClose: 7
-          # Label requiring a response
-          responseRequiredLabel: 'status: waiting for author'
-          # Label to add back when the `responseRequiredLabel` is removed
-          optionalFollowupLabel: 'status: waiting for maintainer'
-          # Comment to post when closing an Issue for lack of response. Set to `false` to disable
-          closeComment: >
-            Since the issue is missing key information and has been inactive for 7 days, it has been automatically closed.
-            If you wish to see the issue reopened, please provide the missing information.
+      pull-requests: write
+    name: Handle stale issues and PRs
+    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@master


### PR DESCRIPTION
I think mui-public should set the standard of what are our GitHub Actions. We tried this new flow for mui-x, it seems to work well, so let's update the source of truth.

One of #487