### PR TITLE
[code-infra] Make sure `useIsoLayoutEffect` is tested by `react-hooks/exhaustive-deps`

### DIFF
--- a/packages/code-infra/src/eslint/material-ui/config.mjs
+++ b/packages/code-infra/src/eslint/material-ui/config.mjs
@@ -411,7 +411,10 @@ export function createCoreConfig(options = {}) {
         'material-ui/no-styled-box': 'error',
         'material-ui/straight-quotes': 'off',
 
-        'react-hooks/exhaustive-deps': ['error', { additionalHooks: 'useEnhancedEffect' }],
+        'react-hooks/exhaustive-deps': [
+          'error',
+          { additionalHooks: '(useEnhancedEffect|useIsoLayoutEffect)' },
+        ],
         'react-hooks/rules-of-hooks': 'error',
 
         'react/default-props-match-prop-types': [


### PR DESCRIPTION
This caused a few issues on the Scheduler and I'm surprised it's not more problematic on Base UI (unless they patch their config to add it).

The `useIsoLayoutEffect` is the new name of the `useEnhancedEffect` hook in the Base UI utils package.