### PR TITLE
[code-infra] Automatically add @mui/infra as reviewer to infra updates

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -35,7 +35,8 @@
       "groupName": "MUI infra packages",
       "matchPackageNames": ["@mui/internal-*", "@mui/docs"],
       "followTag": "canary",
-      "schedule": null
+      "schedule": null,
+      "additionalReviewers": ["@mui/infra"]
     },
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
Automatically assign the team as reviewer. Potentially closes https://github.com/mui/mui-public/issues/572, but let's test first