### PR TITLE
[code-infra] Try to disable node-version updates in github actions

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -55,9 +55,15 @@
     },
     {
       "groupName": "node",
-      "matchDatasources": ["docker", "node-version"],
-      "matchPackageNames": ["@types/node", "node", "cimg/node", "actions/setup-node"],
-      "enabled": false
+      "matchDatasources": ["node-version"],
+      "matchPackageNames": ["@types/node", "node", "cimg/node"],
+      "allowedVersions": "<=22.18"
+    },
+    {
+      "groupName": "node-version",
+      "description": "Restricts Node.js version bumps in Github Actions workflows.",
+      "matchDepTypes": ["uses-with"],
+      "allowedVersions": "<=22.18"
     },
     {
       "groupName": "eslint",
@@ -70,7 +76,8 @@
     },
     {
       "groupName": "Vite & Vitest",
-      "matchPackageNames": ["vite", "@vitejs/**", "/vitest/", "esbuild", "^vitest$", "^@vitest/"]
+      "extends": ["packages:vite", "monorepo:vitest"],
+      "matchPackageNames": ["esbuild"]
     },
     {
       "matchPackageNames": ["eslint-config-prettier"],


### PR DESCRIPTION
Mainly experimenting here to stop renovate from updating the value of `node-version` in github actions.

Fixes #643

Also consolidation Vite packages with a preset.

