### PR TITLE
[code-infra] Widen vite group

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -79,7 +79,14 @@
     },
     {
       "groupName": "Vite & Vitest",
-      "extends": ["packages:vite", "monorepo:vitest"],
+      "extends": ["packages:vite"]
+    },
+    {
+      "groupName": "Vite & Vitest",
+      "extends": ["monorepo:vitest"]
+    },
+    {
+      "groupName": "Vite & Vitest",
       "matchPackageNames": ["esbuild"]
     },
     {


### PR DESCRIPTION
I saw vite being grouped into the [devdependencies group](https://github.com/mui/mui-public/pull/701), but they should be in "vite & vitest"
I believe we need separate rules as to avoid the combined rules from making the group too narrow