### PR TITLE
[code-infra] Improve ci workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: PR Package releases
 on:
+  pull_request:
   push:
-    branches-ignore:
-      # Renovate branches are always Pull Requests.
-      # We don't need to run CI twice (push+pull_request)
-      - 'renovate/**'
-      - 'dependabot/**'
+    branches:
+      - master
+      - next
+      - v*.x
 
 permissions: {}
 


### PR DESCRIPTION
Problem:

- it's running twice for each pull request
- it's not running for renovate pull requests, see https://github.com/mui/mui-public/pull/631

Solution:

- add the `pull_request` trigger
- configure `branches` for the `push` trigger instead of ignore

Supplying the `next` and `v*.x` release branches as well. It doesn't do much on this repo, but will propagate this to other repos and that way it can stay the same across the org. I noticed at least `mui/material-ui` suffers from the same problem