### PR TITLE
[code-infra] Abstract tsdown based build-new command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ yarn-error.log*
 
 lerna-debug.log
 dist/
+adhoc/
 
 build
 

--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -1,27 +1,29 @@
 // @ts-check
-/* eslint-disable @typescript-eslint/no-require-imports */
 // copied from https://github.com/mui/material-ui/blob/master/babel.config.js
 // defaultAlias modified
 // @mui/internal-babel-plugin-minify-errors removed
 
-const path = require('node:path');
-const { default: getBaseConfig } = require('@mui/internal-code-infra/babel-config');
+import * as path from 'node:path';
+import getBaseConfig from '@mui/internal-code-infra/babel-config';
+import { fileURLToPath } from 'node:url';
 
 /**
  * @typedef {import('@babel/core')} babel
  */
+
+const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 /**
  * @param {string} relativeToBabelConf
  * @returns {string}
  */
 function resolveAliasPath(relativeToBabelConf) {
-  const resolvedPath = path.relative(process.cwd(), path.resolve(__dirname, relativeToBabelConf));
+  const resolvedPath = path.relative(process.cwd(), path.resolve(dirname, relativeToBabelConf));
   return `./${resolvedPath.replace('\\', '/')}`;
 }
 
 /** @type {babel.ConfigFunction} */
-module.exports = function getBabelConfig(api) {
+export default function getBabelConfig(api) {
   const baseConfig = getBaseConfig(api);
 
   const defaultAlias = {
@@ -96,4 +98,4 @@ module.exports = function getBabelConfig(api) {
       },
     },
   };
-};
+}

--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
     "@babel/plugin-transform-react-constant-elements": "7.27.1",
     "eslint-plugin-n": "17.23.1",
     "markdownlint-cli2": "0.20.0",
-    "stylelint": "16.26.1"
+    "stylelint": "16.26.1",
+    "baseline-browser-mapping": "2.9.14",
+    "babel-plugin-module-resolver": "^5.0.2"
   },
   "packageManager": "pnpm@10.25.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "stylelint": "stylelint --reportInvalidScopeDisables --reportNeedlessDisables \"**/*.?(c|m)[jt]s?(x)\" \"**/*.css\" --ignore-path .lintignore",
     "typescript": "tsc -b --verbose",
     "release:version": "lerna version --no-changelog --no-push --no-git-tag-version --no-private",
-    "release:build": "pnpm -r -F \"./packages/*\" run build",
+    "release:build": "pnpm -r -F \"./packages/*\" build",
     "size:snapshot": "pnpm -F ./test/bundle-size check",
     "size:why": "pnpm size:snapshot --analyze",
     "clean": "pnpm -r exec rm -rf build",
@@ -23,7 +23,7 @@
     "docs:start": "pnpm -F \"./docs\" run start",
     "docs:infra": "pnpm -F \"./docs\" run docs-infra",
     "docs:validate": "pnpm -F \"./docs\" run docs-infra validate --command 'pnpm docs:validate'",
-    "docs:lib": "pnpm -F \"./packages/docs-infra\" run build"
+    "docs:lib": "pnpm -F \"./packages/docs-infra\" build"
   },
   "pnpm": {
     "packageExtensions": {

--- a/packages/code-infra/bin/code-infra.mjs
+++ b/packages/code-infra/bin/code-infra.mjs
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import '../src/cli/index.mjs';

--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -46,10 +46,11 @@
     }
   },
   "bin": {
-    "code-infra": "./bin/code-infra.mjs"
+    "code-infra": "./src/bin/code-infra.mjs"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "build-tsdown": "node ./src/bin/code-infra.mjs build-new --bundle esm",
     "typescript": "tsc -p tsconfig.json",
     "test": "pnpm -w test --project @mui/internal-code-infra",
     "test:copy": "rm -rf build && node bin/code-infra.mjs copy-files --glob \"src/cli/*.mjs\" --glob \"src/eslint/**/*.mjs:esm\""
@@ -78,6 +79,7 @@
     "@octokit/rest": "^22.0.1",
     "@pnpm/find-workspace-dir": "^1000.1.3",
     "@vitest/eslint-plugin": "^1.6.4",
+    "@vitejs/plugin-react": "^5.1.2",
     "babel-plugin-optimize-clsx": "^2.6.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
@@ -111,6 +113,7 @@
     "semver": "^7.7.3",
     "stylelint-config-standard": "^39.0.1",
     "typescript-eslint": "^8.51.0",
+    "tsdown": "^0.18.4",
     "yargs": "^18.0.0"
   },
   "peerDependencies": {
@@ -138,13 +141,6 @@
     "serve": "14.2.5",
     "typescript-eslint": "^8.49.0"
   },
-  "files": [
-    "bin",
-    "build",
-    "src",
-    "README.md",
-    "LICENSE"
-  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -78,8 +78,8 @@
     "@octokit/oauth-methods": "^6.0.2",
     "@octokit/rest": "^22.0.1",
     "@pnpm/find-workspace-dir": "^1000.1.3",
+    "@rollup/plugin-babel": "^6.1.0",
     "@vitest/eslint-plugin": "^1.6.4",
-    "@vitejs/plugin-react": "^5.1.2",
     "babel-plugin-optimize-clsx": "^2.6.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
@@ -139,6 +139,7 @@
     "get-port": "7.1.0",
     "prettier": "3.7.4",
     "serve": "14.2.5",
+    "rolldown": "^1.0.0-beta.53",
     "typescript-eslint": "^8.49.0"
   },
   "publishConfig": {

--- a/packages/code-infra/src/babel-config.mjs
+++ b/packages/code-infra/src/babel-config.mjs
@@ -20,6 +20,7 @@ import pluginRemovePropTypes from 'babel-plugin-transform-react-remove-prop-type
  * @param {string} param0.runtimeVersion
  * @param {string} [param0.reactCompilerReactVersion]
  * @param {string} [param0.reactCompilerMode]
+ * @param {boolean} [param0.isTsdownBundler=false]
  * @returns {import('@babel/core').TransformOptions} The base Babel configuration.
  */
 export function getBaseConfig({
@@ -32,6 +33,7 @@ export function getBaseConfig({
   outExtension,
   reactCompilerReactVersion,
   reactCompilerMode,
+  isTsdownBundler = false,
 }) {
   /**
    * @type {import('@babel/preset-env').Options}
@@ -39,14 +41,16 @@ export function getBaseConfig({
   const presetEnvOptions = {
     bugfixes: true,
     debug,
-    modules: bundle === 'esm' ? false : 'commonjs',
+    // eslint-disable-next-line no-nested-ternary
+    modules: isTsdownBundler ? 'auto' : bundle === 'esm' ? false : 'commonjs',
     // @TODO
-    browserslistEnv: bundle === 'esm' ? 'stable' : 'node',
+    // eslint-disable-next-line no-nested-ternary
+    browserslistEnv: isTsdownBundler ? 'node' : bundle === 'esm' ? 'stable' : 'node',
   };
   /**
-   * @type {import('@babel/core').TransformOptions["plugins"]}
+   * @type {([import('@babel/core').PluginTarget, import('@babel/core').PluginOptions, string | undefined])[]}
    */
-  const plugins = [
+  let plugins = [
     [
       pluginTransformRuntime,
       {
@@ -71,6 +75,12 @@ export function getBaseConfig({
       'babel-plugin-transform-inline-environment-variables',
     ],
   ];
+
+  if (isTsdownBundler) {
+    plugins = plugins.filter(
+      ([, , pluginName]) => pluginName !== 'babel-plugin-transform-inline-environment-variables',
+    );
+  }
 
   if (reactCompilerReactVersion) {
     /**
@@ -129,14 +139,23 @@ export function getBaseConfig({
       /prettier/,
       '**/*.template.js',
     ],
-    presets: [
-      [presetEnv, presetEnvOptions],
-      [
-        presetReact,
-        { runtime: 'automatic', useBuiltIns: bundle === 'esm', useSpread: bundle === 'esm' },
-      ],
-      [presetTypescript],
-    ],
+    presets: (() => {
+      const presets = [
+        [presetEnv, presetEnvOptions],
+        [
+          presetReact,
+          {
+            runtime: 'automatic',
+            useBuiltIns: isTsdownBundler || bundle === 'esm',
+            useSpread: isTsdownBundler || bundle === 'esm',
+          },
+        ],
+      ];
+      if (!isTsdownBundler) {
+        presets.push([presetTypescript]);
+      }
+      return presets;
+    })(),
     plugins,
   };
 }
@@ -146,6 +165,7 @@ export function getBaseConfig({
  * @prop {'esm' | 'cjs'} [Options.bundle]
  * @prop {boolean} [Options.noResolveImports]
  * @prop {undefined} [options.env]
+ * @prop {string} [options.bundler]
  */
 
 /**
@@ -157,6 +177,44 @@ export default function getBabelConfig(api) {
   let bundle;
   /** @type {boolean} */
   let noResolveImports;
+  let isTsdownBundler = false;
+  let babelRuntimeVersion = process.env.MUI_BABEL_RUNTIME_VERSION || '^7.25.0';
+  let optimizeClsx = process.env.MUI_OPTIMIZE_CLSX === 'true';
+  let removePropTypes = process.env.MUI_REMOVE_PROP_TYPES === 'true';
+  let reactCompilerReactVersion = process.env.MUI_REACT_COMPILER_REACT_VERSION;
+  let reactCompilerMode = process.env.MUI_REACT_COMPILER_MODE;
+
+  if (typeof api === 'object') {
+    if ('caller' in api && api.caller) {
+      api.caller((caller) => {
+        if (!caller) {
+          return false;
+        }
+        if (caller?.name === 'tsdown-bundler') {
+          isTsdownBundler = true;
+        }
+        const typedCaller = /** @type {Record<string, any>} */ (caller);
+        if (typedCaller.optimizeClsx) {
+          optimizeClsx = true;
+        }
+        if (typedCaller.removePropTypes) {
+          removePropTypes = true;
+        }
+        if (typedCaller.reactCompilerReactVersion) {
+          reactCompilerReactVersion = typedCaller.reactCompilerReactVersion;
+        }
+        if (typedCaller.reactCompilerMode) {
+          reactCompilerMode = typedCaller.reactCompilerMode;
+        }
+        if (typedCaller.babelRuntimeVersion) {
+          babelRuntimeVersion = typedCaller.babelRuntimeVersion;
+        }
+        return true;
+      });
+    } else if ('bundler' in api) {
+      isTsdownBundler = api.bundler === 'tsdown-bundler';
+    }
+  }
 
   if (api.env) {
     // legacy
@@ -172,11 +230,12 @@ export default function getBabelConfig(api) {
     bundle,
     outExtension: process.env.MUI_OUT_FILE_EXTENSION || null,
     // any package needs to declare 7.25.0 as a runtime dependency. default is ^7.0.0
-    runtimeVersion: process.env.MUI_BABEL_RUNTIME_VERSION || '^7.25.0',
-    optimizeClsx: process.env.MUI_OPTIMIZE_CLSX === 'true',
-    removePropTypes: process.env.MUI_REMOVE_PROP_TYPES === 'true',
-    noResolveImports,
-    reactCompilerReactVersion: process.env.MUI_REACT_COMPILER_REACT_VERSION,
-    reactCompilerMode: process.env.MUI_REACT_COMPILER_MODE,
+    runtimeVersion: babelRuntimeVersion,
+    optimizeClsx,
+    removePropTypes,
+    noResolveImports: isTsdownBundler ? false : noResolveImports,
+    reactCompilerReactVersion,
+    reactCompilerMode,
+    isTsdownBundler,
   });
 }

--- a/packages/code-infra/src/bin/code-infra.mjs
+++ b/packages/code-infra/src/bin/code-infra.mjs
@@ -1,0 +1,3 @@
+import { run } from '../cli/index.mjs';
+
+run();

--- a/packages/code-infra/src/bundlers/tsdown.mjs
+++ b/packages/code-infra/src/bundlers/tsdown.mjs
@@ -1,0 +1,238 @@
+/* eslint-disable no-console */
+import * as fs from 'node:fs/promises';
+import { builtinModules } from 'node:module';
+import { build as tsdown } from 'tsdown';
+import reactPlugin from '@vitejs/plugin-react';
+import {
+  generateEntriesFromExports,
+  getTsConfigPath,
+  getVersionEnvVariables,
+  writePkgJson,
+} from '../utils/build.mjs';
+import { copyFiles } from '../utils/copyFiles.mjs';
+
+/**
+ * @TODOs -
+ * [ ] Handle custom babel plugin transforms
+ * [ ] Figure out how to pass targets (easy to do if we want to have same target for all output formats)
+ * [x] Write your own package.json exports (the one built into tsdown doesn't cut it)
+ * [x] Side effects from type imports without the "type" identifier. Need eslint rule to enforce this.
+ * [ ] Figure out how to handle conditional exports. Specifically `react-server` exports.
+ */
+
+/**
+ * @typedef {import('../cli/cmdBuildNew.mjs').Args} Args
+ */
+
+/**
+ * @typedef {import('../cli/cmdBuildNew.mjs').PackageJson} PackageJson
+ */
+
+/**
+ * @param {Args} args
+ * @param {PackageJson} pkgJson
+ * @returns {Promise<void>}
+ */
+export async function build(args, pkgJson) {
+  const cwd = process.cwd();
+
+  const outDir = /** @type {any} */ (pkgJson.publishConfig)?.directory;
+  await fs.rm(outDir, {
+    recursive: true,
+    force: true,
+  });
+
+  const [exportEntries, nullEntries, binEntries] = await generateEntriesFromExports(
+    pkgJson.exports ?? {},
+    pkgJson.bin ?? {},
+    { cwd },
+  );
+  const externals = new Set([
+    ...Object.keys(pkgJson.dependencies || {}),
+    ...Object.keys(pkgJson.peerDependencies || {}),
+  ]);
+  /**
+   * @type {(string|RegExp)[]}
+   */
+  const externalsArray = Array.from(externals);
+  externalsArray.push(new RegExp(`^(${externalsArray.join('|')})/`));
+  externalsArray.push(/^node:/);
+  externalsArray.push(/\.css$/);
+  externalsArray.push(...builtinModules);
+
+  const tsconfigPath = args.skipTypes ? null : await getTsConfigPath(cwd);
+  const bannerText = `/**
+ * ${pkgJson.name} v${pkgJson.version}
+ *
+ * @license ${pkgJson.license ?? 'MIT'}
+ * This source code is licensed under the ${pkgJson.license} license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+`;
+
+  /**
+   * @type {import('tsdown').InlineConfig}
+   */
+  const baseOptions = {
+    watch: false,
+    config: false,
+    outDir,
+    unbundle: true,
+    clean: false,
+    skipNodeModulesBundle: true,
+    external: externalsArray,
+    platform: 'neutral',
+    ignoreWatch: ['**/node_modules/**', '**/dist/**', '**/build/**'],
+    env: {
+      ...getVersionEnvVariables(pkgJson.version ?? ''),
+    },
+    loader: {
+      '.js': 'jsx',
+    },
+    logLevel: args.verbose ? 'info' : 'silent',
+    tsconfig: tsconfigPath ?? false,
+    sourcemap: args.sourceMap || false,
+    banner: {
+      js: bannerText,
+      css: bannerText,
+    },
+    minify: 'dce-only',
+    hash: false,
+    name: pkgJson.name,
+    plugins: [
+      reactPlugin({
+        jsxRuntime: 'automatic',
+        babel: {
+          babelrc: true,
+          configFile: true,
+        },
+      }),
+    ],
+  };
+
+  /**
+   * @type {Promise<import('tsdown').TsdownBundle[]>[]}
+   */
+  const promises = [];
+
+  /**
+   * @type {Record<string, {paths: string[]; isBin?: boolean}>}
+   */
+  const outChunks = {};
+  /**
+   * @type {Set<string>}
+   */
+  const exportEntrySet = new Set();
+  /**
+   * @type {Set<string>}
+   */
+  const binEntrySet = new Set();
+
+  if (Object.keys(exportEntries).length > 0) {
+    args.bundle.forEach((format) => {
+      promises.push(
+        tsdown({
+          ...baseOptions,
+          entry: exportEntries,
+          format,
+          dts: tsconfigPath
+            ? {
+                cwd,
+                tsconfig: tsconfigPath,
+                compilerOptions: {
+                  jsx: 'react-jsx',
+                  outDir,
+                },
+                sourcemap: args.sourceMap ?? false,
+              }
+            : false,
+          outputOptions: {
+            plugins: [
+              {
+                name: `get-output-chunks-${format}`,
+                writeBundle(_ctx, chunks) {
+                  Object.entries(chunks).forEach(([fileName, chunk]) => {
+                    if (chunk.type !== 'chunk' || !chunk.isEntry) {
+                      return;
+                    }
+                    const chunkName = chunk.name.endsWith('.d')
+                      ? chunk.name.slice(0, -2)
+                      : chunk.name;
+                    outChunks[chunkName] = outChunks[chunkName] || { paths: [] };
+                    outChunks[chunkName].paths.push(fileName);
+                    exportEntrySet.add(chunkName);
+                  });
+                },
+              },
+            ],
+          },
+        }),
+      );
+    });
+  }
+
+  if (Object.keys(binEntries).length > 0) {
+    const format = pkgJson.type === 'module' ? 'esm' : 'cjs';
+    promises.push(
+      tsdown({
+        ...baseOptions,
+        tsconfig: undefined,
+        entry: binEntries,
+        format,
+        platform: 'node',
+        outputOptions: {
+          plugins: [
+            {
+              name: 'bin-shebang',
+              // eslint-disable-next-line consistent-return
+              renderChunk(code, chunk) {
+                if (chunk.isEntry && !code.startsWith('#!')) {
+                  return `#!/usr/bin/env node\n${code}`;
+                }
+              },
+            },
+            {
+              name: 'get-output-chunks-bin',
+              writeBundle(_ctx, chunks) {
+                Object.entries(chunks).forEach(([fileName, chunk]) => {
+                  if (chunk.type !== 'chunk' || !chunk.isEntry) {
+                    return;
+                  }
+                  outChunks[chunk.name] = outChunks[chunk.name] || { paths: [], isBin: true };
+                  outChunks[chunk.name].paths.push(fileName);
+                  binEntrySet.add(chunk.name);
+                });
+              },
+            },
+          ],
+        },
+      }),
+    );
+  }
+  await Promise.all(promises);
+
+  if (exportEntrySet.size || binEntrySet.size) {
+    const messages = [];
+    if (exportEntrySet.size > 0) {
+      messages.push(`${exportEntrySet.size} export${exportEntrySet.size > 1 ? 's' : ''}`);
+    }
+    if (binEntrySet.size > 0) {
+      messages.push(`${binEntrySet.size} bin ${binEntrySet.size > 1 ? 'entries' : 'entry'}`);
+    }
+    if (messages.length > 0) {
+      console.log(`+ Added ${messages.join(' and ')} to package.json.`);
+    }
+  }
+
+  await writePkgJson(pkgJson, outChunks, nullEntries, {
+    usePkgType: true,
+  });
+
+  // tsdown's --copy arg doesn't support glob patterns.
+  await copyFiles({
+    cwd,
+    globs: args.copy ?? [],
+    buildDir: outDir,
+    verbose: args.verbose,
+  });
+}

--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -1,13 +1,11 @@
 /* eslint-disable no-console */
-import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
 import { $ } from 'execa';
-import { globby } from 'globby';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { sep as posixSep } from 'node:path/posix';
 import * as semver from 'semver';
 
-import { getOutExtension, isMjsBuild, mapConcurrently, validatePkgJson } from '../utils/build.mjs';
+import { getOutExtension, isMjsBuild, validatePkgJson } from '../utils/build.mjs';
+import { copyFiles } from '../utils/copyFiles.mjs';
 
 /**
  * @typedef {Object} Args
@@ -359,6 +357,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     } = args;
 
     const cwd = process.cwd();
+    performance.mark('build-start');
     const pkgJsonPath = path.join(cwd, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(pkgJsonPath, { encoding: 'utf8' }));
     validatePkgJson(packageJson, { skipMainCheck: args.skipMainCheck, enableReactCompiler });
@@ -501,7 +500,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       addTypes: buildTypes,
     });
 
-    await copyHandler({
+    await copyFiles({
       cwd,
       globs: args.copy ?? [],
       buildDir,
@@ -509,135 +508,3 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     });
   },
 });
-
-/**
- * @param {Object} param0
- * @param {string} param0.cwd - The current working directory.
- * @param {string[]} [param0.globs=[]] - Extra files to copy, can be specified as `source:target` pairs or just `source`.
- * @param {string} param0.buildDir - The build directory to copy to.
- * @param {boolean} [param0.verbose=false] - Whether to suppress output.
- * @returns {Promise<void>}
- */
-async function copyHandler({ cwd, globs = [], buildDir, verbose = false }) {
-  /**
-   * @type {(string|{targetPath: string; sourcePath: string})[]}
-   */
-  const defaultFiles = [];
-  const workspaceDir = await findWorkspaceDir(cwd);
-  if (!workspaceDir) {
-    throw new Error('Workspace directory not found');
-  }
-
-  const localOrRootFiles = [
-    [path.join(cwd, 'README.md'), path.join(workspaceDir, 'README.md')],
-    [path.join(cwd, 'LICENSE'), path.join(workspaceDir, 'LICENSE')],
-    [path.join(cwd, 'CHANGELOG.md'), path.join(workspaceDir, 'CHANGELOG.md')],
-  ];
-  await Promise.all(
-    localOrRootFiles.map(async (filesToCopy) => {
-      for (const file of filesToCopy) {
-        if (
-          // eslint-disable-next-line no-await-in-loop
-          await fs.stat(file).then(
-            () => true,
-            () => false,
-          )
-        ) {
-          defaultFiles.push(file);
-          break;
-        }
-      }
-    }),
-  );
-
-  if (globs.length) {
-    const res = globs.map((globPattern) => {
-      const [pattern, baseDir] = globPattern.split(':');
-      return { pattern, baseDir };
-    });
-    /**
-     * Avoids redundant globby calls for the same pattern.
-     *
-     * @type {Map<string, Promise<string[]>>}
-     */
-    const globToResMap = new Map();
-
-    const result = await Promise.all(
-      res.map(async ({ pattern, baseDir }) => {
-        if (!globToResMap.has(pattern)) {
-          const promise = globby(pattern, { cwd });
-          globToResMap.set(pattern, promise);
-        }
-        const files = await globToResMap.get(pattern);
-        return { files: files ?? [], baseDir };
-      }),
-    );
-    globToResMap.clear();
-
-    result.forEach(({ files, baseDir }) => {
-      files.forEach((file) => {
-        const sourcePath = path.resolve(cwd, file);
-        // Use posix separator for the relative paths. So devs can only specify globs with `/` even on Windows.
-        const pathSegments = file.split(posixSep);
-        const relativePath =
-          // Use index 2 (when required) since users can also specify paths like `./src/index.js`
-          pathSegments.slice(pathSegments[0] === '.' ? 2 : 1).join(posixSep) || file;
-        const targetPath = baseDir
-          ? path.resolve(buildDir, baseDir, relativePath)
-          : path.resolve(buildDir, relativePath);
-        defaultFiles.push({ sourcePath, targetPath });
-      });
-    });
-  }
-
-  if (!defaultFiles.length) {
-    if (verbose) {
-      console.log('⓿ No files to copy.');
-    }
-  }
-  await mapConcurrently(
-    defaultFiles,
-    async (file) => {
-      if (typeof file === 'string') {
-        const sourcePath = file;
-        const fileName = path.basename(file);
-        const targetPath = path.join(buildDir, fileName);
-        await recursiveCopy({ source: sourcePath, target: targetPath, verbose });
-      } else {
-        await fs.mkdir(path.dirname(file.targetPath), { recursive: true });
-        await recursiveCopy({ source: file.sourcePath, target: file.targetPath, verbose });
-      }
-    },
-    20,
-  );
-  console.log(`📋 Copied ${defaultFiles.length} files.`);
-}
-
-/**
- * Recursively copies files and directories from a source path to a target path.
- *
- * @async
- * @param {Object} options - The options for copying files.
- * @param {string} options.source - The source path to copy from.
- * @param {string} options.target - The target path to copy to.
- * @param {boolean} [options.verbose=true] - If true, suppresses console output.
- * @returns {Promise<boolean>} Resolves when the copy operation is complete.
- * @throws {Error} Throws if an error occurs other than the source not existing.
- */
-async function recursiveCopy({ source, target, verbose = true }) {
-  try {
-    await fs.cp(source, target, { recursive: true });
-    if (verbose) {
-      console.log(`Copied ${source} to ${target}`);
-    }
-    return true;
-  } catch (err) {
-    if (/** @type {{ code: string }} */ (err).code !== 'ENOENT') {
-      throw err;
-    }
-    if (verbose) {
-      console.warn(`Source does not exist: ${source}`);
-    }
-    throw err;
-  }
-}

--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -152,6 +152,11 @@ async function writePackageJson({ packageJson, bundles, outputDir, cwd, addTypes
   delete packageJson.imports;
 
   packageJson.type = packageJson.type || 'commonjs';
+  if (packageJson.packageScripts) {
+    // @ts-expect-error temporary fix to move packageScripts to scripts
+    packageJson.scripts = packageJson.packageScripts;
+    delete packageJson.packageScripts;
+  }
 
   /**
    * @type {import('./packageJson').PackageJson.ExportConditions}
@@ -360,7 +365,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     performance.mark('build-start');
     const pkgJsonPath = path.join(cwd, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(pkgJsonPath, { encoding: 'utf8' }));
-    validatePkgJson(packageJson, { skipMainCheck: args.skipMainCheck, enableReactCompiler });
+    await validatePkgJson(packageJson, { skipMainCheck: args.skipMainCheck, enableReactCompiler });
 
     const buildDirBase = /** @type {string} */ (packageJson.publishConfig?.directory);
     const buildDir = path.join(cwd, buildDirBase);

--- a/packages/code-infra/src/cli/cmdBuildNew.mjs
+++ b/packages/code-infra/src/cli/cmdBuildNew.mjs
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { markFn, measureFn, validatePkgJson } from '../utils/build.mjs';
+
+/**
+ * @typedef {Object} Args
+ * @property {import('../utils/build.mjs').BundleType[]} bundle
+ * @property {boolean} verbose
+ * @property {boolean} skipTypes
+ * @property {boolean} sourceMap
+ * @property {string[]} [copy]
+ */
+
+/**
+ * @typedef {Partial<import('../../package.json')>} PackageJson
+ */
+
+/**
+ * @type {import('../utils/build.mjs').BundleType[]}
+ */
+const validBundles = ['esm', 'cjs'];
+
+export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
+  command: 'build-new',
+  describe: 'Builds the package for publishing.',
+  builder: (yargs) =>
+    yargs
+      .option('bundle', {
+        array: true,
+        demandOption: true,
+        type: 'string',
+        choices: validBundles,
+        description: 'Bundles to output',
+        default: ['esm', 'cjs'],
+      })
+      .option('verbose', {
+        type: 'boolean',
+        default: false,
+        description: 'Enable verbose logging.',
+      })
+      .option('skipTypes', {
+        type: 'boolean',
+        default: false,
+        description: 'Whether to skip building types for the package.',
+      })
+      .option('sourceMap', {
+        type: 'boolean',
+        default: false,
+        description: 'Enable source maps for the build.',
+      })
+      .option('copy', {
+        type: 'string',
+        array: true,
+        description:
+          'Files/Directories to be copied to the output directory. Can be a glob pattern.',
+        default: [],
+      }),
+  async handler(args) {
+    let pkgName = '';
+    await markFn('build-new', async () => {
+      const cwd = process.cwd();
+      const pkgJson = JSON.parse(await fs.readFile(path.join(cwd, 'package.json'), 'utf8'));
+      validatePkgJson(pkgJson);
+      pkgName = pkgJson.name;
+
+      await import('../bundlers/tsdown.mjs').then(({ build }) => build(args, pkgJson));
+    });
+    console.log(
+      `✅ Built "${pkgName}" in ${(measureFn('build-new').duration / 1000).toFixed(3)}s.`,
+    );
+  },
+});

--- a/packages/code-infra/src/cli/cmdBuildNew.mjs
+++ b/packages/code-infra/src/cli/cmdBuildNew.mjs
@@ -10,6 +10,7 @@ import { markFn, measureFn, validatePkgJson } from '../utils/build.mjs';
  * @property {boolean} skipTypes
  * @property {boolean} sourceMap
  * @property {string[]} [copy]
+ * @property {boolean} enableReactCompiler
  */
 
 /**
@@ -55,13 +56,21 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         description:
           'Files/Directories to be copied to the output directory. Can be a glob pattern.',
         default: [],
+      })
+      .option('enableReactCompiler', {
+        type: 'boolean',
+        default: false,
+        description: 'Whether to use the React compiler.',
       }),
   async handler(args) {
     let pkgName = '';
     await markFn('build-new', async () => {
       const cwd = process.cwd();
       const pkgJson = JSON.parse(await fs.readFile(path.join(cwd, 'package.json'), 'utf8'));
-      validatePkgJson(pkgJson);
+      await validatePkgJson(pkgJson, {
+        enableReactCompiler: args.enableReactCompiler,
+        skipBabelRuntimeCheck: true, // this check is done in tsdown build
+      });
       pkgName = pkgJson.name;
 
       await import('../bundlers/tsdown.mjs').then(({ build }) => build(args, pkgJson));

--- a/packages/code-infra/src/cli/index.mjs
+++ b/packages/code-infra/src/cli/index.mjs
@@ -4,6 +4,7 @@ import { hideBin } from 'yargs/helpers';
 
 import cmdArgosPush from './cmdArgosPush.mjs';
 import cmdBuild from './cmdBuild.mjs';
+import cmdBuildNew from './cmdBuildNew.mjs';
 import cmdCopyFiles from './cmdCopyFiles.mjs';
 import cmdExtractErrorCodes from './cmdExtractErrorCodes.mjs';
 import cmdGithubAuth from './cmdGithubAuth.mjs';
@@ -14,24 +15,30 @@ import cmdPublishNewPackage from './cmdPublishNewPackage.mjs';
 import cmdSetVersionOverrides from './cmdSetVersionOverrides.mjs';
 import cmdValidateBuiltTypes from './cmdValidateBuiltTypes.mjs';
 
-const pkgJson = createRequire(import.meta.url)('../../package.json');
+export function run() {
+  const { version } = createRequire(import.meta.url)(
+    process.env.MUI_VERSION ? '../package.json' : '../../package.json',
+  );
 
-yargs()
-  .scriptName('code-infra')
-  .usage('$0 <command> [args]')
-  .command(cmdArgosPush)
-  .command(cmdBuild)
-  .command(cmdCopyFiles)
-  .command(cmdExtractErrorCodes)
-  .command(cmdGithubAuth)
-  .command(cmdListWorkspaces)
-  .command(cmdPublish)
-  .command(cmdPublishCanary)
-  .command(cmdPublishNewPackage)
-  .command(cmdSetVersionOverrides)
-  .command(cmdValidateBuiltTypes)
-  .demandCommand(1, 'You need at least one command before moving on')
-  .strict()
-  .help()
-  .version(pkgJson.version)
-  .parse(hideBin(process.argv));
+  yargs()
+    .scriptName('code-infra')
+    .usage('$0 <command> [args]')
+    .command(cmdArgosPush)
+    .command(cmdBuild)
+    .command(cmdBuildNew)
+    .command(cmdCopyFiles)
+    .command(cmdExtractErrorCodes)
+    .command(cmdGithubAuth)
+    .command(cmdListWorkspaces)
+    .command(cmdPublish)
+    .command(cmdPublishCanary)
+    .command(cmdPublishNewPackage)
+    .command(cmdSetVersionOverrides)
+    .command(cmdValidateBuiltTypes)
+
+    .demandCommand(1, 'You need at least one command before moving on')
+    .strict()
+    .help()
+    .version(version)
+    .parse(hideBin(process.argv));
+}

--- a/packages/code-infra/src/untyped-plugins.d.ts
+++ b/packages/code-infra/src/untyped-plugins.d.ts
@@ -95,6 +95,20 @@ declare module '@next/eslint-plugin-next' {
   export default config;
 }
 
+declare module '@babel/plugin-transform-object-rest-spread' {
+  import type { PluginItem } from '@babel/core';
+
+  declare const plugin: PluginItem;
+  export default plugin;
+}
+
+declare module '@babel/plugin-transform-react-pure-annotations' {
+  import type { PluginItem } from '@babel/core';
+
+  declare const plugin: PluginItem;
+  export default plugin;
+}
+
 declare module '@babel/plugin-transform-runtime' {
   import type { PluginItem } from '@babel/core';
 

--- a/packages/code-infra/src/utils/babel.mjs
+++ b/packages/code-infra/src/utils/babel.mjs
@@ -14,7 +14,7 @@ const TO_TRANSFORM_EXTENSIONS = ['.js', '.ts', '.tsx'];
  * @param {string} pkgVersion
  * @returns {Record<string, string>} An object containing version-related environment variables.
  */
-export function getVersionEnvVariables(pkgVersion) {
+function getVersionEnvVariables(pkgVersion) {
   if (!pkgVersion) {
     throw new Error('No version found in package.json');
   }

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -1,9 +1,13 @@
 import * as semver from 'semver';
+import { globby } from 'globby';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 
 /**
  * @typedef {'esm' | 'cjs'} BundleType
  */
 export const isMjsBuild = !!process.env.MUI_EXPERIMENTAL_MJS;
+export const DTS_REGEX = /\.d\.[m|c]?ts$/;
 
 /**
  * @param {BundleType} bundle
@@ -19,6 +23,397 @@ export function getOutExtension(bundle, isType = false) {
     return '.js';
   }
   return bundle === 'esm' ? '.mjs' : '.js';
+}
+
+/**
+ * @typedef {Object} BuildOptions
+ * @property {boolean} [watch=false] - Whether to watch files for changes.
+ * @property {boolean} [verbose=false] - Whether to enable verbose logging.
+ * @property {boolean} [sourceMap=false] - Whether to generate source maps.
+ */
+
+/**
+ * @typedef {Record<string, string | null | Record<string, string>>} Exports
+ */
+
+/**
+ * @param {Record<string, string>} entryMap
+ * @param {string} key
+ * @param {string} value
+ */
+function addEntry(entryMap, key, value) {
+  const finalKey = key.startsWith('./') ? key.slice(2) : key;
+  entryMap[finalKey] = value;
+}
+
+/**
+ * @param {Record<string, string | Record<string, string>> | undefined} pkgExports
+ * @param {{ buildDirBase: string }} options
+ * @returns {[Record<string, string | Record<string, Record<string, string>>>, {main: string | undefined; module: string | undefined;types: string| undefined}]}
+ */
+export function processExports(pkgExports, { buildDirBase }) {
+  /**
+   * @type {{main: string| undefined; module: string | undefined;types: string| undefined}}
+   */
+  const topLevel = {
+    main: undefined,
+    module: undefined,
+    types: undefined,
+  };
+  /**
+   * @type {Record<string, string | Record<string, Record<string, string>>>}
+   */
+  const outExports = {};
+  if (pkgExports && typeof pkgExports === 'object' && Object.keys(pkgExports).length > 0) {
+    Object.entries(pkgExports).forEach(([key, value]) => {
+      const buildDirRegex = new RegExp(`^./${buildDirBase}/`);
+      if (value && typeof value === 'object') {
+        /**
+         * @type {Record<string, Record<string, string>>}
+         */
+        const newKey = {};
+        Object.entries(value).forEach(([subKey, subValue]) => {
+          const filePath = subValue.replace(buildDirRegex, './');
+          const pathExt = path.extname(subValue);
+          let typeExt = pathExt === '.mjs' ? '.d.mts' : '.d.ts';
+          if (pathExt === '.cjs') {
+            typeExt = '.d.cts';
+          }
+          // outExports[key][subKey] = subValue.replace(/^\.\/build\//, './');
+          newKey[subKey] = newKey[subKey] ?? {};
+          newKey[subKey].types = `${filePath.replace(new RegExp(`${pathExt}$`), typeExt)}`;
+          newKey[subKey].default = filePath;
+
+          if (key === '.' && subKey === 'require') {
+            topLevel.main = newKey[subKey].default;
+            topLevel.types = newKey[subKey].types;
+          }
+        });
+        outExports[key] = newKey;
+      } else if (typeof value === 'string') {
+        outExports[key] = value.replace(buildDirRegex, './');
+      }
+    });
+  }
+  return [outExports, topLevel];
+}
+
+/**
+ *
+ * @param {string} pkgVersion
+ * @returns {Record<string, string>}
+ */
+export function getVersionEnvVariables(pkgVersion) {
+  if (!pkgVersion) {
+    throw new Error('No version found in package.json');
+  }
+
+  const [versionNumber, prerelease] = pkgVersion.split('-');
+  const [major, minor, patch] = versionNumber.split('.');
+
+  if (!major || !minor || !patch) {
+    throw new Error(`Couldn't parse version from package.json`);
+  }
+
+  /**
+   * @type {Record<string, string>}
+   */
+  const res = {
+    MUI_VERSION: pkgVersion,
+    MUI_MAJOR_VERSION: major,
+    MUI_MINOR_VERSION: minor,
+    MUI_PATCH_VERSION: patch,
+    MUI_PRERELEASE: prerelease ?? 'undefined',
+  };
+  return res;
+}
+
+/**
+ * Processes the exports field of a package.json file and maps them to entry points to be used by tsdown.
+ * Expands glob patterns and resolves file paths.
+ * @param {Exports} pkgExports
+ * @param {string | Record<string, string>} pkgBin
+ * @param {{ cwd: string }} options
+ * @returns {Promise<[Record<string, string>, string[], Record<string, string>]>}
+ */
+export async function generateEntriesFromExports(pkgExports, pkgBin, { cwd }) {
+  /**
+   * @type {Record<string, string>}
+   */
+  const entries = {};
+  /**
+   * @type {Record<string, string>}
+   */
+  const binEntries = {};
+  /**
+   * @type {string[]}
+   */
+  const nullEntries = [];
+
+  if (typeof pkgBin === 'string') {
+    addEntry(binEntries, 'bin', pkgBin);
+  } else if (pkgBin && typeof pkgBin === 'object') {
+    Object.entries(pkgBin).forEach(([key, value]) => {
+      addEntry(binEntries, `bin/${key}`, value);
+    });
+  }
+
+  if (typeof pkgExports === 'object' && pkgExports && Object.keys(pkgExports).length > 0) {
+    await Promise.all(
+      Object.entries(pkgExports).map(async ([key, value]) => {
+        if (!value) {
+          nullEntries.push(key);
+          return;
+        }
+        if (key.endsWith('.json') || key.endsWith('.css')) {
+          return;
+        }
+        let entryValue = '';
+        if (typeof value === 'string') {
+          entryValue = value;
+        } else if (value && typeof value === 'object') {
+          // entries[key] = processExportsToEntry(value)[0];
+          // @TODO
+          if (value.default && typeof value.default === 'string') {
+            entryValue = value.default;
+          } else {
+            throw new Error('TODO: Objects in exports are not supported yet.');
+          }
+        }
+        if (entryValue.includes('*')) {
+          if (
+            entryValue.includes('**') ||
+            entryValue.indexOf('*') !== entryValue.lastIndexOf('*')
+          ) {
+            throw new Error(
+              `Unsupported glob pattern: ${entryValue} in "exports.${key}". Please use single asterisks (*) for glob patterns.`,
+            );
+          }
+          const files = await globby(entryValue, {
+            cwd,
+            globstar: false,
+          });
+          files.forEach((file) => {
+            const fileName = path.basename(file);
+            const ext = path.extname(file);
+            if (fileName.replace(ext, '') === 'index') {
+              const fileKey = file
+                .replace(/^(src|\.\/src)\//, '')
+                .replace(new RegExp(`\\${ext}$`), '');
+              addEntry(entries, fileKey, file);
+            } else {
+              const fileKey = file
+                .replace(/^(src|\.\/src)\//, '')
+                .replace(new RegExp(`\\${ext}$`), '');
+              addEntry(entries, fileKey, file);
+            }
+          });
+        } else {
+          const fileName = path.basename(entryValue);
+          const ext = path.extname(entryValue);
+          const entryKey = key === '.' ? 'index' : key;
+          if (fileName.replace(ext, '') === 'index' && key !== '.') {
+            addEntry(entries, `${entryKey}/index`, entryValue);
+          } else {
+            addEntry(entries, entryKey, entryValue);
+          }
+        }
+      }),
+    );
+  }
+  if (Object.keys(entries).length === 0 && Object.keys(binEntries).length === 0) {
+    throw new Error('No entries found in exports or bin field of package.json');
+  }
+  return [entries, nullEntries, binEntries];
+} /**
+ * @typedef {import('rolldown').RolldownOutput['output']} RolldownOutput
+ */
+/**
+ * @typedef {{directory?: string}} PublishConfig
+ */
+/**
+ * @typedef {Object} OutChunk
+ * @property {string} fileName
+ * @property {string} name
+ * @property {boolean} isEntry
+ */
+/**
+ * @typedef {{esm: OutChunk[], cjs: OutChunk[], bin: OutChunk[]}} OutChunks
+ */
+
+/**
+ * @param {Record<string, any>} basePkgJson
+ * @param {Record<string, {paths: string[]; isBin?: boolean}>} chunks
+ * @param {string[]} [nullEntries]
+ * @param {{ usePkgType?: boolean }} [options]
+ * @returns {Promise<void>}
+ */
+export async function writePkgJson(basePkgJson, chunks, nullEntries = [], options = {}) {
+  const usePkgType = options.usePkgType || false;
+  const cwd = process.cwd();
+  const outPath = path.join(
+    cwd,
+    /** @type {{directory: string}} */ (basePkgJson.publishConfig).directory,
+    'package.json',
+  );
+  delete basePkgJson.publishConfig?.directory;
+  delete basePkgJson.scripts;
+  delete basePkgJson.devDependencies;
+  delete basePkgJson.publishConfig;
+  delete basePkgJson.exports;
+  delete basePkgJson.bin;
+  if (basePkgJson.packageScripts) {
+    delete basePkgJson.scripts;
+    basePkgJson.scripts = basePkgJson.packageScripts;
+    delete basePkgJson.packageScripts;
+  }
+  basePkgJson.sideEffects ??= false;
+  basePkgJson.type ??= 'commonjs';
+  const isModule = basePkgJson.type === 'module';
+
+  /**
+   * @type {Record<string, Partial<Record<'default' | 'import' | 'require' | 'react-server', Record<string, string | undefined> | undefined>>>}
+   */
+  const newExports = {};
+  /**
+   * @type {null | Record<string, string>}
+   */
+  let newBin = null;
+
+  Object.entries(chunks).forEach(([key, chunk]) => {
+    if (chunk.isBin) {
+      newBin = newBin || {};
+      newBin[key.substring('bin/'.length)] =
+        `./${isModule ? chunk.paths.find((p) => p.endsWith('.mjs') || p.endsWith('.js')) : chunk.paths.find((p) => p.endsWith('.cjs') || p.endsWith('.js'))}`;
+    } else {
+      const pathKey =
+        key === 'index'
+          ? '.'
+          : `./${key.endsWith('/index') ? key.substring(0, key.length - '/index'.length) : key}`;
+      const cjsExtension = usePkgType && isModule ? '.cjs' : '.js';
+      const cjsDtsExtension = usePkgType && isModule ? '.d.cts' : '.d.ts';
+      const mjsExtension = usePkgType && !isModule ? '.mjs' : '.js';
+      const mjsDtsExtension = usePkgType && !isModule ? '.d.mts' : '.d.ts';
+      const requireTypePath = chunk.paths.find((p) => p.endsWith(cjsDtsExtension));
+      const importTypePath = chunk.paths.find((p) => p.endsWith(mjsDtsExtension));
+      const requirePath = chunk.paths.find((p) => p.endsWith(cjsExtension));
+      const importPath = chunk.paths.find((p) => p.endsWith(mjsExtension));
+      newExports[pathKey] = {
+        require: requirePath
+          ? {
+              types: requireTypePath ? `./${requireTypePath}` : undefined,
+              default: requirePath ? `./${requirePath}` : undefined,
+            }
+          : undefined,
+        import: importPath
+          ? {
+              types: importTypePath ? `./${importTypePath}` : undefined,
+              default: importPath ? `./${importPath}` : undefined,
+            }
+          : undefined,
+      };
+      if (newExports[pathKey].import) {
+        newExports[pathKey].default = newExports[pathKey].import;
+        if (pathKey === '.') {
+          basePkgJson.module = newExports[pathKey].import.default;
+        }
+        delete newExports[pathKey].import;
+      } else if (newExports[pathKey].require) {
+        newExports[pathKey].default = newExports[pathKey].require;
+        if (pathKey === '.') {
+          basePkgJson.main = newExports[pathKey].require.default;
+          basePkgJson.types = newExports[pathKey].require.types;
+        }
+        delete newExports[pathKey].require;
+      }
+    }
+  });
+
+  if (Object.keys(newExports).length) {
+    const dotExport = newExports['.'];
+    delete newExports['.'];
+    // stringify and parse to remove undefined values
+    basePkgJson.exports = JSON.parse(
+      JSON.stringify({
+        './package.json': './package.json',
+        ...(dotExport ? { '.': dotExport } : {}),
+        ...newExports,
+      }),
+    );
+
+    Object.keys(basePkgJson.exports).forEach((key) => {
+      const value = basePkgJson.exports[key];
+      if (typeof value === 'string') {
+        return;
+      }
+      // clean up entries with only one option
+      if (value && typeof value === 'object') {
+        const objKeys = Object.keys(value);
+        if (objKeys.length === 1) {
+          const exportValue = value[objKeys[0]];
+          if (
+            exportValue &&
+            typeof exportValue === 'object' &&
+            Object.keys(exportValue).length === 1 &&
+            exportValue.default
+          ) {
+            basePkgJson.exports[key] = exportValue.default;
+            return;
+          }
+          basePkgJson.exports[key] = value[objKeys[0]];
+        }
+      }
+    });
+
+    if (dotExport) {
+      const mainExport = dotExport;
+      if (mainExport.require) {
+        basePkgJson.main = mainExport.require.default;
+        basePkgJson.types = mainExport.require.types;
+      }
+      if (mainExport.default) {
+        basePkgJson.module = mainExport.default.default;
+      }
+    }
+  }
+
+  if (nullEntries.length) {
+    basePkgJson.exports = basePkgJson.exports || {};
+    nullEntries.forEach((key) => {
+      const pathKey = key.startsWith('./') ? key : `./${key}`;
+      basePkgJson.exports[pathKey] = null;
+    });
+  }
+
+  if (newBin) {
+    basePkgJson.bin = newBin;
+  }
+
+  await fs.writeFile(outPath, `${JSON.stringify(basePkgJson, null, 2)}\n`);
+}
+
+const TS_CONFIG_PATHS = ['tsconfig.build.json', 'tsconfig.json'];
+
+/**
+ * Checks for the existence of tsconfig.build.json or tsconfig.json in the given directory.
+ * Returns the path of the first found file, or null if neither file exists.
+ * @param {string} cwd
+ * @returns {Promise<string|null>}
+ */
+export async function getTsConfigPath(cwd) {
+  for (const configPath of TS_CONFIG_PATHS) {
+    const fullPath = path.join(cwd, configPath);
+    if (
+      // eslint-disable-next-line no-await-in-loop
+      await fs
+        .stat(fullPath)
+        .then((stat) => stat.isFile())
+        .catch(() => false)
+    ) {
+      return configPath;
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/code-infra/src/utils/copyFiles.mjs
+++ b/packages/code-infra/src/utils/copyFiles.mjs
@@ -1,0 +1,139 @@
+/* eslint-disable no-console */
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
+import { globby } from 'globby';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { sep as posixSep } from 'node:path/posix';
+import { mapConcurrently } from './build.mjs';
+
+/**
+ * @param {Object} param0
+ * @param {string} param0.cwd - The current working directory.
+ * @param {string[]} [param0.globs=[]] - Extra files to copy, can be specified as `source:target` pairs or just `source`.
+ * @param {string} param0.buildDir - The build directory to copy to.
+ * @param {boolean} [param0.verbose=false] - Whether to suppress output.
+ * @returns {Promise<void>}
+ */
+export async function copyFiles({ cwd, globs = [], buildDir, verbose = false }) {
+  /**
+   * @type {(string|{targetPath: string; sourcePath: string})[]}
+   */
+  const defaultFiles = [];
+  const workspaceDir = await findWorkspaceDir(cwd);
+  if (!workspaceDir) {
+    throw new Error('Workspace directory not found');
+  }
+
+  const localOrRootFiles = [
+    [path.join(cwd, 'README.md'), path.join(workspaceDir, 'README.md')],
+    [path.join(cwd, 'LICENSE'), path.join(workspaceDir, 'LICENSE')],
+    [path.join(cwd, 'CHANGELOG.md'), path.join(workspaceDir, 'CHANGELOG.md')],
+  ];
+  await Promise.all(
+    localOrRootFiles.map(async (filesToCopy) => {
+      for (const file of filesToCopy) {
+        if (
+          // eslint-disable-next-line no-await-in-loop
+          await fs.stat(file).then(
+            () => true,
+            () => false,
+          )
+        ) {
+          defaultFiles.push(file);
+          break;
+        }
+      }
+    }),
+  );
+
+  if (globs.length) {
+    const res = globs.map((globPattern) => {
+      const [pattern, baseDir] = globPattern.split(':');
+      return { pattern, baseDir };
+    });
+    /**
+     * Avoids redundant globby calls for the same pattern.
+     *
+     * @type {Map<string, Promise<string[]>>}
+     */
+    const globToResMap = new Map();
+
+    const result = await Promise.all(
+      res.map(async ({ pattern, baseDir }) => {
+        if (!globToResMap.has(pattern)) {
+          const promise = globby(pattern, { cwd });
+          globToResMap.set(pattern, promise);
+        }
+        const files = await globToResMap.get(pattern);
+        return { files: files ?? [], baseDir };
+      }),
+    );
+    globToResMap.clear();
+
+    result.forEach(({ files, baseDir }) => {
+      files.forEach((file) => {
+        const sourcePath = path.resolve(cwd, file);
+        // Use posix separator for the relative paths. So devs can only specify globs with `/` even on Windows.
+        const pathSegments = file.split(posixSep);
+        const relativePath =
+          // Use index 2 (when required) since users can also specify paths like `./src/index.js`
+          pathSegments.slice(pathSegments[0] === '.' ? 2 : 1).join(posixSep) || file;
+        const targetPath = baseDir
+          ? path.resolve(buildDir, baseDir, relativePath)
+          : path.resolve(buildDir, relativePath);
+        defaultFiles.push({ sourcePath, targetPath });
+      });
+    });
+  }
+
+  if (!defaultFiles.length) {
+    if (verbose) {
+      console.log('⓿ No files to copy.');
+    }
+  }
+  await mapConcurrently(
+    defaultFiles,
+    async (file) => {
+      if (typeof file === 'string') {
+        const sourcePath = file;
+        const fileName = path.basename(file);
+        const targetPath = path.join(buildDir, fileName);
+        await recursiveCopy({ source: sourcePath, target: targetPath, verbose });
+      } else {
+        await fs.mkdir(path.dirname(file.targetPath), { recursive: true });
+        await recursiveCopy({ source: file.sourcePath, target: file.targetPath, verbose });
+      }
+    },
+    20,
+  );
+  console.log(`📋 Copied ${defaultFiles.length} files.`);
+}
+
+/**
+ * Recursively copies files and directories from a source path to a target path.
+ *
+ * @async
+ * @param {Object} options - The options for copying files.
+ * @param {string} options.source - The source path to copy from.
+ * @param {string} options.target - The target path to copy to.
+ * @param {boolean} [options.verbose=true] - If true, suppresses console output.
+ * @returns {Promise<boolean>} Resolves when the copy operation is complete.
+ * @throws {Error} Throws if an error occurs other than the source not existing.
+ */
+async function recursiveCopy({ source, target, verbose = true }) {
+  try {
+    await fs.cp(source, target, { recursive: true });
+    if (verbose) {
+      console.log(`Copied ${source} to ${target}`);
+    }
+    return true;
+  } catch (err) {
+    if (/** @type {{ code: string }} */ (err).code !== 'ENOENT') {
+      throw err;
+    }
+    if (verbose) {
+      console.warn(`Source does not exist: ${source}`);
+    }
+    throw err;
+  }
+}

--- a/packages/code-infra/tsconfig.build.json
+++ b/packages/code-infra/tsconfig.build.json
@@ -5,11 +5,11 @@
   "compilerOptions": {
     "paths": {},
     "emitDeclarationOnly": true,
-    "outDir": "./build",
-    "rootDir": "./src",
-    "noEmit": false
+    "outDir": "build",
+    "rootDir": "src",
+    "noEmit": false,
+    "declarationDir": "build"
   },
-  "include": ["src/**/*"],
-  // removing "cli" since its going to run directly and not really imported anywhere
+  "include": ["src", "package.json"],
   "exclude": ["**/*.spec.*", "**/*.test.*", "**/setupVitest.ts"]
 }

--- a/packages/code-infra/tsconfig.json
+++ b/packages/code-infra/tsconfig.json
@@ -13,6 +13,6 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src"],
+  "include": ["src", "package.json"],
   "exclude": ["node_modules", "build"]
 }

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -4,8 +4,9 @@
   "author": "MUI Team",
   "description": "MUI Infra - internal documentation creation tools.",
   "bin": {
-    "docs-infra": "./esm/cli/index.js"
+    "docs-infra": "./src/cli/bin.ts"
   },
+  "type": "module",
   "exports": {
     "./abstractCreateDemo": "./src/abstractCreateDemo/index.ts",
     "./abstractCreateDemoClient": "./src/abstractCreateDemoClient/index.ts",
@@ -69,7 +70,7 @@
   },
   "homepage": "https://github.com/mui/mui-public/tree/master/packages/docs-infra",
   "scripts": {
-    "build": "code-infra build --bundle esm",
+    "build": "code-infra build-new --bundle esm --sourceMap",
     "release": "pnpm build && pnpm publish --no-git-checks",
     "test": "pnpm -w test --project @mui/internal-docs-infra",
     "test:watch": "pnpm -w test:watch --project @mui/internal-docs-infra",

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -7,6 +7,7 @@
     "docs-infra": "./src/cli/bin.ts"
   },
   "type": "module",
+  "sideEffects": false,
   "exports": {
     "./abstractCreateDemo": "./src/abstractCreateDemo/index.ts",
     "./abstractCreateDemoClient": "./src/abstractCreateDemoClient/index.ts",
@@ -70,7 +71,7 @@
   },
   "homepage": "https://github.com/mui/mui-public/tree/master/packages/docs-infra",
   "scripts": {
-    "build": "code-infra build-new --bundle esm --sourceMap",
+    "build": "code-infra build-new --bundle esm",
     "release": "pnpm build && pnpm publish --no-git-checks",
     "test": "pnpm -w test --project @mui/internal-docs-infra",
     "test:watch": "pnpm -w test:watch --project @mui/internal-docs-infra",

--- a/packages/docs-infra/src/cli/bin.ts
+++ b/packages/docs-infra/src/cli/bin.ts
@@ -1,0 +1,3 @@
+import { runCli } from './index';
+
+runCli();

--- a/packages/docs-infra/src/cli/index.ts
+++ b/packages/docs-infra/src/cli/index.ts
@@ -3,14 +3,18 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import runValidate from './runValidate';
 
-const pkgJson = createRequire(import.meta.url)('../../package.json');
+export function runCli() {
+  const { version } = createRequire(import.meta.url)(
+    process.env.MUI_VERSION ? '../package.json' : '../../package.json',
+  );
 
-yargs()
-  .scriptName('docs-infra')
-  .usage('$0 <command> [args]')
-  .command(runValidate)
-  .demandCommand(1, 'You need at least one command before moving on')
-  .strict()
-  .help()
-  .version(pkgJson.version)
-  .parse(hideBin(process.argv));
+  yargs()
+    .scriptName('docs-infra')
+    .usage('$0 <command> [args]')
+    .command(runValidate)
+    .demandCommand(1, 'You need at least one command before moving on')
+    .strict()
+    .help()
+    .version(version)
+    .parse(hideBin(process.argv));
+}

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -19,7 +19,7 @@
     "./setupVitest": "./src/setupVitest.ts"
   },
   "scripts": {
-    "build": "code-infra build",
+    "build": "code-infra build-new",
     "test": "pnpm -w test --project @mui/internal-test-utils",
     "typescript": "tsc -p tsconfig.json"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,7 +415,7 @@ importers:
         version: 5.1.4
       rollup-plugin-visualizer:
         specifier: ^6.0.5
-        version: 6.0.5(rollup@4.52.5)
+        version: 6.0.5(rolldown@1.0.0-beta.57)(rollup@4.52.5)
       vite:
         specifier: ^7.3.1
         version: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
@@ -504,6 +504,9 @@ importers:
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.3
         version: 1000.1.3
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.2(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/eslint-plugin':
         specifier: ^1.6.4
         version: 1.6.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
@@ -603,6 +606,9 @@ importers:
       stylelint-config-standard:
         specifier: ^39.0.1
         version: 39.0.1(stylelint@16.26.1(typescript@5.9.3))
+      tsdown:
+        specifier: ^0.18.4
+        version: 0.18.4(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1826,8 +1832,8 @@ packages:
   '@dual-bundle/import-meta-resolve@4.2.1':
     resolution: {integrity: sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==}
 
-  '@emnapi/core@1.7.0':
-    resolution: {integrity: sha512-pJdKGq/1iquWYtv1RRSljZklxHCOCAJFJrImO5ZLKPJVJlVUcs8yFwNQlqS0Lo8xT1VAXXTCZocF9n26FWEKsw==}
+  '@emnapi/core@1.7.1':
+    resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
@@ -2898,7 +2904,7 @@ packages:
   '@mui/base@5.0.0-beta.69':
     resolution: {integrity: sha512-r2YyGUXpZxj8rLAlbjp1x2BnMERTZ/dMqd9cClKj2OJ7ALAuiv/9X5E9eHfRc9o/dGRuLSMq/WTjREktJVjxVA==}
     engines: {node: '>=14.0.0'}
-    deprecated: This package has been replaced by @base-ui/react
+    deprecated: This package has been replaced by @base-ui-components/react
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3670,6 +3676,9 @@ packages:
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
 
+  '@napi-rs/wasm-runtime@1.1.0':
+    resolution: {integrity: sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==}
+
   '@next/bundle-analyzer@16.1.1':
     resolution: {integrity: sha512-aNJy301GGH8k36rDgrYdnyYEdjRQg6csMi1njzqHo+3qyZvOOWMHSv+p7SztNTzP5RU2KRwX0pPwYBtDcE+vVA==}
 
@@ -4098,6 +4107,9 @@ packages:
     resolution: {integrity: sha512-W8V7m7RnCme+99OmKl/xs5rf6OUhFpr0aPGVmPrXzTLSg4ZqSbRY2euS2S/lgjjYi/0NhEWqwoq8nDY6Ihx4EA==}
     engines: {node: '>= 20.0.0'}
 
+  '@oxc-project/types@0.103.0':
+    resolution: {integrity: sha512-bkiYX5kaXWwUessFRSoXFkGIQTmc6dLGdxuRTrC+h8PSnIdZyuXHHlLAeTmOue5Br/a0/a7dHH0Gca6eXn9MKg==}
+
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
@@ -4143,6 +4155,9 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -4860,6 +4875,89 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@rolldown/binding-android-arm64@1.0.0-beta.57':
+    resolution: {integrity: sha512-GoOVDy8bjw9z1K30Oo803nSzXJS/vWhFijFsW3kzvZCO8IZwFnNa6pGctmbbJstKl3Fv6UBwyjJQN6msejW0IQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.57':
+    resolution: {integrity: sha512-9c4FOhRGpl+PX7zBK5p17c5efpF9aSpTPgyigv57hXf5NjQUaJOOiejPLAtFiKNBIfm5Uu6yFkvLKzOafNvlTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.57':
+    resolution: {integrity: sha512-6RsB8Qy4LnGqNGJJC/8uWeLWGOvbRL/KG5aJ8XXpSEupg/KQtlBEiFaYU/Ma5Usj1s+bt3ItkqZYAI50kSplBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.57':
+    resolution: {integrity: sha512-uA9kG7+MYkHTbqwv67Tx+5GV5YcKd33HCJIi0311iYBd25yuwyIqvJfBdt1VVB8tdOlyTb9cPAgfCki8nhwTQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57':
+    resolution: {integrity: sha512-3KkS0cHsllT2T+Te+VZMKHNw6FPQihYsQh+8J4jkzwgvAQpbsbXmrqhkw3YU/QGRrD8qgcOvBr6z5y6Jid+rmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57':
+    resolution: {integrity: sha512-A3/wu1RgsHhqP3rVH2+sM81bpk+Qd2XaHTl8LtX5/1LNR7QVBFBCpAoiXwjTdGnI5cMdBVi7Z1pi52euW760Fw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
+    resolution: {integrity: sha512-d0kIVezTQtazpyWjiJIn5to8JlwfKITDqwsFv0Xc6s31N16CD2PC/Pl2OtKgS7n8WLOJbfqgIp5ixYzTAxCqMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
+    resolution: {integrity: sha512-E199LPijo98yrLjPCmETx8EF43sZf9t3guSrLee/ej1rCCc3zDVTR4xFfN9BRAapGVl7/8hYqbbiQPTkv73kUg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
+    resolution: {integrity: sha512-++EQDpk/UJ33kY/BNsh7A7/P1sr/jbMuQ8cE554ZIy+tCUWCivo9zfyjDUoiMdnxqX6HLJEqqGnbGQOvzm2OMQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
+    resolution: {integrity: sha512-voDEBcNqxbUv/GeXKFtxXVWA+H45P/8Dec4Ii/SbyJyGvCqV1j+nNHfnFUIiRQ2Q40DwPe/djvgYBs9PpETiMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.57':
+    resolution: {integrity: sha512-bRhcF7NLlCnpkzLVlVhrDEd0KH22VbTPkPTbMjlYvqhSmarxNIq5vtlQS8qmV7LkPKHrNLWyJW/V/sOyFba26Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.57':
+    resolution: {integrity: sha512-rnDVGRks2FQ2hgJ2g15pHtfxqkGFGjJQUDWzYznEkE8Ra2+Vag9OffxdbJMZqBWXHVM0iS4dv8qSiEn7bO+n1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
+    resolution: {integrity: sha512-OqIUyNid1M4xTj6VRXp/Lht/qIP8fo25QyAZlCP+p6D2ATCEhyW4ZIFLnC9zAGN/HMbXoCzvwfa8Jjg/8J4YEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.53':
+    resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
+
+  '@rolldown/pluginutils@1.0.0-beta.57':
+    resolution: {integrity: sha512-aQNelgx14tGA+n2tNSa9x6/jeoCL9fkDeCei7nOKnHx0fEFRRMu5ReiITo+zZD5TzWDGGRjbSYCs93IfRIyTuQ==}
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
@@ -5867,6 +5965,12 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
+  '@vitejs/plugin-react@5.1.2':
+    resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
   '@vitest/coverage-v8@4.0.16':
     resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
     peerDependencies:
@@ -6094,6 +6198,10 @@ packages:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
 
+  ansis@4.2.0:
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
+    engines: {node: '>=14'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -6203,6 +6311,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-kit@2.2.0:
+    resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
+    engines: {node: '>=20.19.0'}
 
   ast-metadata-inferer@0.8.1:
     resolution: {integrity: sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==}
@@ -6355,6 +6467,9 @@ packages:
   binary@0.3.0:
     resolution: {integrity: sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==}
 
+  birpc@4.0.0:
+    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -6432,6 +6547,10 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   cacache@19.0.1:
     resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
@@ -7033,6 +7152,9 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
   delaunator@5.0.1:
     resolution: {integrity: sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==}
 
@@ -7132,6 +7254,15 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
+  dts-resolver@2.1.3:
+    resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -7167,6 +7298,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -8116,6 +8251,9 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hookable@6.0.1:
+    resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
+
   hookified@1.13.0:
     resolution: {integrity: sha512-6sPYUY8olshgM/1LDNW4QZQN0IqgKhtl/1C8koNZBJrKLBk3AZl6chQtNwpNztvfiApHMEwMHek5rv993PRbWw==}
 
@@ -8235,6 +8373,10 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  import-without-cache@0.2.5:
+    resolution: {integrity: sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A==}
+    engines: {node: '>=20.19.0'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -10212,6 +10354,9 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -10302,6 +10447,10 @@ packages:
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
@@ -10575,6 +10724,30 @@ packages:
 
   robust-predicates@3.0.2:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
+
+  rolldown-plugin-dts@0.20.0:
+    resolution: {integrity: sha512-cLAY1kN2ilTYMfZcFlGWbXnu6Nb+8uwUBsi+Mjbh4uIx7IN8uMOmJ7RxrrRgPsO4H7eSz3E+JwGoL1gyugiyUA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@ts-macro/tsc': ^0.3.6
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.57
+      typescript: ^5.0.0
+      vue-tsc: ~3.2.0
+    peerDependenciesMeta:
+      '@ts-macro/tsc':
+        optional: true
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-beta.57:
+    resolution: {integrity: sha512-lMMxcNN71GMsSko8RyeTaFoATHkCh4IWU7pYF73ziMYjhHZWfVesC6GQ+iaJCvZmVjvgSks9Ks1aaqEkBd8udg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup-plugin-visualizer@6.0.5:
     resolution: {integrity: sha512-9+HlNgKCVbJDs8tVtjQ43US12eqaiHyyiLMdBwQ7vSZPiHMysGNo2E88TAp1si5wx8NAoYriI2A5kuKfIakmJg==}
@@ -11278,6 +11451,31 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tsdown@0.18.4:
+    resolution: {integrity: sha512-J/tRS6hsZTkvqmt4+xdELUCkQYDuUCXgBv0fw3ImV09WPGbEKfsPD65E+WUjSu3E7Z6tji9XZ1iWs8rbGqB/ZA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@vitejs/devtools': '*'
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      publint:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -11391,6 +11589,9 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
+  unconfig-core@7.4.2:
+    resolution: {integrity: sha512-VgPCvLWugINbXvMQDf8Jh0mlbvNjNC6eSUziHsBCMpxR05OPrNrvDnyatdMjRgcHaaNsCqz+wjNXxNw1kRLHUg==}
+
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -11477,6 +11678,16 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  unrun@0.2.21:
+    resolution: {integrity: sha512-VuwI4YKtwBpDvM7hCEop2Im/ezS82dliqJpkh9pvS6ve8HcUsBDvESHxMmUfImXR03GkmfdDynyrh/pUJnlguw==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+    peerDependencies:
+      synckit: ^0.11.11
+    peerDependenciesMeta:
+      synckit:
+        optional: true
 
   unzipper@0.10.14:
     resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
@@ -13529,7 +13740,7 @@ snapshots:
 
   '@dual-bundle/import-meta-resolve@4.2.1': {}
 
-  '@emnapi/core@1.7.0':
+  '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
       tslib: 2.8.1
@@ -15340,16 +15551,23 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.7.0
+      '@emnapi/core': 1.7.1
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.7.0
+      '@emnapi/core': 1.7.1
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.9.0
+
+  '@napi-rs/wasm-runtime@1.1.0':
+    dependencies:
+      '@emnapi/core': 1.7.1
+      '@emnapi/runtime': 1.7.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
 
   '@next/bundle-analyzer@16.1.1':
     dependencies:
@@ -15802,6 +16020,8 @@ snapshots:
 
   '@orama/stopwords@3.1.18': {}
 
+  '@oxc-project/types@0.103.0': {}
+
   '@panva/hkdf@1.2.1': {}
 
   '@pkgjs/parseargs@0.11.0':
@@ -15839,6 +16059,10 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@popperjs/core@2.11.8': {}
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
 
   '@radix-ui/number@1.1.1': {}
 
@@ -16618,6 +16842,51 @@ snapshots:
       '@react-spring/types': 9.7.5
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@rolldown/binding-android-arm64@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.57':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.0
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.53': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.57': {}
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     optional: true
@@ -18038,6 +18307,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.53
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -18300,6 +18581,8 @@ snapshots:
 
   ansi-styles@6.2.3: {}
 
+  ansis@4.2.0: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -18461,6 +18744,11 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-kit@2.2.0:
+    dependencies:
+      '@babel/parser': 7.28.5
+      pathe: 2.0.3
+
   ast-metadata-inferer@0.8.1:
     dependencies:
       '@mdn/browser-compat-data': 5.7.6
@@ -18620,6 +18908,8 @@ snapshots:
       buffers: 0.1.1
       chainsaw: 0.1.0
 
+  birpc@4.0.0: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -18710,6 +19000,8 @@ snapshots:
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
+
+  cac@6.7.14: {}
 
   cacache@19.0.1:
     dependencies:
@@ -19322,6 +19614,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.4: {}
+
   delaunator@5.0.1:
     dependencies:
       robust-predicates: 3.0.2
@@ -19408,6 +19702,8 @@ snapshots:
 
   dotenv@16.6.1: {}
 
+  dts-resolver@2.1.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -19439,6 +19735,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@2.0.0: {}
 
   encodeurl@1.0.2: {}
 
@@ -20863,6 +21161,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hookable@6.0.1: {}
+
   hookified@1.13.0: {}
 
   hosted-git-info@2.8.9: {}
@@ -20995,6 +21295,8 @@ snapshots:
       resolve-cwd: 3.0.0
 
   import-meta-resolve@4.2.0: {}
+
+  import-without-cache@0.2.5: {}
 
   imurmurhash@0.1.4: {}
 
@@ -23402,6 +23704,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  quansync@1.0.0: {}
+
   queue-microtask@1.2.3: {}
 
   quick-lru@4.0.1: {}
@@ -23562,6 +23866,8 @@ snapshots:
   react-is@19.2.0: {}
 
   react-refresh@0.14.2: {}
+
+  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.3):
     dependencies:
@@ -23919,13 +24225,49 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rollup-plugin-visualizer@6.0.5(rollup@4.52.5):
+  rolldown-plugin-dts@0.20.0(rolldown@1.0.0-beta.57)(typescript@5.9.3):
+    dependencies:
+      '@babel/generator': 7.28.5
+      '@babel/parser': 7.28.5
+      '@babel/types': 7.28.5
+      ast-kit: 2.2.0
+      birpc: 4.0.0
+      dts-resolver: 2.1.3
+      get-tsconfig: 4.13.0
+      obug: 2.1.1
+      rolldown: 1.0.0-beta.57
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - oxc-resolver
+
+  rolldown@1.0.0-beta.57:
+    dependencies:
+      '@oxc-project/types': 0.103.0
+      '@rolldown/pluginutils': 1.0.0-beta.57
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.57
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.57
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.57
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.57
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.57
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.57
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.57
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.57
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.57
+      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.57
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.57
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.57
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.57
+
+  rollup-plugin-visualizer@6.0.5(rolldown@1.0.0-beta.57)(rollup@4.52.5):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
+      rolldown: 1.0.0-beta.57
       rollup: 4.52.5
 
   rollup@4.52.5:
@@ -24764,6 +25106,33 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tsdown@0.18.4(typescript@5.9.3):
+    dependencies:
+      ansis: 4.2.0
+      cac: 6.7.14
+      defu: 6.1.4
+      empathic: 2.0.0
+      hookable: 6.0.1
+      import-without-cache: 0.2.5
+      obug: 2.1.1
+      picomatch: 4.0.3
+      rolldown: 1.0.0-beta.57
+      rolldown-plugin-dts: 0.20.0(rolldown@1.0.0-beta.57)(typescript@5.9.3)
+      semver: 7.7.3
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+      unconfig-core: 7.4.2
+      unrun: 0.2.21
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@ts-macro/tsc'
+      - '@typescript/native-preview'
+      - oxc-resolver
+      - synckit
+      - vue-tsc
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -24876,6 +25245,11 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
+  unconfig-core@7.4.2:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
@@ -24982,6 +25356,10 @@ snapshots:
       '@unrs/resolver-binding-win32-arm64-msvc': 1.11.1
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
+
+  unrun@0.2.21:
+    dependencies:
+      rolldown: 1.0.0-beta.57
 
   unzipper@0.10.14:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,12 @@ importers:
       '@babel/plugin-transform-react-constant-elements':
         specifier: 7.27.1
         version: 7.27.1(@babel/core@7.28.5)
+      babel-plugin-module-resolver:
+        specifier: ^5.0.2
+        version: 5.0.2
+      baseline-browser-mapping:
+        specifier: 2.9.14
+        version: 2.9.14
       eslint-plugin-n:
         specifier: 17.23.1
         version: 17.23.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -504,9 +510,9 @@ importers:
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.3
         version: 1000.1.3
-      '@vitejs/plugin-react':
-        specifier: ^5.1.2
-        version: 5.1.2(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@rollup/plugin-babel':
+        specifier: ^6.1.0
+        version: 6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.52.5)
       '@vitest/eslint-plugin':
         specifier: ^1.6.4
         version: 1.6.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
@@ -664,6 +670,9 @@ importers:
       prettier:
         specifier: 3.7.4
         version: 3.7.4
+      rolldown:
+        specifier: ^1.0.0-beta.53
+        version: 1.0.0-beta.57
       serve:
         specifier: 14.2.5
         version: 14.2.5
@@ -4953,11 +4962,30 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.53':
-    resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
-
   '@rolldown/pluginutils@1.0.0-beta.57':
     resolution: {integrity: sha512-aQNelgx14tGA+n2tNSa9x6/jeoCL9fkDeCei7nOKnHx0fEFRRMu5ReiITo+zZD5TzWDGGRjbSYCs93IfRIyTuQ==}
+
+  '@rollup/plugin-babel@6.1.0':
+    resolution: {integrity: sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      '@types/babel__core': ^7.1.9
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      '@types/babel__core':
+        optional: true
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     resolution: {integrity: sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==}
@@ -5965,12 +5993,6 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitejs/plugin-react@5.1.2':
-    resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
-
   '@vitest/coverage-v8@4.0.16':
     resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
     peerDependencies:
@@ -6373,6 +6395,9 @@ packages:
     resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
     engines: {node: '>=10', npm: '>=6'}
 
+  babel-plugin-module-resolver@5.0.2:
+    resolution: {integrity: sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==}
+
   babel-plugin-optimize-clsx@2.6.2:
     resolution: {integrity: sha512-TxgyjdVb7trTAsg/J5ByqJdbBPTYR8yaWLGQGpSxwygw8IFST5gEc1J9QktCGCHCb+69t04DWg9KOE0y2hN30w==}
 
@@ -6423,8 +6448,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.24:
-    resolution: {integrity: sha512-uUhTRDPXamakPyghwrUcjaGvvBqGrWvBHReoiULMIpOJVM9IYzQh83Xk2Onx5HlGI2o10NNCzcs9TG/S3TkwrQ==}
+  baseline-browser-mapping@2.9.14:
+    resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
     hasBin: true
 
   basic-auth@2.0.1:
@@ -7645,6 +7670,9 @@ packages:
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -7791,6 +7819,9 @@ packages:
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
     engines: {node: '>= 0.8'}
+
+  find-babel-config@2.1.2:
+    resolution: {integrity: sha512-ZfZp1rQyp4gyuxqt1ZqjFGVeVBvmpURMqdIWXbPRfB97Bf6BzdK/xSIbylEINzQ0kB5tlDQfn9HkNXXWsqTqLg==}
 
   find-cache-dir@3.3.2:
     resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
@@ -10449,10 +10480,6 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
-  react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
-    engines: {node: '>=0.10.0'}
-
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -10668,6 +10695,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@4.1.8:
+    resolution: {integrity: sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==}
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
@@ -16884,9 +16914,26 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-beta.57':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.53': {}
-
   '@rolldown/pluginutils@1.0.0-beta.57': {}
+
+  '@rollup/plugin-babel@6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.52.5)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/helper-module-imports': 7.27.1
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.5)
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
+      rollup: 4.52.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@rollup/pluginutils@5.3.0(rollup@4.52.5)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.52.5
 
   '@rollup/rollup-android-arm-eabi@4.52.5':
     optional: true
@@ -18307,18 +18354,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
-      '@rolldown/pluginutils': 1.0.0-beta.53
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -18802,6 +18837,14 @@ snapshots:
       cosmiconfig: 7.1.0
       resolve: 1.22.11
 
+  babel-plugin-module-resolver@5.0.2:
+    dependencies:
+      find-babel-config: 2.1.2
+      glob: 9.3.5
+      pkg-up: 3.1.0
+      reselect: 4.1.8
+      resolve: 1.22.11
+
   babel-plugin-optimize-clsx@2.6.2:
     dependencies:
       '@babel/generator': 7.28.5
@@ -18867,7 +18910,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.24: {}
+  baseline-browser-mapping@2.9.14: {}
 
   basic-auth@2.0.1:
     dependencies:
@@ -18965,7 +19008,7 @@ snapshots:
 
   browserslist@4.27.0:
     dependencies:
-      baseline-browser-mapping: 2.8.24
+      baseline-browser-mapping: 2.9.14
       caniuse-lite: 1.0.30001760
       electron-to-chromium: 1.5.244
       node-releases: 2.0.27
@@ -20346,6 +20389,8 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/unist': 3.0.3
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -20568,6 +20613,10 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  find-babel-config@2.1.2:
+    dependencies:
+      json5: 2.2.3
 
   find-cache-dir@3.3.2:
     dependencies:
@@ -22895,7 +22944,7 @@ snapshots:
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.8.24
+      baseline-browser-mapping: 2.9.14
       caniuse-lite: 1.0.30001760
       postcss: 8.4.31
       react: 19.2.3
@@ -23867,8 +23916,6 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
-  react-refresh@0.18.0: {}
-
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -24179,6 +24226,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   requires-port@1.0.0: {}
+
+  reselect@4.1.8: {}
 
   reselect@5.1.1: {}
 


### PR DESCRIPTION
Adds a new `code-infra` cli `build-new` which is equivalent to the current `build` cli with a subset of flags as in `build`.
The new cli is an abstraction over the tsdown api which configures tsdown by getting the entrypoint from the package.json `exports` globs and then writes a new `package.json` in the `build` directory.

Repo PRs -

1. https://github.com/mui/base-ui/pull/3557
2. https://github.com/mui/mui-x/pull/19400
