### PR TITLE
[infra] Ignore null exports in bundle size checker

### DIFF
--- a/packages/bundle-size-checker/src/configLoader.js
+++ b/packages/bundle-size-checker/src/configLoader.js
@@ -88,6 +88,10 @@ export function applyUploadConfigDefaults(uploadConfig, ciInfo) {
 function findExports(exportsObj) {
   const paths = [];
   for (const [key, value] of Object.entries(exportsObj)) {
+    // ignore null values
+    if (!value) {
+      continue;
+    }
     if (key.startsWith('.')) {
       paths.push(key);
     } else {


### PR DESCRIPTION
when expanding entries from package.json, ie

```json
{
  "./esm": null
}
```