### PR TITLE
[code-infra] Validate package.json fields before building

### DIFF
--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -16,6 +16,7 @@ import { getOutExtension, isMjsBuild, validatePkgJson } from '../utils/build.mjs
  * @property {boolean} skipTsc - Whether to build types for the package.
  * @property {boolean} skipBabelRuntimeCheck - Whether to skip checking for Babel runtime dependencies in the package.
  * @property {boolean} skipPackageJson - Whether to skip generating the package.json file in the bundle output.
+ * @property {boolean} skipMainCheck - Whether to skip checking for main field in package.json.
  * @property {string[]} ignore - Globs to be ignored by Babel.
  */
 
@@ -291,6 +292,12 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         type: 'boolean',
         default: false,
         description: 'Skip generating the package.json file in the bundle output.',
+      })
+      .option('skipMainCheck', {
+        // Currently added only to support @mui/icons-material. To be removed separately.
+        type: 'boolean',
+        default: false,
+        description: 'Skip checking for main field in package.json.',
       });
   },
   async handler(args) {
@@ -310,7 +317,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     const cwd = process.cwd();
     const pkgJsonPath = path.join(cwd, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(pkgJsonPath, { encoding: 'utf8' }));
-    validatePkgJson(packageJson);
+    validatePkgJson(packageJson, { skipMainCheck: args.skipMainCheck });
 
     const buildDirBase = /** @type {string} */ (packageJson.publishConfig?.directory);
     const buildDir = path.join(cwd, buildDirBase);

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -22,8 +22,11 @@ export function getOutExtension(bundle, isType = false) {
 /**
  * Validates the package.json before building.
  * @param {Record<string, any>} packageJson
+ * @param {Object} [options]
+ * @param {boolean} [options.skipMainCheck=false] - Whether to skip checking for main field in package.json.
  */
-export function validatePkgJson(packageJson) {
+export function validatePkgJson(packageJson, options = {}) {
+  const { skipMainCheck = false } = options;
   /**
    * @type {string[]}
    */
@@ -40,22 +43,24 @@ export function validatePkgJson(packageJson) {
     );
   }
 
-  if (packageJson.main) {
-    errors.push(
-      `Remove the field "main" from "${packageJson.name}" package.json. Add it as "exports["."]" instead.`,
-    );
-  }
+  if (!skipMainCheck) {
+    if (packageJson.main) {
+      errors.push(
+        `Remove the field "main" from "${packageJson.name}" package.json. Add it as "exports["."]" instead.`,
+      );
+    }
 
-  if (packageJson.module) {
-    errors.push(
-      `Remove the field "module" from "${packageJson.name}" package.json. Add it as "exports["."]" instead.`,
-    );
-  }
+    if (packageJson.module) {
+      errors.push(
+        `Remove the field "module" from "${packageJson.name}" package.json. Add it as "exports["."]" instead.`,
+      );
+    }
 
-  if (packageJson.types || packageJson.typings) {
-    errors.push(
-      `Remove the field "types/typings" from "${packageJson.name}" package.json. Add it as "exports["."]" instead.`,
-    );
+    if (packageJson.types || packageJson.typings) {
+      errors.push(
+        `Remove the field "types/typings" from "${packageJson.name}" package.json. Add it as "exports["."]" instead.`,
+      );
+    }
   }
 
   if (errors.length > 0) {


### PR DESCRIPTION
Moved some existing validations to a function and also added checks for existence of `main`/`module`/`types`.

Migrations PRs -

1. https://github.com/mui/mui-x/pull/19407
2. https://github.com/mui/material-ui/pull/46856
3. Base UI is not affected since it doesn't have `main` field.

fixes #503