### PR TITLE
[code-infra] Merge copy command with build

### DIFF
--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -1,9 +1,13 @@
 /* eslint-disable no-console */
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
 import { $ } from 'execa';
+import { globby } from 'globby';
 import set from 'lodash-es/set.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { getOutExtension, isMjsBuild, validatePkgJson } from '../utils/build.mjs';
+import { sep as posixSep } from 'node:path/posix';
+
+import { getOutExtension, isMjsBuild, mapConcurrently, validatePkgJson } from '../utils/build.mjs';
 
 /**
  * @typedef {Object} Args
@@ -18,6 +22,7 @@ import { getOutExtension, isMjsBuild, validatePkgJson } from '../utils/build.mjs
  * @property {boolean} skipPackageJson - Whether to skip generating the package.json file in the bundle output.
  * @property {boolean} skipMainCheck - Whether to skip checking for main field in package.json.
  * @property {string[]} ignore - Globs to be ignored by Babel.
+ * @property {string[]} [copy] - Files/Directories to be copied. Can be a glob pattern.
  */
 
 const validBundles = [
@@ -298,6 +303,13 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         type: 'boolean',
         default: false,
         description: 'Skip checking for main field in package.json.',
+      })
+      .option('copy', {
+        type: 'string',
+        array: true,
+        description:
+          'Files/Directories to be copied to the output directory. Can be a glob pattern.',
+        default: [],
       });
   },
   async handler(args) {
@@ -442,5 +454,144 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       outputDir: buildDir,
       addTypes: buildTypes,
     });
+
+    await copyHandler({
+      cwd,
+      globs: args.copy ?? [],
+      buildDir,
+      verbose: args.verbose,
+    });
   },
 });
+
+/**
+ * @param {Object} param0
+ * @param {string} param0.cwd - The current working directory.
+ * @param {string[]} [param0.globs=[]] - Extra files to copy, can be specified as `source:target` pairs or just `source`.
+ * @param {string} param0.buildDir - The build directory to copy to.
+ * @param {boolean} [param0.verbose=false] - Whether to suppress output.
+ * @returns {Promise<void>}
+ */
+async function copyHandler({ cwd, globs = [], buildDir, verbose = false }) {
+  /**
+   * @type {(string|{targetPath: string; sourcePath: string})[]}
+   */
+  const defaultFiles = [];
+  const workspaceDir = await findWorkspaceDir(cwd);
+  if (!workspaceDir) {
+    throw new Error('Workspace directory not found');
+  }
+
+  const localOrRootFiles = [
+    [path.join(cwd, 'README.md'), path.join(workspaceDir, 'README.md')],
+    [path.join(cwd, 'LICENSE'), path.join(workspaceDir, 'LICENSE')],
+    [path.join(cwd, 'CHANGELOG.md'), path.join(workspaceDir, 'CHANGELOG.md')],
+  ];
+  await Promise.all(
+    localOrRootFiles.map(async (filesToCopy) => {
+      for (const file of filesToCopy) {
+        if (
+          // eslint-disable-next-line no-await-in-loop
+          await fs.stat(file).then(
+            () => true,
+            () => false,
+          )
+        ) {
+          defaultFiles.push(file);
+          break;
+        }
+      }
+    }),
+  );
+
+  if (globs.length) {
+    const res = globs.map((globPattern) => {
+      const [pattern, baseDir] = globPattern.split(':');
+      return { pattern, baseDir };
+    });
+    /**
+     * Avoids redundant globby calls for the same pattern.
+     *
+     * @type {Map<string, Promise<string[]>>}
+     */
+    const globToResMap = new Map();
+
+    const result = await Promise.all(
+      res.map(async ({ pattern, baseDir }) => {
+        if (!globToResMap.has(pattern)) {
+          const promise = globby(pattern, { cwd });
+          globToResMap.set(pattern, promise);
+        }
+        const files = await globToResMap.get(pattern);
+        return { files: files ?? [], baseDir };
+      }),
+    );
+    globToResMap.clear();
+
+    result.forEach(({ files, baseDir }) => {
+      files.forEach((file) => {
+        const sourcePath = path.resolve(cwd, file);
+        // Use posix separator for the relative paths. So devs can only specify globs with `/` even on Windows.
+        const pathSegments = file.split(posixSep);
+        const relativePath =
+          // Use index 2 (when required) since users can also specify paths like `./src/index.js`
+          pathSegments.slice(pathSegments[0] === '.' ? 2 : 1).join(posixSep) || file;
+        const targetPath = baseDir
+          ? path.resolve(buildDir, baseDir, relativePath)
+          : path.resolve(buildDir, relativePath);
+        defaultFiles.push({ sourcePath, targetPath });
+      });
+    });
+  }
+
+  if (!defaultFiles.length) {
+    if (verbose) {
+      console.log('⓿ No files to copy.');
+    }
+  }
+  await mapConcurrently(
+    defaultFiles,
+    async (file) => {
+      if (typeof file === 'string') {
+        const sourcePath = file;
+        const fileName = path.basename(file);
+        const targetPath = path.join(buildDir, fileName);
+        await recursiveCopy({ source: sourcePath, target: targetPath, verbose });
+      } else {
+        await fs.mkdir(path.dirname(file.targetPath), { recursive: true });
+        await recursiveCopy({ source: file.sourcePath, target: file.targetPath, verbose });
+      }
+    },
+    20,
+  );
+  console.log(`📋 Copied ${defaultFiles.length} files.`);
+}
+
+/**
+ * Recursively copies files and directories from a source path to a target path.
+ *
+ * @async
+ * @param {Object} options - The options for copying files.
+ * @param {string} options.source - The source path to copy from.
+ * @param {string} options.target - The target path to copy to.
+ * @param {boolean} [options.verbose=true] - If true, suppresses console output.
+ * @returns {Promise<boolean>} Resolves when the copy operation is complete.
+ * @throws {Error} Throws if an error occurs other than the source not existing.
+ */
+async function recursiveCopy({ source, target, verbose = true }) {
+  try {
+    await fs.cp(source, target, { recursive: true });
+    if (verbose) {
+      console.log(`Copied ${source} to ${target}`);
+    }
+    return true;
+  } catch (err) {
+    if (/** @type {{ code: string }} */ (err).code !== 'ENOENT') {
+      throw err;
+    }
+    if (verbose) {
+      console.warn(`Source does not exist: ${source}`);
+    }
+    throw err;
+  }
+}

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/mui/mui-public/tree/master/packages/docs-infra",
   "scripts": {
-    "build": "code-infra build --bundle esm && pnpm build:copy-files",
-    "build:copy-files": "code-infra copy-files",
+    "build": "code-infra build --bundle esm",
     "test": "exit 0",
     "typescript": "tsc -p tsconfig.json"
   },


### PR DESCRIPTION
Closes #608 
Closes https://github.com/mui/mui-public/issues/674

`copy-files` command to be removed in a separate PR once other repos are migrated away from using the command.

Also updated the init script of cli to log duration taken to run each command.

Repo PRs -

1. https://github.com/mui/mui-x/pull/19518
2. https://github.com/mui/material-ui/pull/46902