### PR TITLE
[code-infra][bundle-sizes] Improve externals handling

### DIFF
--- a/packages/bundle-size-checker/src/builder.js
+++ b/packages/bundle-size-checker/src/builder.js
@@ -75,7 +75,7 @@ async function createViteConfig(entry, args) {
       emptyOutDir: true,
       rollupOptions: {
         input: '/index.tsx',
-        external: (id) => externalsArray.some((ext) => id === ext || id.startsWith(ext + '/')),
+        external: (id) => externalsArray.some((ext) => id === ext || id.startsWith(`${ext}/`)),
         plugins: [
           ...(args.analyze
             ? [


### PR DESCRIPTION
Handle externals better. Make sure to externalize `@mui/material`, but also `@mui/material/Button`. Fix node env to `'production'`.