### PR TITLE
[code-infra] Make sure `eslint-plugin-n` ends up in the eslint group

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -69,6 +69,10 @@
       "extends": ["monorepo:eslint", "monorepo:typescript-eslint"]
     },
     {
+      "groupName": "eslint",
+      "matchPackageNames": ["eslint-plugin-*"]
+    },
+    {
       "groupName": "playwright monorepo",
       "description": "Extends existing playwright preset to include docker images. See https://github.com/renovatebot/renovate/discussions/23889",
       "matchPackageNames": ["mcr.microsoft.com/playwright"]


### PR DESCRIPTION
Currently it's updated as part of dev depndencies
Separate rule as we want to add more deps to the existing group, instead of filtering the existing group.