### PR TITLE
Add Benchmarking Pages to Docs

### DIFF
--- a/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContent.module.css
+++ b/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContent.module.css
@@ -1,0 +1,14 @@
+.code {
+  margin: 1rem 0;
+  background: #f6f8fa;
+  border: 1px solid #e1e5e9;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.codeBlock {
+  margin: 0;
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}

--- a/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContent.module.css
+++ b/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContent.module.css
@@ -1,7 +1,7 @@
 .code {
   margin: 1rem 0;
-  background: #f6f8fa;
-  border: 1px solid #e1e5e9;
+  background: #fdfcfe;
+  border: 1px solid #d0cdd7;
   border-radius: 8px;
   overflow-x: auto;
 }

--- a/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContent.tsx
+++ b/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContent.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ContentProps } from '@mui/internal-docs-infra/CodeHighlighter/types';
+import { useCode } from '@mui/internal-docs-infra/useCode';
+
+import styles from './CodeContent.module.css';
+
+import '@wooorm/starry-night/style/light';
+
+export function CodeContent(props: ContentProps<{}>) {
+  const code = useCode(props, { preClassName: styles.codeBlock });
+
+  return <div className={styles.code}>{code.selectedFile}</div>;
+}

--- a/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContentLoading.tsx
+++ b/docs/app/bench/docs-infra/components/code-highlighter/demos/CodeContentLoading.tsx
@@ -1,0 +1,17 @@
+import 'server-only';
+
+import * as React from 'react';
+import type { ContentLoadingProps } from '@mui/internal-docs-infra/CodeHighlighter/types';
+import styles from './CodeContent.module.css';
+
+import '@wooorm/starry-night/style/light';
+
+export function CodeContentLoading(props: ContentLoadingProps<{}>) {
+  return (
+    <div>
+      <div className={styles.code}>
+        <pre className={styles.codeBlock}>{props.source}</pre>
+      </div>
+    </div>
+  );
+}

--- a/docs/app/bench/docs-infra/components/code-highlighter/demos/code/index.ts
+++ b/docs/app/bench/docs-infra/components/code-highlighter/demos/code/index.ts
@@ -1,0 +1,4 @@
+import { createDemoPerformance } from '@/functions/createDemoPerformance';
+import Page from './page';
+
+export const DemoCodeHighlighterPerformance = createDemoPerformance(import.meta.url, Page);

--- a/docs/app/bench/docs-infra/components/code-highlighter/demos/code/page.tsx
+++ b/docs/app/bench/docs-infra/components/code-highlighter/demos/code/page.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { createParseSource } from '@mui/internal-docs-infra/pipeline/parseSource';
+import { CodeHighlighter } from '@mui/internal-docs-infra/CodeHighlighter';
+
+import { CodeContent } from '../CodeContent';
+import { CodeContentLoading } from '../CodeContentLoading';
+
+import code from '../../snippets/large/snippet';
+
+const sourceParser = createParseSource();
+
+export default function Page() {
+  return (
+    <CodeHighlighter
+      Content={CodeContent}
+      ContentLoading={CodeContentLoading}
+      sourceParser={sourceParser}
+      fileName="large-file.js"
+    >
+      {code}
+    </CodeHighlighter>
+  );
+}

--- a/docs/app/bench/docs-infra/components/code-highlighter/page.mdx
+++ b/docs/app/bench/docs-infra/components/code-highlighter/page.mdx
@@ -1,0 +1,9 @@
+# Benchmarking Code Highlighter
+
+This demo showcases the performance of the [`CodeHighlighter`](../../../../docs-infra/components/code-highlighter/page.mdx) component when handling large code snippets. It uses RSC to highlight the code.
+
+import { DemoCodeHighlighterPerformance } from './demos/code';
+
+<DemoCodeHighlighterPerformance />
+
+[See Setup](./demos/code/)

--- a/docs/app/bench/docs-infra/components/code-highlighter/snippets/large/snippet.ts
+++ b/docs/app/bench/docs-infra/components/code-highlighter/snippets/large/snippet.ts
@@ -1,0 +1,1481 @@
+const snippet: string = `// @ts-check
+
+const { declare } = require('@babel/helper-plugin-utils');
+
+/**
+ * @typedef {import('@babel/core')} babel
+ * @typedef {{ id: babel.types.Expression, computed?: boolean }} ComponentIdentifier
+ */
+
+// remember to set \`cacheDirectory\` to \`false\` when modifying this plugin
+
+const DEFAULT_ALLOWED_CALLEES = {
+  react: ['createContext', 'forwardRef', 'memo'],
+};
+
+/** @type {Map<string, string[]>} */
+const calleeModuleMapping = new Map(); // Mapping of callee name to module name
+const seenDisplayNames = new Set();
+
+/**
+ * Applies allowed callees mapping to the internal calleeModuleMapping.
+ * @param {Record<string, string[]>} mapping - The mapping of module names to method names.
+ */
+function applyAllowedCallees(mapping) {
+  Object.entries(mapping).forEach(([moduleName, methodNames]) => {
+    methodNames.forEach((methodName) => {
+      const moduleNames = calleeModuleMapping.get(methodName) ?? [];
+      moduleNames.push(moduleName);
+      calleeModuleMapping.set(methodName, moduleNames);
+    });
+  });
+}
+
+module.exports = declare((api, options) => {
+  api.assertVersion(7);
+
+  calleeModuleMapping.clear();
+
+  applyAllowedCallees(DEFAULT_ALLOWED_CALLEES);
+
+  if (options.allowedCallees) {
+    applyAllowedCallees(options.allowedCallees);
+  }
+
+  const t = api.types;
+
+  return {
+    name: '@probablyup/babel-plugin-react-displayname',
+    visitor: {
+      Program() {
+        // We allow duplicate names across files,
+        // so we clear when we're transforming on a new file
+        seenDisplayNames.clear();
+      },
+      'FunctionExpression|ArrowFunctionExpression|ObjectMethod': (
+        /** @type {babel.NodePath<babel.types.FunctionExpression|babel.types.ArrowFunctionExpression|babel.types.ObjectMethod>} */ path,
+      ) => {
+        // if the parent is a call expression, make sure it's an allowed one
+        if (
+          path.parentPath && path.parentPath.isCallExpression()
+            ? isAllowedCallExpression(t, path.parentPath)
+            : true
+        ) {
+          if (doesReturnJSX(t, path.node.body)) {
+            addDisplayNamesToFunctionComponent(t, path);
+          }
+        }
+      },
+      CallExpression(path) {
+        if (isAllowedCallExpression(t, path)) {
+          addDisplayNamesToFunctionComponent(t, path);
+        }
+      },
+    },
+  };
+});
+
+/**
+ * Checks if this function returns JSX nodes.
+ * It does not do type-checking, which means calling
+ * other functions that return JSX will still return \`false\`.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.types.Statement | babel.types.Expression} node function node
+ */
+function doesReturnJSX(t, node) {
+  if (!node) {
+    return false;
+  }
+
+  const body = t.toBlock(node).body;
+  if (!body) {
+    return false;
+  }
+
+  return body.some((statement) => {
+    /** @type {babel.Node | null | undefined} */
+    let currentNode;
+
+    if (t.isReturnStatement(statement)) {
+      currentNode = statement.argument;
+    } else if (
+      t.isExpressionStatement(statement) &&
+      !t.isCallExpression(statement.expression)
+    ) {
+      currentNode = statement.expression;
+    } else {
+      return false;
+    }
+
+    if (
+      t.isCallExpression(currentNode) &&
+      // detect *.createElement and count it as returning JSX
+      // this could be improved a lot but will work for the 99% case
+      t.isMemberExpression(currentNode.callee) &&
+      t.isIdentifier(currentNode.callee.property) &&
+      currentNode.callee.property.name === 'createElement'
+    ) {
+      return true;
+    }
+
+    if (t.isConditionalExpression(currentNode)) {
+      return (
+        isJSX(t, currentNode.consequent) || isJSX(t, currentNode.alternate)
+      );
+    }
+
+    if (t.isLogicalExpression(currentNode)) {
+      return isJSX(t, currentNode.left) || isJSX(t, currentNode.right);
+    }
+
+    if (t.isArrayExpression(currentNode)) {
+      return currentNode.elements.some((ele) => isJSX(t, ele));
+    }
+
+    return isJSX(t, currentNode);
+  });
+}
+
+/**
+ * Checks if this node is JSXElement or JSXFragment,
+ * which are the root nodes of react components.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.Node | null | undefined} node babel node
+ */
+function isJSX(t, node) {
+  return t.isJSXElement(node) || t.isJSXFragment(node);
+}
+
+/**
+ * Checks if this path is an allowed CallExpression.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.NodePath<babel.types.CallExpression>} path path of callee
+ */
+function isAllowedCallExpression(t, path) {
+  const calleePath = path.get('callee');
+  const callee = /** @type {babel.types.Expression} */ path.node.callee;
+  /** @type {string | undefined} */
+  const calleeName =
+    /** @type {any} */ callee.name || /** @type {any} */ callee.property?.name;
+  const moduleNames = calleeName && calleeModuleMapping.get(calleeName);
+
+  if (!moduleNames) {
+    return false;
+  }
+
+  // If the callee is an identifier expression, then check if it matches
+  // a named import, e.g. \`import {createContext} from 'react'\`.
+  if (calleePath.isIdentifier()) {
+    return moduleNames.some((moduleName) =>
+      calleePath.referencesImport(moduleName, calleeName),
+    );
+  }
+
+  if (calleePath.isMemberExpression()) {
+    const object = calleePath.get('object');
+
+    return moduleNames.some(
+      (moduleName) =>
+        object.referencesImport(moduleName, 'default') ||
+        object.referencesImport(moduleName, '*'),
+    );
+  }
+
+  return false;
+}
+
+/**
+ * Adds displayName to the function component if it is:
+ *  - assigned to a variable or object path
+ *  - not within other JSX elements
+ *  - not called by a react hook or _createClass helper
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.NodePath<babel.types.FunctionExpression|babel.types.ArrowFunctionExpression|babel.types.ObjectMethod|babel.types.CallExpression>} path path of function
+ */
+function addDisplayNamesToFunctionComponent(t, path) {
+  /** @type {ComponentIdentifier[]} */
+  const componentIdentifiers = [];
+  if (/** @type {any} */ path.node.key) {
+    componentIdentifiers.push({ id: /** @type {any} */ path.node.key });
+  }
+
+  /** @type {babel.NodePath | undefined} */
+  let assignmentPath;
+  let hasCallee = false;
+  let hasObjectProperty = false;
+
+  const scopePath = path.scope.parent && path.scope.parent.path;
+  path.find((parentPath) => {
+    // we've hit the scope, stop going further up
+    if (parentPath === scopePath) {
+      return true;
+    }
+
+    // Ignore functions within jsx
+    if (isJSX(t, parentPath.node)) {
+      return true;
+    }
+
+    if (parentPath.isCallExpression()) {
+      // Ignore immediately invoked function expressions (IIFEs)
+      const callee =
+        /** @types {babel.types.Expression} */ parentPath.node.callee;
+      if (
+        t.isArrowFunctionExpression(callee) ||
+        t.isFunctionExpression(callee)
+      ) {
+        return true;
+      }
+
+      // Ignore instances where displayNames are disallowed
+      // _createClass(() => <Element />)
+      // useMemo(() => <Element />)
+      const calleeName = t.isIdentifier(callee) ? callee.name : undefined;
+      if (
+        calleeName &&
+        (calleeName.startsWith('_') || calleeName.startsWith('use'))
+      ) {
+        return true;
+      }
+
+      hasCallee = true;
+    }
+
+    // componentIdentifier = <Element />
+    if (parentPath.isAssignmentExpression()) {
+      assignmentPath = parentPath.parentPath;
+      componentIdentifiers.unshift({
+        id: /** @type {babel.types.Expression} */ parentPath.node.left,
+      });
+      return true;
+    }
+
+    // const componentIdentifier = <Element />
+    if (parentPath.isVariableDeclarator()) {
+      // Ternary expression
+      if (t.isConditionalExpression(parentPath.node.init)) {
+        const { consequent, alternate } = parentPath.node.init;
+        const isConsequentFunction =
+          t.isArrowFunctionExpression(consequent) ||
+          t.isFunctionExpression(consequent);
+        const isAlternateFunction =
+          t.isArrowFunctionExpression(alternate) ||
+          t.isFunctionExpression(alternate);
+
+        // Only add display name if variable is a function
+        if (!isConsequentFunction || !isAlternateFunction) {
+          return false;
+        }
+      }
+      assignmentPath = parentPath.parentPath;
+      componentIdentifiers.unshift({
+        id: /** @type {babel.types.Expression} */ parentPath.node.id,
+      });
+      return true;
+    }
+
+    // if this is not a continuous object key: value pair, stop processing it
+    if (
+      hasObjectProperty &&
+      !(parentPath.isObjectProperty() || parentPath.isObjectExpression())
+    ) {
+      return true;
+    }
+
+    // { componentIdentifier: <Element /> }
+    if (parentPath.isObjectProperty()) {
+      hasObjectProperty = true;
+      const node = parentPath.node;
+      componentIdentifiers.unshift({
+        id: /** @type {babel.types.Expression} */ node.key,
+        computed: node.computed,
+      });
+    }
+
+    return false;
+  });
+
+  if (!assignmentPath || componentIdentifiers.length === 0) {
+    return;
+  }
+
+  const name = generateDisplayName(t, componentIdentifiers);
+
+  const pattern = \`\${name}.displayName\`;
+
+  // disallow duplicate names if they were assigned in different scopes
+  if (
+    seenDisplayNames.has(name) &&
+    !hasBeenAssignedPrev(t, assignmentPath, pattern, name)
+  ) {
+    return;
+  }
+
+  // skip unnecessary addition of name if it is reassigned later on
+  if (hasBeenAssignedNext(t, assignmentPath, pattern)) {
+    return;
+  }
+
+  // at this point we're ready to start pushing code
+
+  if (hasCallee) {
+    // if we're getting called by some wrapper function,
+    // give this function a name
+    setInternalFunctionName(t, path, name);
+  }
+
+  const displayNameStatement = createDisplayNameStatement(
+    t,
+    componentIdentifiers,
+    name,
+  );
+
+  assignmentPath.insertAfter(displayNameStatement);
+
+  seenDisplayNames.add(name);
+}
+
+/**
+ * Generate a displayName string based on the ids collected.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {ComponentIdentifier[]} componentIdentifiers list of { id, computed } objects
+ */
+function generateDisplayName(t, componentIdentifiers) {
+  let displayName = '';
+  componentIdentifiers.forEach((componentIdentifier) => {
+    const node = componentIdentifier.id;
+    if (!node) {
+      return;
+    }
+    const name = generateNodeDisplayName(t, node);
+    displayName += componentIdentifier.computed ? \`[\${name}]\` : \`.\${name}\`;
+  });
+
+  return displayName.slice(1);
+}
+
+/**
+ * Generate a displayName string based on the node.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.Node} node identifier or member expression node
+ * @returns {string}
+ */
+function generateNodeDisplayName(t, node) {
+  if (t.isIdentifier(node)) {
+    return node.name;
+  }
+
+  if (t.isMemberExpression(node)) {
+    const objectDisplayName = generateNodeDisplayName(t, node.object);
+    const propertyDisplayName = generateNodeDisplayName(t, node.property);
+
+    const res = node.computed
+      ? \`\${objectDisplayName}[\${propertyDisplayName}]\`
+      : \`\${objectDisplayName}.\${propertyDisplayName}\`;
+    return res;
+  }
+
+  return '';
+}
+
+/**
+ * Checks if this path has been previously assigned to a particular value.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.NodePath} assignmentPath path where assignement will take place
+ * @param {string} pattern assignment path in string form e.g. \`x.y.z\`
+ * @param {string} value assignment value to compare with
+ * @returns {boolean}
+ */
+function hasBeenAssignedPrev(t, assignmentPath, pattern, value) {
+  return assignmentPath.getAllPrevSiblings().some((sibling) => {
+    const expression = /** @type {babel.NodePath} */ sibling.get('expression');
+    if (!t.isAssignmentExpression(expression.node, { operator: '=' })) {
+      return false;
+    }
+    if (!t.isStringLiteral(expression.node.right, { value })) {
+      return false;
+    }
+    return /** @type {babel.NodePath} */ expression
+      .get('left')
+      .matchesPattern(pattern);
+  });
+}
+
+/**
+ * Checks if this path will be assigned later in the scope.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.NodePath} assignmentPath path where assignement will take place
+ * @param {string} pattern assignment path in string form e.g. \`x.y.z\`
+ * @returns {boolean}
+ */
+function hasBeenAssignedNext(t, assignmentPath, pattern) {
+  return assignmentPath.getAllNextSiblings().some((sibling) => {
+    const expression = /** @type {babel.NodePath} */ sibling.get('expression');
+    if (!t.isAssignmentExpression(expression.node, { operator: '=' })) {
+      return false;
+    }
+    return /** @type {babel.NodePath} */ expression
+      .get('left')
+      .matchesPattern(pattern);
+  });
+}
+
+/**
+ * Generate a displayName ExpressionStatement node based on the ids.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {ComponentIdentifier[]} componentIdentifiers list of { id, computed } objects
+ * @param {string} displayName name of the function component
+ */
+function createDisplayNameStatement(t, componentIdentifiers, displayName) {
+  const node = createMemberExpression(t, componentIdentifiers);
+
+  const expression = t.assignmentExpression(
+    '=',
+    t.memberExpression(node, t.identifier('displayName')),
+    t.stringLiteral(displayName),
+  );
+
+  const ifStatement = t.ifStatement(
+    t.binaryExpression(
+      '!==',
+      t.memberExpression(
+        t.memberExpression(t.identifier('process'), t.identifier('env')),
+        t.identifier('NODE_ENV'),
+      ),
+      t.stringLiteral('production'),
+    ),
+    t.expressionStatement(expression),
+  );
+
+  return ifStatement;
+}
+
+/**
+ * Helper that creates a MemberExpression node from the ids.
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {ComponentIdentifier[]} componentIdentifiers list of { id, computed } objects
+ * @returns {babel.types.Expression}
+ */
+function createMemberExpression(t, componentIdentifiers) {
+  let node = componentIdentifiers[0].id;
+  if (componentIdentifiers.length > 1) {
+    for (let i = 1; i < componentIdentifiers.length; i += 1) {
+      const { id, computed } = componentIdentifiers[i];
+      node = t.memberExpression(node, id, computed);
+    }
+  }
+  return node;
+}
+
+/**
+ * Changes the arrow function to a function expression and gives it a name.
+ * \`name\` will be changed to ensure that it is unique within the scope. e.g. \`helper\` -> \`_helper\`
+ *
+ * @param {babel.types} t content of @babel/types package
+ * @param {babel.NodePath<babel.types.ArrowFunctionExpression | babel.types.CallExpression | babel.types.FunctionExpression | babel.types.ObjectMethod>} path path to the function node
+ * @param {string} name name of function to follow after
+ */
+function setInternalFunctionName(t, path, name) {
+  if (
+    !name ||
+    ('id' in path.node && path.node.id != null) ||
+    ('key' in path.node && path.node.key != null)
+  ) {
+    return;
+  }
+
+  const id = path.scope.generateUidIdentifier(name);
+  if (path.isArrowFunctionExpression()) {
+    path.arrowFunctionToExpression();
+  }
+  // @ts-expect-error
+  path.node.id = id;
+}
+
+const cssComponents = ['Box', 'Grid', 'Typography', 'Stack'];
+
+/**
+ * Produces markdown of the description that can be hosted anywhere.
+ *
+ * By default we assume that the markdown is hosted on mui.com which is
+ * why the source includes relative url. We transform them to absolute urls with
+ * this method.
+ */
+export async function computeApiDescription(
+  api: { description: ComponentReactApi['description'] },
+  options: { host: string },
+): Promise<string> {
+  const { host } = options;
+  const file = await remark()
+    .use(function docsLinksAttacher() {
+      return function transformer(tree) {
+        remarkVisit(tree, 'link', (linkNode) => {
+          const link = linkNode as Link;
+          if ((link.url as string).startsWith('/')) {
+            link.url = \`\${host}\${link.url}\`;
+          }
+        });
+      };
+    })
+    .process(api.description);
+
+  return file.toString().trim();
+}
+
+/**
+ * Add demos & API comment block to type definitions, e.g.:
+ * /**
+ *  * Demos:
+ *  *
+ *  * - [Icons](https://mui.com/components/icons/)
+ *  * - [Material Icons](https://mui.com/components/material-icons/)
+ *  *
+ *  * API:
+ *  *
+ *  * - [Icon API](https://mui.com/api/icon/)
+ */
+async function annotateComponentDefinition(
+  api: ComponentReactApi,
+  componentJsdoc: Annotation,
+  projectSettings: ProjectSettings,
+) {
+  const HOST = projectSettings.baseApiUrl ?? 'https://mui.com';
+
+  const typesFilename = api.filename.replace(/.js$/, '.d.ts');
+  const fileName = path.parse(api.filename).name;
+  const typesSource = readFileSync(typesFilename, { encoding: 'utf8' });
+  const typesAST = await babel.parseAsync(typesSource, {
+    configFile: false,
+    filename: typesFilename,
+    presets: [require.resolve('@babel/preset-typescript')],
+  });
+  if (typesAST === null) {
+    throw new Error('No AST returned from babel.');
+  }
+
+  let start = 0;
+  let end = null;
+  traverse(typesAST, {
+    ExportDefaultDeclaration(babelPath) {
+      /**
+       * export default function Menu() {}
+       */
+      let node: babel.Node = babelPath.node;
+      if (node.declaration.type === 'Identifier') {
+        // declare const Menu: {};
+        // export default Menu;
+        if (babel.types.isIdentifier(babelPath.node.declaration)) {
+          const bindingId = babelPath.node.declaration.name;
+          const binding = babelPath.scope.bindings[bindingId];
+
+          // The JSDoc MUST be located at the declaration
+          if (babel.types.isFunctionDeclaration(binding.path.node)) {
+            // For function declarations the binding is equal to the declaration
+            // /**
+            //  */
+            // function Component() {}
+            node = binding.path.node;
+          } else {
+            // For variable declarations the binding points to the declarator.
+            // /**
+            //  */
+            // const Component = () => {}
+            node = binding.path.parentPath!.node;
+          }
+        }
+      }
+
+      const { leadingComments } = node;
+      const leadingCommentBlocks =
+        leadingComments != null
+          ? leadingComments.filter(({ type }) => type === 'CommentBlock')
+          : null;
+      const jsdocBlock =
+        leadingCommentBlocks != null ? leadingCommentBlocks[0] : null;
+      if (leadingCommentBlocks != null && leadingCommentBlocks.length > 1) {
+        throw new Error(
+          \`Should only have a single leading jsdoc block but got \${
+            leadingCommentBlocks.length
+          }:
+\${leadingCommentBlocks
+            .map(({ type, value }, index) => \`#\${index} (\${type}): \${value}\`)
+            .join('
+')}\`,
+        );
+      }
+      if (jsdocBlock?.start != null && jsdocBlock?.end != null) {
+        start = jsdocBlock.start;
+        end = jsdocBlock.end;
+      } else if (node.start != null) {
+        start = node.start - 1;
+        end = start;
+      }
+    },
+
+    ExportNamedDeclaration(babelPath) {
+      let node: babel.Node = babelPath.node;
+
+      if (node.declaration == null) {
+        // export { Menu };
+        node.specifiers.forEach((specifier) => {
+          if (
+            specifier.type === 'ExportSpecifier' &&
+            specifier.local.name === fileName
+          ) {
+            const binding = babelPath.scope.bindings[specifier.local.name];
+
+            if (babel.types.isFunctionDeclaration(binding.path.node)) {
+              // For function declarations the binding is equal to the declaration
+              // /**
+              //  */
+              // function Component() {}
+              node = binding.path.node;
+            } else {
+              // For variable declarations the binding points to the declarator.
+              // /**
+              //  */
+              // const Component = () => {}
+              node = binding.path.parentPath!.node;
+            }
+          }
+        });
+      } else if (babel.types.isFunctionDeclaration(node.declaration)) {
+        // export function Menu() {}
+        if (node.declaration.id?.name === fileName) {
+          node = node.declaration;
+        }
+      } else {
+        return;
+      }
+
+      const { leadingComments } = node;
+      const leadingCommentBlocks =
+        leadingComments != null
+          ? leadingComments.filter(({ type }) => type === 'CommentBlock')
+          : null;
+      const jsdocBlock =
+        leadingCommentBlocks != null ? leadingCommentBlocks[0] : null;
+      if (leadingCommentBlocks != null && leadingCommentBlocks.length > 1) {
+        throw new Error(
+          \`Should only have a single leading jsdoc block but got \${
+            leadingCommentBlocks.length
+          }:
+\${leadingCommentBlocks
+            .map(({ type, value }, index) => \`#\${index} (\${type}): \${value}\`)
+            .join('
+')}\`,
+        );
+      }
+      if (jsdocBlock?.start != null && jsdocBlock?.end != null) {
+        start = jsdocBlock.start;
+        end = jsdocBlock.end;
+      } else if (node.start != null) {
+        start = node.start - 1;
+        end = start;
+      }
+    },
+  });
+
+  if (end === null || start === 0) {
+    throw new TypeError(
+      \`\${api.filename}: Don't know where to insert the jsdoc block. Probably no default export or named export matching the file name was found.\`,
+    );
+  }
+
+  let inheritanceAPILink = null;
+  if (api.inheritance) {
+    inheritanceAPILink = \`[\${api.inheritance.name} API](\${
+      api.inheritance.apiPathname.startsWith('http')
+        ? api.inheritance.apiPathname
+        : \`\${HOST}\${api.inheritance.apiPathname}\`
+    })\`;
+  }
+
+  const markdownLines = (
+    await computeApiDescription(api, { host: HOST })
+  ).split('
+');
+  // Ensure a newline between manual and generated description.
+  if (markdownLines[markdownLines.length - 1] !== '') {
+    markdownLines.push('');
+  }
+
+  if (api.customAnnotation) {
+    markdownLines.push(
+      ...api.customAnnotation
+        .split('
+')
+        .map((line) => line.trim())
+        .filter(Boolean),
+    );
+  } else {
+    markdownLines.push(
+      'Demos:',
+      '',
+      ...api.demos.map((demo) => {
+        return \`- [\${demo.demoPageTitle}](\${
+          demo.demoPathname.startsWith('http')
+            ? demo.demoPathname
+            : \`\${HOST}\${demo.demoPathname}\`
+        })\`;
+      }),
+      '',
+    );
+
+    markdownLines.push(
+      'API:',
+      '',
+      \`- [\${api.name} API](\${
+        api.apiPathname.startsWith('http')
+          ? api.apiPathname
+          : \`\${HOST}\${api.apiPathname}\`
+      })\`,
+    );
+    if (api.inheritance) {
+      markdownLines.push(\`- inherits \${inheritanceAPILink}\`);
+    }
+  }
+
+  if (componentJsdoc.tags.length > 0) {
+    markdownLines.push('');
+  }
+
+  componentJsdoc.tags.forEach((tag) => {
+    markdownLines.push(
+      \`@\${tag.title}\${tag.name ? \` \${tag.name} -\` : ''} \${tag.description}\`,
+    );
+  });
+
+  const jsdoc = \`/**
+\${markdownLines
+    .map((line) => (line.length > 0 ? \` * \${line}\` : \` *\`))
+    .join('
+')}
+ */\`;
+  const typesSourceNew =
+    typesSource.slice(0, start) + jsdoc + typesSource.slice(end);
+  writeFileSync(typesFilename, typesSourceNew, { encoding: 'utf8' });
+}
+
+/**
+ * Substitute CSS class description conditions with placeholder
+ */
+function extractClassCondition(description: string) {
+  const stylesRegex =
+    /((Styles|State class|Class name) applied to )(.*?)(( if | unless | when |, ){1}(.*))?./;
+
+  const conditions = description.match(stylesRegex);
+
+  if (conditions && conditions[6]) {
+    return {
+      description: renderMarkdown(
+        description.replace(stylesRegex, '$1{{nodeName}}$5{{conditions}}.'),
+      ),
+      nodeName: renderMarkdown(conditions[3]),
+      conditions: renderMarkdown(renderCodeTags(conditions[6])),
+    };
+  }
+
+  if (conditions && conditions[3] && conditions[3] !== 'the root element') {
+    return {
+      description: renderMarkdown(
+        description.replace(stylesRegex, '$1{{nodeName}}$5.'),
+      ),
+      nodeName: renderMarkdown(conditions[3]),
+    };
+  }
+
+  return { description: renderMarkdown(description) };
+}
+
+const generateApiPage = async (
+  apiPagesDirectory: string,
+  importTranslationPagesDirectory: string,
+  reactApi: ComponentReactApi,
+  sortingStrategies?: SortingStrategiesType,
+  onlyJsonFile: boolean = false,
+  layoutConfigPath: string = '',
+) => {
+  const normalizedApiPathname = reactApi.apiPathname.replace(/\\/g, '/');
+  /**
+   * Gather the metadata needed for the component's API page.
+   */
+  const pageContent: ComponentApiContent = {
+    // Sorted by required DESC, name ASC
+    props: _.fromPairs(
+      Object.entries(reactApi.propsTable).sort(
+        ([aName, aData], [bName, bData]) => {
+          if (
+            (aData.required && bData.required) ||
+            (!aData.required && !bData.required)
+          ) {
+            return aName.localeCompare(bName);
+          }
+          if (aData.required) {
+            return -1;
+          }
+          return 1;
+        },
+      ),
+    ),
+    name: reactApi.name,
+    imports: reactApi.imports,
+    ...(reactApi.slots?.length > 0 && { slots: reactApi.slots }),
+    ...(Object.keys(reactApi.cssVariables).length > 0 && {
+      cssVariables: reactApi.cssVariables,
+    }),
+    ...(Object.keys(reactApi.dataAttributes).length > 0 && {
+      dataAttributes: reactApi.dataAttributes,
+    }),
+    classes: reactApi.classes,
+    spread: reactApi.spread,
+    themeDefaultProps: reactApi.themeDefaultProps,
+    muiName: normalizedApiPathname.startsWith('/joy-ui')
+      ? reactApi.muiName.replace('Mui', 'Joy')
+      : reactApi.muiName,
+    forwardsRefTo: reactApi.forwardsRefTo,
+    filename: toGitHubPath(reactApi.filename),
+    inheritance: reactApi.inheritance
+      ? {
+          component: reactApi.inheritance.name,
+          pathname: reactApi.inheritance.apiPathname,
+        }
+      : null,
+    demos: \`<ul>\${reactApi.demos
+      .map(
+        (item) =>
+          \`<li><a href="\${item.demoPathname}">\${item.demoPageTitle}</a></li>\`,
+      )
+      .join('
+')}</ul>\`,
+    cssComponent: cssComponents.includes(reactApi.name),
+    deprecated: reactApi.deprecated,
+  };
+
+  const { classesSort = sortAlphabetical('key'), slotsSort = null } = {
+    ...sortingStrategies,
+  };
+
+  if (classesSort) {
+    pageContent.classes = [...pageContent.classes].sort(classesSort);
+  }
+  if (slotsSort && pageContent.slots) {
+    pageContent.slots = [...pageContent.slots].sort(slotsSort);
+  }
+
+  await writePrettifiedFile(
+    path.resolve(apiPagesDirectory, \`\${kebabCase(reactApi.name)}.json\`),
+    JSON.stringify(pageContent),
+  );
+
+
+  export default function Page(props) {
+    const { descriptions, pageContent } = props;
+    return <ApiPage \${layoutConfigPath === '' ? '' : '{...layoutConfig} '}descriptions={descriptions} pageContent={pageContent} />;
+  }
+
+  Page.getInitialProps = () => {
+    const req = require.context(
+      '\${importTranslationPagesDirectory}/\${kebabCase(reactApi.name)}',
+      false,
+      /\\.\\/\${kebabCase(reactApi.name)}.*.json$/,
+    );
+    const descriptions = mapApiPageTranslations(req);
+
+    return {
+      descriptions,
+      pageContent: jsonPageContent,
+    };
+  };
+  \`.replace(/
+?
+/g, reactApi.EOL),
+    );
+  }
+};
+
+const attachTranslations = (
+  reactApi: ComponentReactApi,
+  deprecationInfo: string | undefined,
+  settings?: CreateDescribeablePropSettings,
+) => {
+  const translations: ComponentReactApi['translations'] = {
+    componentDescription: reactApi.description,
+    deprecationInfo: deprecationInfo
+      ? renderMarkdown(deprecationInfo)
+      : undefined,
+    propDescriptions: {},
+    classDescriptions: {},
+  };
+  Object.entries(reactApi.props!).forEach(([propName, propDescriptor]) => {
+    let prop: DescribeablePropDescriptor | null;
+    try {
+      prop = createDescribeableProp(propDescriptor, propName, settings);
+    } catch (error) {
+      prop = null;
+    }
+    if (prop) {
+      const {
+        deprecated,
+        seeMore,
+        jsDocText,
+        signatureArgs,
+        signatureReturn,
+        requiresRef,
+      } = generatePropDescription(prop, propName);
+      // description = renderMarkdownInline(\`\${description}\`);
+
+      const typeDescriptions: TypeDescriptions = {};
+      (signatureArgs || [])
+        .concat(signatureReturn || [])
+        .forEach(({ name, description, argType, argTypeDescription }) => {
+          typeDescriptions[name] = {
+            name,
+            description: renderMarkdown(description),
+            argType,
+            argTypeDescription: argTypeDescription
+              ? renderMarkdown(argTypeDescription)
+              : undefined,
+          };
+        });
+
+      translations.propDescriptions[propName] = {
+        description: renderMarkdown(jsDocText),
+        requiresRef: requiresRef || undefined,
+        deprecated: renderMarkdown(deprecated) || undefined,
+        typeDescriptions:
+          Object.keys(typeDescriptions).length > 0
+            ? typeDescriptions
+            : undefined,
+        seeMoreText: seeMore?.description,
+      };
+    }
+  });
+
+  /**
+   * Slot descriptions.
+   */
+  if (reactApi.slots?.length > 0) {
+    translations.slotDescriptions = {};
+    [...reactApi.slots]
+      .sort(sortAlphabetical('name')) // Sort to ensure consistency of object key order
+      .forEach((slot: Slot) => {
+        const { name, description } = slot;
+        translations.slotDescriptions![name] = renderMarkdown(description);
+      });
+  }
+
+  /**
+   * CSS class descriptions and deprecations.
+   */
+  [...reactApi.classes]
+    .sort(sortAlphabetical('key')) // Sort to ensure consistency of object key order
+    .forEach((classDefinition) => {
+      translations.classDescriptions[classDefinition.key] = {
+        ...extractClassCondition(classDefinition.description),
+        deprecationInfo: classDefinition.deprecationInfo,
+      };
+    });
+  reactApi.classes.forEach((classDefinition, index) => {
+    delete reactApi.classes[index].deprecationInfo; // store deprecation info in translations only
+  });
+
+  /**
+   * CSS variables descriptions.
+   */
+  if (Object.keys(reactApi.cssVariables).length > 0) {
+    translations.cssVariablesDescriptions = {};
+    [...Object.keys(reactApi.cssVariables)]
+      .sort() // Sort to ensure consistency of object key order
+      .forEach((cssVariableName: string) => {
+        const cssVariable = reactApi.cssVariables[cssVariableName];
+        const { description } = cssVariable;
+        translations.cssVariablesDescriptions![cssVariableName] =
+          renderMarkdown(description);
+      });
+  }
+
+  /**
+   * Data attributes descriptions.
+   */
+  if (Object.keys(reactApi.dataAttributes).length > 0) {
+    translations.dataAttributesDescriptions = {};
+    [...Object.keys(reactApi.dataAttributes)]
+      .sort() // Sort to ensure consistency of object key order
+      .forEach((dataAttributeName: string) => {
+        const dataAttribute = reactApi.dataAttributes[dataAttributeName];
+        const { description } = dataAttribute;
+        translations.dataAttributesDescriptions![dataAttributeName] =
+          renderMarkdown(description);
+      });
+  }
+
+  reactApi.translations = translations;
+};
+
+const attachPropsTable = (
+  reactApi: ComponentReactApi,
+  settings?: CreateDescribeablePropSettings,
+) => {
+  const propErrors: Array<[propName: string, error: Error]> = [];
+  type Pair = [string, ComponentReactApi['propsTable'][string]];
+  const componentProps: ComponentReactApi['propsTable'] = _.fromPairs(
+    Object.entries(reactApi.props!).map(([propName, propDescriptor]): Pair => {
+      let prop: DescribeablePropDescriptor | null;
+      try {
+        prop = createDescribeableProp(propDescriptor, propName, settings);
+      } catch (error) {
+        propErrors.push([\`[\${reactApi.name}] \\\`\${propName}\\\`\`, error as Error]);
+        prop = null;
+      }
+      if (prop === null) {
+        // have to delete \`componentProps.undefined\` later
+        return [] as any;
+      }
+
+      const defaultValue = propDescriptor.jsdocDefaultValue?.value;
+
+      const {
+        signature: signatureType,
+        signatureArgs,
+        signatureReturn,
+        seeMore,
+      } = generatePropDescription(prop, propName);
+      const propTypeDescription = generatePropTypeDescription(
+        propDescriptor.type,
+      );
+      const chainedPropType = getChained(prop.type);
+
+      const requiredProp =
+        prop.required ||
+        prop.type.raw?.includes('.isRequired') ||
+        (chainedPropType !== false && chainedPropType.required);
+
+      const deprecation = (propDescriptor.description || '').match(
+        /@deprecated(s+(?<info>.*))?/,
+      );
+
+      const additionalPropsInfo: AdditionalPropsInfo = {};
+
+      const normalizedApiPathname = reactApi.apiPathname.replace(/\\/g, '/');
+
+      if (propName === 'classes') {
+        additionalPropsInfo.cssApi = true;
+      } else if (propName === 'sx') {
+        additionalPropsInfo.sx = true;
+      } else if (
+        propName === 'slots' &&
+        !normalizedApiPathname.startsWith('/material-ui')
+      ) {
+        additionalPropsInfo.slotsApi = true;
+      } else if (normalizedApiPathname.startsWith('/joy-ui')) {
+        switch (propName) {
+          case 'size':
+            additionalPropsInfo['joy-size'] = true;
+            break;
+          case 'color':
+            additionalPropsInfo['joy-color'] = true;
+            break;
+          case 'variant':
+            additionalPropsInfo['joy-variant'] = true;
+            break;
+          default:
+        }
+      }
+
+      let signature: ComponentReactApi['propsTable'][string]['signature'];
+      if (signatureType !== undefined) {
+        signature = {
+          type: signatureType,
+          describedArgs: signatureArgs?.map((arg) => arg.name),
+          returned: signatureReturn?.name,
+        };
+      }
+      return [
+        propName,
+        {
+          type: {
+            name: propDescriptor.type.name,
+            description:
+              propTypeDescription !== propDescriptor.type.name
+                ? propTypeDescription
+                : undefined,
+          },
+          default: defaultValue,
+          // undefined values are not serialized => saving some bytes
+          required: requiredProp || undefined,
+          deprecated: !!deprecation || undefined,
+          deprecationInfo:
+            renderMarkdown(deprecation?.groups?.info || '').trim() || undefined,
+          signature,
+          additionalInfo:
+            Object.keys(additionalPropsInfo).length === 0
+              ? undefined
+              : additionalPropsInfo,
+          seeMoreLink: seeMore?.link,
+        },
+      ];
+    }),
+  );
+  if (propErrors.length > 0) {
+    throw new Error(
+      \`There were errors creating prop descriptions:
+\${propErrors
+        .map(([propName, error]) => {
+          return \`  - \${propName}: \${error}\`;
+        })
+        .join('
+')}\`,
+    );
+  }
+
+  // created by returning the \`[]\` entry
+  delete componentProps.undefined;
+
+  reactApi.propsTable = componentProps;
+};
+
+/**
+ * Helper to get the import options
+ * @param name The name of the component
+ * @param filename The filename where its defined (to infer the package)
+ * @returns an array of import command
+ */
+const defaultGetComponentImports = (name: string, filename: string) => {
+  const githubPath = toGitHubPath(filename);
+  const rootImportPath = githubPath.replace(
+    //packages/mui(?:-(.+?))?/src/.*/,
+    (match, pkg) => \`@mui/\${pkg}\`,
+  );
+
+  const subdirectoryImportPath = githubPath.replace(
+    //packages/mui(?:-(.+?))?/src/([^\\/]+)/.*/,
+    (match, pkg, directory) => \`@mui/\${pkg}/\${directory}\`,
+  );
+
+  let namedImportName = name;
+  const defaultImportName = name;
+
+  if (githubPath.includes('Unstable_')) {
+    namedImportName = \`Unstable_\${name} as \${name}\`;
+  }
+
+  const useNamedImports = rootImportPath === '@mui/base';
+
+
+  return [subpathImport, rootImport];
+};
+
+const attachTable = (
+  reactApi: ComponentReactApi,
+  params: ParsedProperty[],
+  attribute: 'cssVariables' | 'dataAttributes',
+  defaultType?: string,
+) => {
+  const errors: Array<[propName: string, error: Error]> = [];
+  const data: { [key: string]: ApiItemDescription } = params
+    .map((p) => {
+      const { name: propName, ...propDescriptor } = p;
+      let prop: Omit<ParsedProperty, 'name'> | null;
+      try {
+        prop = propDescriptor;
+      } catch (error) {
+        errors.push([propName, error as Error]);
+        prop = null;
+      }
+      if (prop === null) {
+        // have to delete \`componentProps.undefined\` later
+        return [] as any;
+      }
+
+      const deprecationTag = propDescriptor.tags?.deprecated;
+      const deprecation = deprecationTag?.text?.[0]?.text;
+
+      const typeTag = propDescriptor.tags?.type;
+
+      let type = typeTag?.text?.[0]?.text ?? defaultType;
+      if (typeof type === 'string') {
+        type = type.replace(/{|}/g, '');
+      }
+
+      return {
+        name: propName,
+        description: propDescriptor.description,
+        type,
+        deprecated: !!deprecation || undefined,
+        deprecationInfo: renderMarkdown(deprecation || '').trim() || undefined,
+      };
+    })
+    .reduce((acc, cssVarDefinition) => {
+      const { name, ...rest } = cssVarDefinition;
+      return {
+        ...acc,
+        [name]: rest,
+      };
+    }, {});
+
+  if (errors.length > 0) {
+    throw new Error(
+      \`There were errors creating \${attribute.replace(/([A-Z])/g, ' $1')} descriptions:
+\${errors
+        .map(([item, error]) => {
+          return \`  - \${item}: \${error}\`;
+        })
+        .join('
+')}\`,
+    );
+  }
+
+  reactApi[attribute] = data;
+};
+
+/**
+ * - Build react component (specified filename) api by lookup at its definition (.d.ts or ts)
+ *   and then generate the API page + json data
+ * - Generate the translations
+ * - Add the comment in the component filename with its demo & API urls (including the inherited component).
+ *   this process is done by sourcing markdown files and filter matched \`components\` in the frontmatter
+ */
+export default async function generateComponentApi(
+  componentInfo: ComponentInfo,
+  project: TypeScriptProject,
+  projectSettings: ProjectSettings,
+) {
+  const { shouldSkip, spread, EOL, src } = componentInfo.readFile();
+
+  if (shouldSkip) {
+    return null;
+  }
+
+  const filename = componentInfo.filename;
+  let reactApi: ComponentReactApi;
+
+  try {
+    reactApi = docgenParse(
+      src,
+      null,
+      defaultHandlers.concat(muiDefaultPropsHandler),
+      {
+        filename,
+      },
+    );
+  } catch (error) {
+    // fallback to default logic if there is no \`create*\` definition.
+    if (
+      (error as Error).message === 'No suitable component definition found.'
+    ) {
+      reactApi = docgenParse(
+        src,
+        (ast) => {
+          let node;
+          // TODO migrate to react-docgen v6, using Babel AST now
+          astTypes.visit(ast, {
+            visitFunctionDeclaration: (functionPath) => {
+              // @ts-ignore
+              if (functionPath.node.params[0].name === 'props') {
+                node = functionPath;
+              }
+              return false;
+            },
+            visitVariableDeclaration: (variablePath) => {
+              const definitions: any[] = [];
+              if (variablePath.node.declarations) {
+                variablePath
+                  .get('declarations')
+                  .each((declarator: any) =>
+                    definitions.push(declarator.get('init')),
+                  );
+              }
+              definitions.forEach((definition) => {
+                // definition.value.expression is defined when the source is in TypeScript.
+                const expression = definition.value?.expression
+                  ? definition.get('expression')
+                  : definition;
+                if (expression.value?.callee) {
+                  const definitionName = expression.value.callee.name;
+                  if (definitionName === \`create\${componentInfo.name}\`) {
+                    node = expression;
+                  }
+                }
+              });
+              return false;
+            },
+          });
+
+          return node;
+        },
+        defaultHandlers.concat(muiDefaultPropsHandler),
+        {
+          filename,
+        },
+      );
+    } else {
+      throw error;
+    }
+  }
+
+  if (!reactApi.props) {
+    reactApi.props = {};
+  }
+
+  const { getComponentImports = defaultGetComponentImports } = projectSettings;
+  const componentJsdoc = parseDoctrine(reactApi.description);
+
+  // We override \`reactApi.description\` with \`componentJsdoc.description\` because
+  // the former can include JSDoc tags that we don't want to render in the docs.
+  reactApi.description = componentJsdoc.description;
+
+  // Ignore what we might have generated in \`annotateComponentDefinition\`
+  let annotationBoundary: RegExp = /(Demos|API):
+?
+
+?
+/;
+  if (componentInfo.customAnnotation) {
+    annotationBoundary = new RegExp(
+      escapeRegExp(componentInfo.customAnnotation.trim().split('
+')[0].trim()),
+    );
+  }
+  const annotatedDescriptionMatch = reactApi.description.match(
+    new RegExp(annotationBoundary),
+  );
+  if (annotatedDescriptionMatch !== null) {
+    reactApi.description = reactApi.description
+      .slice(0, annotatedDescriptionMatch.index)
+      .trim();
+  }
+
+  reactApi.filename = filename;
+  reactApi.name = componentInfo.name;
+  reactApi.imports = getComponentImports(componentInfo.name, filename);
+  reactApi.muiName = componentInfo.muiName;
+  reactApi.apiPathname = componentInfo.apiPathname;
+  reactApi.EOL = EOL;
+  reactApi.slots = [];
+  reactApi.classes = [];
+  reactApi.demos = componentInfo.getDemos();
+  reactApi.customAnnotation = componentInfo.customAnnotation;
+  reactApi.inheritance = null;
+  if (reactApi.demos.length === 0) {
+    throw new Error(
+      'Unable to find demos. 
+' +
+        \`Be sure to include \\\`components: \${reactApi.name}\\\` in the markdown pages where the \\\`\${reactApi.name}\\\` component is relevant. \` +
+        'Every public component should have a demo.
+For internal component, add the name of the component to the \`skipComponent\` method of the product.',
+    );
+  }
+
+  try {
+    const testInfo = await parseTest(reactApi.filename);
+    // no Object.assign to visually check for collisions
+    reactApi.forwardsRefTo = testInfo.forwardsRefTo;
+    reactApi.spread = testInfo.spread ?? spread;
+    reactApi.themeDefaultProps = testInfo.themeDefaultProps;
+    reactApi.inheritance = componentInfo.getInheritance(
+      testInfo.inheritComponent,
+    );
+  } catch (error: any) {
+    console.error(error.message);
+    if (project.name.includes('grid')) {
+      // TODO: Use \`describeConformance\` for the DataGrid components
+      reactApi.forwardsRefTo = 'GridRoot';
+    }
+  }
+
+  if (!projectSettings.skipSlotsAndClasses) {
+    const { slots, classes } = parseSlotsAndClasses({
+      typescriptProject: project,
+      projectSettings,
+      componentName: reactApi.name,
+      muiName: reactApi.muiName,
+      slotInterfaceName: componentInfo.slotInterfaceName,
+    });
+
+    reactApi.slots = slots;
+    reactApi.classes = classes;
+  }
+
+  const deprecation = componentJsdoc.tags.find(
+    (tag) => tag.title === 'deprecated',
+  );
+  const deprecationInfo = deprecation?.description || undefined;
+
+  reactApi.deprecated = !!deprecation || undefined;
+
+  const cssVars = await extractInfoFromEnum(
+    \`\${componentInfo.name}CssVars\`,
+    new RegExp(\`\${componentInfo.name}(CssVars|Classes)?.tsx?$\`, 'i'),
+    project,
+  );
+
+  const dataAttributes = await extractInfoFromEnum(
+    \`\${componentInfo.name}DataAttributes\`,
+    new RegExp(\`\${componentInfo.name}(DataAttributes)?.tsx?$\`, 'i'),
+    project,
+  );
+
+  attachPropsTable(reactApi, projectSettings.propsSettings);
+  attachTable(reactApi, cssVars, 'cssVariables', 'string');
+  attachTable(reactApi, dataAttributes, 'dataAttributes');
+  attachTranslations(reactApi, deprecationInfo, projectSettings.propsSettings);
+
+  // eslint-disable-next-line no-console
+  console.log('Built API docs for', reactApi.apiPathname);
+
+  if (!componentInfo.skipApiGeneration) {
+    const {
+      skipAnnotatingComponentDefinition,
+      translationPagesDirectory,
+      importTranslationPagesDirectory,
+      generateJsonFileOnly,
+    } = projectSettings;
+
+    await generateApiTranslations(
+      path.join(process.cwd(), translationPagesDirectory),
+      reactApi,
+      projectSettings.translationLanguages,
+    );
+
+    // Once we have the tabs API in all projects, we can make this default
+    await generateApiPage(
+      componentInfo.apiPagesDirectory,
+      importTranslationPagesDirectory ?? translationPagesDirectory,
+      reactApi,
+      projectSettings.sortingStrategies,
+      generateJsonFileOnly,
+      componentInfo.layoutConfigPath,
+    );
+
+    if (
+      typeof skipAnnotatingComponentDefinition === 'function'
+        ? !skipAnnotatingComponentDefinition(reactApi.filename)
+        : !skipAnnotatingComponentDefinition
+    ) {
+      // Add comment about demo & api links (including inherited component) to the component file
+      await annotateComponentDefinition(
+        reactApi,
+        componentJsdoc,
+        projectSettings,
+      );
+    }
+  }
+
+  return reactApi;
+}
+`;
+
+// TODO: it would be better to get a large example that passes our linting
+// that way we can save the contents as a `.ts` file and let the builder load it
+export default snippet;

--- a/docs/app/bench/layout.tsx
+++ b/docs/app/bench/layout.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import type { Metadata } from 'next';
+
+import { BenchProvider } from '@/components/BenchProvider';
+import styles from '../layout.module.css';
+
+export const metadata: Metadata = {
+  title: 'MUI Infra Benchmarks',
+  description: 'Performance demos for MUI Infra packages',
+  robots: { index: false, follow: false },
+};
+
+export default function Layout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <div className={styles.root}>
+      <div className={styles.container}>
+        <BenchProvider>{children}</BenchProvider>
+      </div>
+    </div>
+  );
+}

--- a/docs/app/docs-infra/components/code-controller-context/demos/code-editor/CodeEditorContent.tsx
+++ b/docs/app/docs-infra/components/code-controller-context/demos/code-editor/CodeEditorContent.tsx
@@ -10,7 +10,8 @@ import styles from './CodeEditorContent.module.css';
 import '@wooorm/starry-night/style/light'; // load the light theme for syntax highlighting
 
 export function CodeEditorContent(props: ContentProps<object>) {
-  const code = useCode(props);
+  const preRef = React.useRef<HTMLPreElement | null>(null);
+  const code = useCode(props, { preClassName: styles.codeBlock, preRef });
 
   const hasJsTransform = code.availableTransforms.includes('js');
   const isJsSelected = code.selectedTransform === 'js';
@@ -29,9 +30,7 @@ export function CodeEditorContent(props: ContentProps<object>) {
     [code],
   );
 
-  const editorRef = React.useRef(null);
-
-  useEditable(editorRef, onInput, { indentation: 2 });
+  useEditable(preRef, onInput, { indentation: 2 });
 
   return (
     <div className={styles.container}>
@@ -45,11 +44,7 @@ export function CodeEditorContent(props: ContentProps<object>) {
           )}
         </div>
       </div>
-      <div className={styles.code}>
-        <pre className={styles.codeBlock} ref={editorRef}>
-          {code.selectedFile}
-        </pre>
-      </div>
+      <div className={styles.code}>{code.selectedFile}</div>
     </div>
   );
 }

--- a/docs/app/docs-infra/components/code-controller-context/demos/demo-live/DemoLiveContent.tsx
+++ b/docs/app/docs-infra/components/code-controller-context/demos/demo-live/DemoLiveContent.tsx
@@ -16,7 +16,8 @@ const variantNames: Record<string, string | undefined> = {
 };
 
 export function DemoLiveContent(props: ContentProps<object>) {
-  const demo = useDemo(props);
+  const preRef = React.useRef<HTMLPreElement | null>(null);
+  const demo = useDemo(props, { preClassName: styles.codeBlock, preRef });
 
   const hasJsTransform = demo.availableTransforms.includes('js');
   const isJsSelected = demo.selectedTransform === 'js';
@@ -39,14 +40,13 @@ export function DemoLiveContent(props: ContentProps<object>) {
     [demo.variants],
   );
 
-  const editorRef = React.useRef(null);
   const onChange = React.useCallback(
     (text: string) => {
       demo.setSource?.(text);
     },
     [demo],
   );
-  useEditable(editorRef, onChange, { indentation: 2, disabled: !demo.setSource });
+  useEditable(preRef, onChange, { indentation: 2, disabled: !demo.setSource });
 
   return (
     <div className={styles.container}>
@@ -81,11 +81,7 @@ export function DemoLiveContent(props: ContentProps<object>) {
             </div>
           </div>
         </div>
-        <div className={styles.code}>
-          <pre className={styles.codeBlock} ref={editorRef}>
-            {demo.selectedFile}
-          </pre>
-        </div>
+        <div className={styles.code}>{demo.selectedFile}</div>
       </div>
     </div>
   );

--- a/docs/app/docs-infra/components/code-controller-context/demos/multi-file/MultiFileContent.tsx
+++ b/docs/app/docs-infra/components/code-controller-context/demos/multi-file/MultiFileContent.tsx
@@ -10,7 +10,8 @@ import styles from '../code-editor/CodeEditorContent.module.css';
 import '@wooorm/starry-night/style/light';
 
 export function MultiFileContent(props: ContentProps<object>) {
-  const code = useCode(props);
+  const preRef = React.useRef<HTMLPreElement | null>(null);
+  const code = useCode(props, { preClassName: styles.codeBlock, preRef });
 
   const tabs = React.useMemo(() => {
     return code.files.map(({ name }) => ({
@@ -26,8 +27,7 @@ export function MultiFileContent(props: ContentProps<object>) {
     [code],
   );
 
-  const editorRef = React.useRef(null);
-  useEditable(editorRef, onInput, { indentation: 2 });
+  useEditable(preRef, onInput, { indentation: 2 });
 
   return (
     <div className={styles.container}>
@@ -40,11 +40,7 @@ export function MultiFileContent(props: ContentProps<object>) {
           />
         </div>
       </div>
-      <div className={styles.code}>
-        <pre className={styles.codeBlock} ref={editorRef}>
-          {code.selectedFile}
-        </pre>
-      </div>
+      <div className={styles.code}>{code.selectedFile}</div>
     </div>
   );
 }

--- a/docs/app/docs-infra/components/code-controller-context/page.mdx
+++ b/docs/app/docs-infra/components/code-controller-context/page.mdx
@@ -141,7 +141,8 @@ import { useEditable } from 'use-editable';
 import { useCode } from '@mui/internal-docs-infra/useCode';
 
 function EditorContent(props) {
-  const code = useCode(props);
+  const preRef = React.useRef<HTMLPreElement | null>(null);
+  const code = useCode(props, { preRef });
 
   // code.setSource updates the controller automatically
   const onInput = React.useCallback(
@@ -151,13 +152,12 @@ function EditorContent(props) {
     [code],
   );
 
-  const editorRef = React.useRef(null);
-  useEditable(editorRef, onInput, { indentation: 2 });
+  useEditable(preRef, onInput, { indentation: 2 });
 
   return (
     <div>
       <h4>{code.selectedFileName}</h4>
-      <pre ref={editorRef}>{code.selectedFile}</pre>
+      {code.selectedFile}
     </div>
   );
 }

--- a/docs/app/docs-infra/components/code-highlighter/bench/page.mdx
+++ b/docs/app/docs-infra/components/code-highlighter/bench/page.mdx
@@ -1,0 +1,5 @@
+import BenchCodeHighlighterPage from '@/app/bench/docs-infra/components/code-highlighter/page.mdx';
+
+export default BenchCodeHighlighterPage;
+
+[See Benchmarks](/docs/app/bench/docs-infra/components/code-highlighter/page.mdx)

--- a/docs/app/docs-infra/components/code-highlighter/demos/DemoContent.module.css
+++ b/docs/app/docs-infra/components/code-highlighter/demos/DemoContent.module.css
@@ -6,14 +6,6 @@
 .demoSection {
   padding: 24px;
   border-radius: 7px 7px 0 0;
-  transition: all 0.3s ease-in-out;
-  background: repeating-linear-gradient(20deg, #f2eff3, #f2eff3 8px, #faf9fb 8px, #faf9fb 16px);
-}
-
-.demoSection:hover,
-.demoSection:active,
-.demoSection:focus-within {
-  background: none;
 }
 
 .codeSection {

--- a/docs/app/docs-infra/components/code-highlighter/demos/DemoContent.tsx
+++ b/docs/app/docs-infra/components/code-highlighter/demos/DemoContent.tsx
@@ -16,7 +16,7 @@ const variantNames: Record<string, string | undefined> = {
 };
 
 export function DemoContent(props: ContentProps<object>) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   const hasJsTransform = demo.availableTransforms.includes('js');
   const isJsSelected = demo.selectedTransform === 'js';
@@ -77,9 +77,7 @@ export function DemoContent(props: ContentProps<object>) {
               </div>
             </div>
           </div>
-          <div className={styles.code}>
-            <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
-          </div>
+          <div className={styles.code}>{demo.selectedFile}</div>
         </div>
       </div>
     </div>

--- a/docs/app/docs-infra/components/code-highlighter/page.mdx
+++ b/docs/app/docs-infra/components/code-highlighter/page.mdx
@@ -232,6 +232,12 @@ You can do so by using the [`CodeProvider`](../code-provider/page.mdx) component
 
 You can use the [`CodeControllerContext`](../code-controller-context/page.mdx) for this purpose, which provides a controlled environment for managing code state in interactive scenarios.
 
+## Benchmarking
+
+We have created some demos that showcase the performance of various configurations.
+
+[See Performance Considerations](./bench/page.mdx)
+
 ## Authoring Recommendations
 
 ### Component Name

--- a/docs/app/docs-infra/hooks/use-code/page.mdx
+++ b/docs/app/docs-infra/hooks/use-code/page.mdx
@@ -69,7 +69,7 @@ function CodeContent(props: ContentProps<{}>) {
         </div>
       )}
 
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
 
       <button onClick={code.copy}>Copy Code</button>
     </div>
@@ -174,7 +174,7 @@ function CodeViewer(props) {
         Current file URL: #{code.files.find((f) => f.name === code.selectedFileName)?.slug}
       </span>
 
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
     </div>
   );
 }
@@ -240,7 +240,7 @@ function TransformSelector(props) {
           ))}
         </select>
       )}
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
     </div>
   );
 }
@@ -271,7 +271,7 @@ function CodeContent(props: ContentProps<{}>) {
 
   return (
     <div>
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
       <button onClick={code.copy}>Copy</button>
     </div>
   );
@@ -294,7 +294,7 @@ When your code has multiple files, you should provide navigation between them. T
 
 ```tsx
 function CodeWithTabs(props) {
-  const code = useCode(props);
+  const code = useCode(props, { preClassName: styles.codeBlock });
 
   return (
     <div className={styles.container}>
@@ -318,9 +318,7 @@ function CodeWithTabs(props) {
         )}
       </div>
 
-      <div className={styles.codeContent}>
-        <pre className={styles.codeBlock}>{code.selectedFile}</pre>
-      </div>
+      <div className={styles.codeContent}>{code.selectedFile}</div>
     </div>
   );
 }
@@ -439,7 +437,7 @@ function CodeViewer(props) {
           {file.name}
         </button>
       ))}
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
     </div>
   );
 }
@@ -459,7 +457,7 @@ function CodeSelector(props) {
         selected={code.selectedVariant}
         onSelect={code.selectVariant}
       />
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
     </div>
   );
 }
@@ -477,7 +475,7 @@ function SafeCodeInterface(props) {
 
   return (
     <div>
-      <pre>{code.selectedFile}</pre>
+      {code.selectedFile}
     </div>
   );
 }

--- a/docs/app/docs-infra/hooks/use-demo/page.mdx
+++ b/docs/app/docs-infra/hooks/use-demo/page.mdx
@@ -25,7 +25,7 @@ Built on top of the `useCode` hook, `useDemo` adds demo-specific functionality l
 import { useDemo } from '@mui/internal-docs-infra';
 
 export function DemoContent(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   return (
     <div className={styles.container} ref={demo.ref}>
@@ -35,7 +35,7 @@ export function DemoContent(props) {
       {/* Code Section */}
       <div className={styles.codeSection}>
         <div className={styles.code}>
-          <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+          {demo.selectedFile}
         </div>
       </div>
     </div>
@@ -49,7 +49,7 @@ export function DemoContent(props) {
 
 ```tsx
 export function DemoContent(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   const hasJsTransform = demo.availableTransforms.includes('js');
   const isJsSelected = demo.selectedTransform === 'js';
@@ -127,7 +127,7 @@ export function DemoContent(props) {
 
         {/* Code Display */}
         <div className={styles.code}>
-          <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+          {demo.selectedFile}
         </div>
       </div>
     </div>
@@ -139,7 +139,8 @@ export function DemoContent(props) {
 
 ```tsx
 export function DemoLiveContent(props) {
-  const demo = useDemo(props);
+   const preRef = React.useRef<HTMLPreElement | null>(null);
+  const demo = useDemo(props, { preClassName: styles.codeBlock, preRef });
 
   const hasJsTransform = demo.availableTransforms.includes('js');
   const isJsSelected = demo.selectedTransform === 'js';
@@ -167,11 +168,10 @@ export function DemoLiveContent(props) {
   );
 
   // Set up editable functionality
-  const editorRef = React.useRef(null);
   const onChange = React.useCallback((text: string) => {
     demo.setSource?.(text);
   }, []);
-  useEditable(editorRef, onChange, {
+  useEditable(preRef, onChange, {
     indentation: 2,
     disabled: !demo.setSource,
   });
@@ -219,9 +219,7 @@ export function DemoLiveContent(props) {
 
         {/* Editable Code Block */}
         <div className={styles.code}>
-          <pre className={styles.codeBlock} ref={editorRef}>
-            {demo.selectedFile}
-          </pre>
+          {demo.selectedFile}
         </div>
       </div>
     </div>
@@ -343,14 +341,14 @@ The most common pattern is to use `useDemo` in a content component that receives
 ```tsx
 // In your demo's Content component
 export function DemoContent(props: ContentProps<{}>) {
-  const demo = useDemo(props); // Always pass props directly
+  const demo = useDemo(props, { preClassName: styles.codeBlock }); // Always pass props directly
 
   return (
     <div className={styles.container}>
       <div className={styles.demoSection}>{demo.component}</div>
 
       <div className={styles.codeSection}>
-        <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+        {demo.selectedFile}
       </div>
     </div>
   );
@@ -382,7 +380,7 @@ const ButtonDemo = createDemo({
 
 ```tsx
 export function DemoContent(props: ContentProps<{}>) {
-  const demo = useDemo(props); // [✓] Pass props directly
+  const demo = useDemo(props, { preClassName: styles.codeBlock }); // [✓] Pass props directly
 
   // [x] Never access props.name, props.code, etc.
   // [✓] Use demo.name, demo.selectedFile, etc.
@@ -391,7 +389,7 @@ export function DemoContent(props: ContentProps<{}>) {
     <div className={styles.container}>
       <div className={styles.demoSection}>{demo.component}</div>
       <div className={styles.codeSection}>
-        <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+        {demo.selectedFile}
       </div>
     </div>
   );
@@ -402,7 +400,7 @@ export function DemoContent(props: ContentProps<{}>) {
 
 ```tsx
 export function DemoContent(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   return (
     <div className={styles.container}>
@@ -419,7 +417,7 @@ export function DemoContent(props) {
         <span>{demo.selectedFileName}</span>
       )}
 
-      <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+      {demo.selectedFile}
     </div>
   );
 }
@@ -429,7 +427,7 @@ export function DemoContent(props) {
 
 ```tsx
 export function DemoContent(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   const hasTransforms = demo.availableTransforms.length > 0;
   const isJsSelected = demo.selectedTransform === 'js';
@@ -444,7 +442,7 @@ export function DemoContent(props) {
         </button>
       )}
 
-      <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+      {demo.selectedFile}
     </div>
   );
 }
@@ -482,7 +480,7 @@ function DemoContent(props) {
           {file.name}
         </button>
       ))}
-      <pre>{demo.selectedFile}</pre>
+      {demo.selectedFile}
     </div>
   );
 }
@@ -496,13 +494,13 @@ The most basic pattern for showing a component with its code:
 
 ```tsx
 export function DemoContent(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   return (
     <div className={styles.container}>
       <div className={styles.demoSection}>{demo.component}</div>
       <div className={styles.codeSection}>
-        <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+        {demo.selectedFile}
       </div>
     </div>
   );
@@ -515,7 +513,7 @@ When you have multiple files to show (includes automatic URL hash management):
 
 ```tsx
 export function MultiFileDemoContent(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   return (
     <div className={styles.container}>
@@ -538,7 +536,7 @@ export function MultiFileDemoContent(props) {
           </div>
         )}
 
-        <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+        {demo.selectedFile}
       </div>
     </div>
   );
@@ -551,7 +549,7 @@ For demos that support TypeScript/JavaScript switching:
 
 ```tsx
 export function DemoWithLanguageToggle(props) {
-  const demo = useDemo(props);
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
 
   const canToggleJs = demo.availableTransforms.includes('js');
   const showingJs = demo.selectedTransform === 'js';
@@ -569,7 +567,7 @@ export function DemoWithLanguageToggle(props) {
           </div>
         )}
 
-        <pre className={styles.codeBlock}>{demo.selectedFile}</pre>
+        {demo.selectedFile}
       </div>
     </div>
   );

--- a/docs/components/BenchProvider/BenchProvider.tsx
+++ b/docs/components/BenchProvider/BenchProvider.tsx
@@ -1,0 +1,457 @@
+'use client';
+
+import * as React from 'react';
+import { onCLS, onFCP, onLCP, onINP } from 'web-vitals/attribution';
+import type { Metric } from 'web-vitals/attribution';
+
+// Helper function for severity assessment
+const getLongTaskSeverity = (duration: number): 'blocking' | 'concerning' | 'minor' => {
+  if (duration > 100) {
+    return 'blocking';
+  }
+  if (duration > 50) {
+    return 'concerning';
+  }
+  return 'minor';
+};
+const getRating = (
+  value: number,
+  thresholds: { good: number; poor: number },
+): 'good' | 'needs-improvement' | 'poor' => {
+  if (value <= thresholds.good) {
+    return 'good';
+  }
+  if (value <= thresholds.poor) {
+    return 'needs-improvement';
+  }
+  return 'poor';
+};
+
+// Custom metric type for TTI and long tasks
+interface CustomMetric {
+  name: string;
+  value: number;
+  rating?: 'good' | 'needs-improvement' | 'poor';
+  navigationType?: string;
+  entries?: any[];
+  metadata?: {
+    startTime?: number;
+    endTime?: number;
+    attribution?: any[];
+    source?: string;
+    timeFromPageLoad?: number;
+    severity?: 'blocking' | 'concerning' | 'minor';
+  };
+}
+
+const report = (metric: Metric | CustomMetric) => {
+  if (!window.parent) {
+    // eslint-disable-next-line no-console
+    console.log(metric);
+    return;
+  }
+
+  // Serialize entries to avoid cloning issues with PerformanceEntry objects
+  const serializableEntries =
+    'entries' in metric && metric.entries
+      ? metric.entries.map((entry) => ({
+          name: entry.name,
+          entryType: entry.entryType,
+          startTime: entry.startTime,
+          duration: entry.duration,
+          // Add other relevant properties that are serializable
+          ...(entry.size !== undefined && { size: entry.size }),
+          ...(entry.renderTime !== undefined && { renderTime: entry.renderTime }),
+          ...(entry.loadTime !== undefined && { loadTime: entry.loadTime }),
+        }))
+      : undefined;
+
+  window.parent.postMessage(
+    {
+      source: 'docs-infra:bench',
+      type: 'web-vitals',
+      metric: {
+        name: metric.name,
+        navigationType: metric.navigationType,
+        rating: metric.rating,
+        value: metric.value,
+        ...(serializableEntries && { entries: serializableEntries }),
+        ...('metadata' in metric && metric.metadata && { metadata: metric.metadata }),
+      },
+    },
+    '*',
+  );
+};
+
+// Helper functions for TTI calculation
+const findLastLongTaskBefore = (
+  time: number,
+  longTasks: PerformanceEntry[],
+): PerformanceEntry | null => {
+  let lastTask = null;
+  for (const task of longTasks) {
+    if (task.startTime < time) {
+      lastTask = task;
+    } else {
+      break;
+    }
+  }
+  return lastTask;
+};
+
+const isQuietWindow = (
+  startTime: number,
+  endTime: number,
+  longTasks: PerformanceEntry[],
+  networkRequests: PerformanceEntry[],
+): boolean => {
+  // Early exit: Check for long tasks in this window using binary search approach
+  // Since longTasks are already sorted, we can optimize this check
+  const firstTaskInWindow = longTasks.find((task) => task.startTime >= startTime);
+  if (firstTaskInWindow && firstTaskInWindow.startTime < endTime) {
+    return false;
+  }
+
+  // Fast path: if no network requests, it's quiet
+  if (networkRequests.length === 0) {
+    return true;
+  }
+
+  // Optimized network request check - only process relevant requests
+  let maxConcurrentRequests = 0;
+  let currentRequests = 0;
+
+  // Pre-filter and create events only for relevant requests
+  const relevantEvents: Array<{ time: number; type: 'start' | 'end' }> = [];
+
+  for (let i = 0; i < networkRequests.length; i += 1) {
+    const request = networkRequests[i];
+    const reqStartTime = request.startTime;
+    const reqEndTime = reqStartTime + request.duration;
+
+    // Skip requests that don't overlap with our window
+    if (reqEndTime <= startTime || reqStartTime >= endTime) {
+      continue;
+    }
+
+    relevantEvents.push(
+      { time: Math.max(reqStartTime, startTime), type: 'start' },
+      { time: Math.min(reqEndTime, endTime), type: 'end' },
+    );
+  }
+
+  // Early exit if no relevant events
+  if (relevantEvents.length === 0) {
+    return true;
+  }
+
+  // Sort events by time (this is now a smaller array)
+  relevantEvents.sort((a, b) => a.time - b.time);
+
+  // Process events to find max concurrent requests
+  for (let i = 0; i < relevantEvents.length; i += 1) {
+    const event = relevantEvents[i];
+    if (event.type === 'start') {
+      currentRequests += 1;
+      maxConcurrentRequests = Math.max(maxConcurrentRequests, currentRequests);
+      // Early exit optimization: if we already exceed 2, no need to continue
+      if (maxConcurrentRequests > 2) {
+        return false;
+      }
+    } else {
+      currentRequests -= 1;
+    }
+  }
+
+  return maxConcurrentRequests <= 2;
+};
+
+const findTTI = (
+  fcpTime: number,
+  longTasks: PerformanceEntry[],
+  networkRequests: PerformanceEntry[],
+): number => {
+  const searchStartTime = fcpTime;
+  const now = performance.now();
+
+  // Sort long tasks by start time
+  const sortedLongTasks = longTasks
+    .filter((task) => task.startTime >= searchStartTime)
+    .sort((a, b) => a.startTime - b.startTime);
+
+  // Find a quiet window of 5 seconds
+  for (let time = searchStartTime; time <= now - 5000; time += 100) {
+    if (isQuietWindow(time, time + 5000, sortedLongTasks, networkRequests)) {
+      // Found quiet window, now search backwards for last long task
+      const lastLongTask = findLastLongTaskBefore(time, sortedLongTasks);
+      return lastLongTask ? lastLongTask.startTime + lastLongTask.duration : fcpTime;
+    }
+  }
+
+  // If no quiet window found, use current time
+  const lastLongTask = sortedLongTasks[sortedLongTasks.length - 1];
+  return lastLongTask ? lastLongTask.startTime + lastLongTask.duration : fcpTime;
+};
+
+// Global collection of all long tasks for consistent reporting
+// eslint-disable-next-line prefer-const
+let globalLongTasks: PerformanceEntry[] = [];
+let globalLongTaskObserver: PerformanceObserver | null = null;
+
+// Initialize global long task observer
+const initializeGlobalLongTaskObserver = () => {
+  if (globalLongTaskObserver || !('PerformanceObserver' in window)) {
+    return;
+  }
+
+  globalLongTaskObserver = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      globalLongTasks.push(entry);
+    }
+  });
+
+  try {
+    globalLongTaskObserver.observe({ type: 'longtask', buffered: true });
+  } catch {
+    // Long task API not supported
+    globalLongTaskObserver = null;
+  }
+};
+
+// Calculate TBT (Total Blocking Time) between FCP and TTI
+const calculateTBT = (fcpTime: number, ttiTime: number): number => {
+  let totalBlockingTime = 0;
+
+  for (const task of globalLongTasks) {
+    // Only consider tasks between FCP and TTI
+    if (task.startTime >= fcpTime && task.startTime < ttiTime) {
+      // Only the portion above 50ms counts as blocking time
+      const blockingTime = Math.max(0, task.duration - 50);
+      totalBlockingTime += blockingTime;
+    }
+  }
+
+  return totalBlockingTime;
+};
+
+// Calculate TTI and TBT based on the algorithm described
+const calculateTTIAndTBT = (fcpTime: number): Promise<{ tti: number; tbt: number }> => {
+  return new Promise((resolve) => {
+    const networkRequests: PerformanceEntry[] = [];
+    let intervalId: NodeJS.Timeout;
+    let resourceObserver: PerformanceObserver | null = null;
+
+    // Initialize the global long task observer if not already done
+    initializeGlobalLongTaskObserver();
+
+    // Collect all long tasks
+    // (Using global observer initialized above)
+
+    // Collect network requests
+    if ('PerformanceObserver' in window) {
+      resourceObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.name.startsWith('http') && entry.startTime >= fcpTime) {
+            networkRequests.push(entry);
+          }
+        }
+      });
+
+      try {
+        resourceObserver.observe({ type: 'resource', buffered: true });
+      } catch {
+        // Resource timing not supported
+        resourceObserver = null;
+      }
+    }
+
+    // Function to check for quiet window and calculate TTI
+    const checkForTTI = () => {
+      const now = performance.now();
+
+      // Sort long tasks by start time for efficient processing
+      const sortedLongTasks = globalLongTasks
+        .filter((task) => task.startTime >= fcpTime)
+        .sort((a, b) => a.startTime - b.startTime);
+
+      // Check if we can find a quiet window
+      for (let time = fcpTime; time <= now - 5000; time += 100) {
+        if (isQuietWindow(time, time + 5000, sortedLongTasks, networkRequests)) {
+          // Found quiet window! Calculate TTI and TBT, then resolve
+          const lastLongTask = findLastLongTaskBefore(time, sortedLongTasks);
+          const tti = lastLongTask ? lastLongTask.startTime + lastLongTask.duration : fcpTime;
+          const tbt = calculateTBT(fcpTime, tti);
+
+          // Clean up observers and interval
+          clearInterval(intervalId);
+          if (resourceObserver) {
+            resourceObserver.disconnect();
+          }
+
+          resolve({ tti, tbt });
+          return;
+        }
+      }
+    };
+
+    // Check every second for quiet window
+    intervalId = setInterval(checkForTTI, 1000);
+
+    // Fallback: if we haven't found TTI after 24.9 more seconds, calculate it anyway
+    // (Total of 30 seconds from FCP: 5.1 second delay + 24.9 second search)
+    setTimeout(() => {
+      clearInterval(intervalId);
+      if (resourceObserver) {
+        resourceObserver.disconnect();
+      }
+
+      const tti = findTTI(fcpTime, globalLongTasks, networkRequests);
+      const tbt = calculateTBT(fcpTime, tti);
+      resolve({ tti, tbt });
+    }, 24900); // Fallback after 24.9 more seconds (total 30s from FCP)
+  });
+};
+
+// Report long tasks with callback pattern similar to web-vitals
+const onLongTask = (callback: (metric: CustomMetric) => void) => {
+  if (!('PerformanceObserver' in window)) {
+    return;
+  }
+
+  // Initialize global observer if not already done
+  initializeGlobalLongTaskObserver();
+
+  // Create a separate observer just for reporting individual tasks with metadata
+  const reportingObserver = new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      // Try to extract better source information
+      let source = 'JavaScript (main thread)'; // Default fallback
+      const attribution = [];
+
+      // Check if attribution data is available
+      if ((entry as any).attribution && (entry as any).attribution.length > 0) {
+        const attr = (entry as any).attribution[0];
+        attribution.push({
+          name: attr.name || 'unknown',
+          entryType: attr.entryType || 'unknown',
+          startTime: attr.startTime || 0,
+          duration: attr.duration || 0,
+          containerType: attr.containerType || 'unknown',
+          containerSrc: attr.containerSrc || 'unknown',
+          containerId: attr.containerId || 'unknown',
+          containerName: attr.containerName || 'unknown',
+        });
+
+        // Try to determine a meaningful source name
+        if (attr.containerSrc && attr.containerSrc !== 'unknown') {
+          try {
+            const url = new URL(attr.containerSrc);
+            source = url.pathname.split('/').pop() || attr.containerSrc;
+          } catch {
+            source = attr.containerSrc;
+          }
+        } else if (attr.containerName && attr.containerName !== 'unknown') {
+          source = attr.containerName;
+        } else if (attr.name && attr.name !== 'unknown') {
+          source = attr.name;
+        }
+      }
+
+      // If no attribution, try to infer from current script context
+      if (attribution.length === 0) {
+        // Check if we can get current script information
+        const currentScript = document.currentScript as HTMLScriptElement;
+        if (currentScript && currentScript.src) {
+          try {
+            const url = new URL(currentScript.src);
+            source = url.pathname.split('/').pop() || 'current-script';
+          } catch {
+            source = 'current-script';
+          }
+        } else {
+          // Fallback to detecting if it's likely React/framework related
+          const hasReact = (window as any).React !== undefined;
+          // eslint-disable-next-line no-underscore-dangle
+          const hasNextData = (window as any).__NEXT_DATA__ !== undefined;
+
+          if (hasNextData) {
+            source = 'Next.js';
+          } else if (hasReact) {
+            source = 'React';
+          }
+        }
+      }
+
+      // Call the callback with each long task and additional metadata
+      callback({
+        name: 'long-task',
+        value: entry.duration,
+        rating: getRating(entry.duration, { good: 50, poor: 100 }),
+        entries: [entry],
+        // Additional metadata for long tasks
+        metadata: {
+          startTime: entry.startTime,
+          endTime: entry.startTime + entry.duration,
+          attribution,
+          source, // Simplified source name for display
+          // Calculate timing relative to page load
+          timeFromPageLoad: entry.startTime,
+          severity: getLongTaskSeverity(entry.duration),
+        },
+      });
+    }
+  });
+
+  try {
+    reportingObserver.observe({ type: 'longtask', buffered: true });
+  } catch {
+    // Long task API not supported
+    console.warn('Long Task API not supported');
+  }
+};
+
+export function BenchProvider({ children }: { children: React.ReactNode }) {
+  React.useEffect(() => {
+    // Initialize global long task collection
+    initializeGlobalLongTaskObserver();
+
+    onCLS(report); // Measures Cumulative Layout Shift
+    onFCP((metric) => {
+      report(metric); // Report FCP first
+
+      // Wait 5.1 seconds before starting TTI calculation to ensure we have enough
+      // time for a potential 5-second quiet window to be meaningful
+      setTimeout(() => {
+        // Calculate and report TTI and TBT after sufficient time has passed
+        calculateTTIAndTBT(metric.value)
+          .then(({ tti, tbt }) => {
+            // Report TTI
+            report({
+              name: 'TTI',
+              value: tti,
+              rating: getRating(tti, { good: 3800, poor: 5000 }),
+              navigationType: metric.navigationType,
+            });
+
+            // Report TBT
+            report({
+              name: 'TBT',
+              value: tbt,
+              rating: getRating(tbt, { good: 200, poor: 600 }),
+              navigationType: metric.navigationType,
+            });
+          })
+          .catch(() => {
+            // TTI/TBT calculation failed, ignore
+          });
+      }, 5100); // Wait 5.1 seconds after FCP before starting TTI calculation
+    }); // Measures First Contentful Paint
+    onLCP(report); // Measures Largest Contentful Paint
+    onINP(report); // Measures Interaction to Next Paint
+
+    // Start reporting long tasks
+    onLongTask(report);
+  }, []);
+
+  return children;
+}

--- a/docs/components/BenchProvider/index.ts
+++ b/docs/components/BenchProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './BenchProvider';

--- a/docs/components/BenchViewer/BenchViewer.module.css
+++ b/docs/components/BenchViewer/BenchViewer.module.css
@@ -1,0 +1,135 @@
+.Root {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.Button {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 2.5rem;
+  padding: 0 0.875rem;
+  margin: 0;
+  outline: 0;
+  border: 1px solid #d0cdd7;
+  border-radius: 0.375rem;
+  background-color: #fdfcfe;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  color: #65636d;
+  user-select: none;
+
+  @media (hover: hover) {
+    &:hover {
+      background-color: #30004010;
+    }
+  }
+
+  &:active {
+    background-color: #20003820;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #8e4ec6;
+    outline-offset: -1px;
+  }
+}
+
+.Backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: #fefcfe;
+  opacity: 0.2;
+  transition: opacity 150ms cubic-bezier(0.45, 1.005, 0, 1.005);
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+  }
+}
+
+.Popup {
+  box-sizing: border-box;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 1120px;
+  max-width: calc(100vw - 3rem);
+  height: 85%;
+  margin-top: -2rem;
+  padding: 1.5rem;
+  border-radius: 0.5rem;
+  outline: 1px solid #d0cdd7;
+  background-color: #fefcfe;
+  transition: all 150ms;
+  z-index: 100;
+  display: flex;
+  gap: 1rem;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+
+.Interactive {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
+.Results {
+  flex: 1;
+}
+
+.Title {
+  margin-top: -0.375rem;
+  margin-bottom: 0.25rem;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  letter-spacing: -0.0025em;
+  font-weight: 500;
+}
+
+.Description {
+  margin: 0 0 1.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  color: #65636d;
+}
+
+.Actions {
+  display: flex;
+  gap: 1rem;
+}
+
+.FrameContainer {
+  width: 792px;
+  position: relative;
+}
+
+.Frame {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.FrameContainer.isDisabled {
+  cursor: wait;
+}
+
+/* Overlay to temporarily block interaction while the benchmark waits for idle/TTI */
+.FrameBlocker {
+  position: absolute;
+  inset: 0;
+  z-index: 100;
+  background: transparent;
+  touch-action: none;
+  cursor: wait;
+}

--- a/docs/components/BenchViewer/BenchViewer.tsx
+++ b/docs/components/BenchViewer/BenchViewer.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import * as React from 'react';
+import { Dialog } from '@base-ui-components/react/dialog';
+import type { useDemo } from '@mui/internal-docs-infra/useDemo';
+import styles from './BenchViewer.module.css';
+
+const metricNames: Record<string, string | undefined> = {
+  FCP: 'First Contentful Paint',
+  LCP: 'Largest Contentful Paint',
+  CLS: 'Cumulative Layout Shift',
+  INP: 'Interaction to Next Paint',
+  TTI: 'Time to Interactive',
+  TBT: 'Total Blocking Time',
+  'long-task': 'Long Task',
+};
+
+const metricUnits: Record<string, string | undefined> = {
+  FCP: 'ms',
+  LCP: 'ms',
+  INP: 'ms',
+  TTI: 'ms',
+  TBT: 'ms',
+  'long-task': 'ms',
+};
+
+export function BenchViewer({
+  url,
+  demo,
+}: {
+  url: string | undefined;
+  demo: ReturnType<typeof useDemo>;
+}) {
+  const { name } = demo.userProps;
+  const demoURL = new URL('.', url).toString().slice(0, -1); // remove filename and trailing slash
+  const lastAppIndex = demoURL ? demoURL.lastIndexOf('app/') : -1;
+  const demoPath = lastAppIndex !== -1 ? demoURL!.substring(lastAppIndex + 3) : demoURL || '';
+
+  const [open, setOpen] = React.useState(false);
+  const [benchShown, setBenchShown] = React.useState(false);
+  const [waitingForTTI, setWaitingForTTI] = React.useState(false);
+  const [metrics, setMetrics] = React.useState<
+    {
+      name: string;
+      rating?: string;
+      value: number;
+      metadata?: any;
+    }[]
+  >([]);
+
+  // reset benchmarks when reopening
+  React.useEffect(() => {
+    if (open) {
+      setMetrics([]);
+      setBenchShown(false);
+      setWaitingForTTI(false);
+      // request idle callback
+      window.requestIdleCallback(() => {
+        setBenchShown(true);
+        // Start waiting for TTI after FCP is received
+        setWaitingForTTI(true);
+      });
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    const callback = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return; // our iframes are always same origin
+      }
+
+      if (event.data?.source !== 'docs-infra:bench') {
+        return;
+      }
+
+      if (event.data.type === 'web-vitals' && event.data.metric) {
+        // Stop waiting for TTI when it or TBT arrives (since TBT comes right after TTI)
+        if (event.data.metric.name === 'TTI' || event.data.metric.name === 'TBT') {
+          setWaitingForTTI(false);
+        }
+
+        setMetrics((prevMetrics) => [
+          ...prevMetrics,
+          {
+            name: event.data.metric.name,
+            rating: event.data.metric.rating,
+            value: event.data.metric.value,
+            metadata: event.data.metric.metadata,
+          },
+        ]);
+      }
+    };
+    window.addEventListener('message', callback, false);
+
+    return () => {
+      window.removeEventListener('message', callback);
+    };
+  }, []);
+
+  const frameRef = React.useRef<HTMLIFrameElement>(null);
+  // When interaction is re-enabled, ensure the iframe regains focus
+  React.useEffect(() => {
+    if (!waitingForTTI && open && benchShown) {
+      // Try focusing iframe element and its contentWindow for wheel/scroll
+      const el = frameRef.current;
+      // Defer to next frame to ensure overlay is removed
+      requestAnimationFrame(() => {
+        try {
+          el?.focus();
+          el?.contentWindow?.focus();
+        } catch {
+          // noop
+        }
+      });
+    }
+  }, [waitingForTTI, open, benchShown]);
+
+  const refreshFrame = React.useCallback(() => {
+    setMetrics([]);
+    setWaitingForTTI(false); // Reset waiting state first
+    setBenchShown(false); // Hide the iframe temporarily
+
+    if (frameRef.current) {
+      // Resetting the src forces a reload, which is important to get fresh metrics
+      const currentSrc = frameRef.current.src;
+      frameRef.current.src = currentSrc;
+    }
+
+    // Restart the benchmark process after a brief delay
+    window.requestIdleCallback(() => {
+      setBenchShown(true);
+      setWaitingForTTI(true); // Start waiting for TTI again
+    });
+  }, []);
+
+  const openInNewTab = React.useCallback(() => {
+    window.open(demoPath, '_blank', 'noopener,noreferrer');
+  }, [demoPath]);
+
+  return (
+    <div className={styles.Root}>
+      <Dialog.Root open={open} onOpenChange={setOpen}>
+        <Dialog.Trigger className={styles.Button}>Start Benchmark</Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Backdrop className={styles.Backdrop} />
+          <Dialog.Popup className={styles.Popup}>
+            <div className={styles.Interactive}>
+              <Dialog.Title className={styles.Title}>{name} Benchmark</Dialog.Title>
+              <div className={styles.Results}>
+                {metrics.map((metric, index) => (
+                  <div key={`${metric.name}-${index}`}>
+                    <strong>{metricNames[metric.name] || metric.name}</strong>:{' '}
+                    {Math.round(metric.value)}
+                    {metricUnits[metric.name] || ''} {metric.rating && `(${metric.rating})`}
+                    {metric.name === 'long-task' && metric.metadata && (
+                      <div style={{ marginLeft: '20px', fontSize: '0.9em', color: '#666' }}>
+                        <div>Start: {Math.round(metric.metadata.startTime)}ms</div>
+                        <div>Severity: {metric.metadata.severity}</div>
+                        <div>Source: {metric.metadata.source || 'Unknown'}</div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+                {waitingForTTI && (
+                  <div style={{ fontStyle: 'italic', color: '#888', marginTop: '8px' }}>
+                    Waiting for 5 seconds of JS Idle...
+                  </div>
+                )}
+              </div>
+              <div className={styles.Actions}>
+                <Dialog.Close className={styles.Button}>Close</Dialog.Close>
+                <button className={styles.Button} type="button" onClick={refreshFrame}>
+                  Reload
+                </button>
+                <button className={styles.Button} type="button" onClick={openInNewTab}>
+                  Open
+                </button>
+              </div>
+            </div>
+            <div
+              className={[styles.FrameContainer, waitingForTTI && styles.isDisabled]
+                .filter(Boolean)
+                .join(' ')}
+            >
+              {open && benchShown ? (
+                <iframe
+                  className={styles.Frame}
+                  src={demoPath}
+                  title="Bench Viewer"
+                  tabIndex={-1}
+                  ref={frameRef}
+                />
+              ) : null}
+              {waitingForTTI ? <div className={styles.FrameBlocker} aria-hidden /> : null}
+            </div>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}

--- a/docs/components/BenchViewer/index.ts
+++ b/docs/components/BenchViewer/index.ts
@@ -1,0 +1,1 @@
+export * from './BenchViewer';

--- a/docs/components/DemoPerformanceContent/DemoPerformanceContent.tsx
+++ b/docs/components/DemoPerformanceContent/DemoPerformanceContent.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import * as React from 'react';
+import type { ContentProps } from '@mui/internal-docs-infra/CodeHighlighter/types';
+import { useDemo } from '@mui/internal-docs-infra/useDemo';
+import { LabeledSwitch } from '@/components/LabeledSwitch';
+import { Tabs } from '@/components/Tabs';
+import { CopyButton } from '@/components/CopyButton';
+import { Select } from '@/components/Select';
+import styles from '../../app/docs-infra/components/code-highlighter/demos/DemoContent.module.css';
+
+import '@wooorm/starry-night/style/light';
+import { BenchViewer } from '../BenchViewer';
+
+const variantNames: Record<string, string | undefined> = {
+  CssModules: 'CSS Modules',
+};
+
+export function DemoPerformanceContent(props: ContentProps<object>) {
+  const demo = useDemo(props, { preClassName: styles.codeBlock });
+
+  const hasJsTransform = demo.availableTransforms.includes('js');
+  const isJsSelected = demo.selectedTransform === 'js';
+
+  const labels = { false: 'TS', true: 'JS' };
+  const toggleJs = React.useCallback(
+    (checked: boolean) => {
+      demo.selectTransform(checked ? 'js' : null);
+    },
+    [demo],
+  );
+
+  const tabs = React.useMemo(
+    () => demo.files.map(({ name, slug }) => ({ id: name, name, slug })),
+    [demo.files],
+  );
+  const variants = React.useMemo(
+    () =>
+      demo.variants.map((variant) => ({ value: variant, label: variantNames[variant] || variant })),
+    [demo.variants],
+  );
+
+  return (
+    <div>
+      {demo.files.map(({ slug }) => (
+        <span key={slug} id={slug} className={styles.fileRefs} />
+      ))}
+      <div className={styles.container}>
+        <div className={styles.demoSection}>
+          <BenchViewer url={props.url} demo={demo} />
+        </div>
+        <div className={styles.codeSection}>
+          <div className={styles.header}>
+            <div className={styles.headerContainer}>
+              <div className={styles.tabContainer}>
+                <Tabs
+                  tabs={tabs}
+                  selectedTabId={demo.selectedFileName}
+                  onTabSelect={demo.selectFileName}
+                />
+              </div>
+              <div className={styles.headerActions}>
+                <CopyButton copy={demo.copy} />
+                {demo.variants.length > 1 && (
+                  <Select
+                    items={variants}
+                    value={demo.selectedVariant}
+                    onValueChange={demo.selectVariant}
+                  />
+                )}
+                {hasJsTransform && (
+                  <div className={styles.switchContainer}>
+                    <LabeledSwitch
+                      checked={isJsSelected}
+                      onCheckedChange={toggleJs}
+                      labels={labels}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className={styles.code}>{demo.selectedFile}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/components/DemoPerformanceContent/index.ts
+++ b/docs/components/DemoPerformanceContent/index.ts
@@ -1,0 +1,1 @@
+export * from './DemoPerformanceContent';

--- a/docs/components/DemoPerformanceContentLoading/DemoPerformanceContentLoading.tsx
+++ b/docs/components/DemoPerformanceContentLoading/DemoPerformanceContentLoading.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import * as React from 'react';
+import type { ContentLoadingProps } from '@mui/internal-docs-infra/CodeHighlighter/types';
+import { Tabs } from '@/components/Tabs';
+import styles from '../../app/docs-infra/components/code-highlighter/demos/DemoContent.module.css';
+
+import '@wooorm/starry-night/style/light';
+
+export function DemoPerformanceContentLoading(props: ContentLoadingProps<object>) {
+  const tabs = React.useMemo(
+    () =>
+      props.fileNames?.map((name) => ({
+        id: name || '',
+        name: name || '',
+        slug: name,
+      })),
+    [props.fileNames],
+  );
+
+  const onTabSelect = React.useCallback(() => {
+    // No-op
+  }, []);
+
+  return (
+    <div>
+      {Object.keys(props.extraSource || {}).map((slug) => (
+        <span key={slug} id={slug} className={styles.fileRefs} />
+      ))}
+      <div className={styles.container}>
+        <div className={styles.demoSection}></div>
+        <div className={styles.codeSection}>
+          <div className={styles.header}>
+            <div className={styles.headerContainer}>
+              {tabs && (
+                <div className={styles.tabContainer}>
+                  <Tabs
+                    tabs={tabs}
+                    selectedTabId={props.fileNames?.[0]}
+                    onTabSelect={onTabSelect}
+                    disabled={true}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+          <div className={styles.code}>
+            <pre className={styles.codeBlock}>{props.source}</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/components/DemoPerformanceContentLoading/index.ts
+++ b/docs/components/DemoPerformanceContentLoading/index.ts
@@ -1,0 +1,1 @@
+export * from './DemoPerformanceContentLoading';

--- a/docs/functions/createDemoPerformance/createDemoPerformance.tsx
+++ b/docs/functions/createDemoPerformance/createDemoPerformance.tsx
@@ -1,0 +1,34 @@
+import 'server-only';
+
+import {
+  createDemoFactory,
+  createDemoWithVariantsFactory,
+} from '@mui/internal-docs-infra/abstractCreateDemo';
+
+import { DemoPerformanceContent } from '@/components/DemoPerformanceContent';
+import { DemoPerformanceContentLoading } from '@/components/DemoPerformanceContentLoading';
+
+/**
+ * Creates a demo component for displaying code examples with syntax highlighting.
+ * Also adds additional performance tracking capabilities.
+ * @param url Depends on `import.meta.url` to determine the source file location.
+ * @param component The component to be rendered in the demo.
+ * @param meta Additional meta for the demo.
+ */
+export const createDemoPerformance = createDemoFactory({
+  DemoContent: DemoPerformanceContent,
+  DemoContentLoading: DemoPerformanceContentLoading,
+});
+
+/**
+ * Creates a demo component for displaying code examples with syntax highlighting.
+ * A variant is a different implementation style of the same component.
+ * Also adds additional performance tracking capabilities.
+ * @param url Depends on `import.meta.url` to determine the source file location.
+ * @param variants The variants of the component to be rendered in the demo.
+ * @param meta Additional meta for the demo.
+ */
+export const createDemoPerformanceWithVariants = createDemoWithVariantsFactory({
+  DemoContent: DemoPerformanceContent,
+  DemoContentLoading: DemoPerformanceContentLoading,
+});

--- a/docs/functions/createDemoPerformance/index.ts
+++ b/docs/functions/createDemoPerformance/index.ts
@@ -1,0 +1,1 @@
+export * from './createDemoPerformance';

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,8 @@
     "remark-gfm": "^4.0.1",
     "server-only": "^0.0.1",
     "use-editable": "^2.3.3",
-    "vscode-oniguruma": "^2.0.1"
+    "vscode-oniguruma": "^2.0.1",
+    "web-vitals": "^5.1.0"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^15.5.2",

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -23,6 +23,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mdx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/packages/docs-infra/src/CodeProvider/CodeProvider.tsx
+++ b/packages/docs-infra/src/CodeProvider/CodeProvider.tsx
@@ -56,7 +56,8 @@ export function CodeProvider({
         }
 
         const highlighted = starryNight.highlight(source, extensionMap[fileType]);
-        starryNightGutter(highlighted); // mutates the tree to add line gutters
+        const sourceLines = source.split(/\r?\n|\r/);
+        starryNightGutter(highlighted, sourceLines); // mutates the tree to add line gutters
 
         return highlighted;
       };

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
@@ -20,8 +20,17 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
-        children: [{ type: 'text', value: 'hello world' }],
+        properties: {
+          className: 'frame',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 1 },
+            children: [{ type: 'text', value: 'hello world' }],
+          },
+        ],
       },
     ]);
     expect((tree.data as any)?.totalLines).toBe(1);
@@ -44,15 +53,24 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
-        children: [{ type: 'text', value: 'line1' }],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [{ type: 'text', value: 'line2' }],
+        properties: {
+          className: 'frame',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 1 },
+            children: [{ type: 'text', value: 'line1' }],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 2 },
+            children: [{ type: 'text', value: 'line2' }],
+          },
+        ],
       },
     ]);
   });
@@ -74,22 +92,31 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
-        children: [{ type: 'text', value: 'line1' }],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [{ type: 'text', value: 'line2' }],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 3 },
-        children: [{ type: 'text', value: 'line3' }],
+        properties: {
+          className: 'frame',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 1 },
+            children: [{ type: 'text', value: 'line1' }],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 2 },
+            children: [{ type: 'text', value: 'line2' }],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 3 },
+            children: [{ type: 'text', value: 'line3' }],
+          },
+        ],
       },
     ]);
   });
@@ -121,23 +148,32 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
+        properties: {
+          className: 'frame',
+        },
         children: [
-          { type: 'text', value: 'hello ' },
           {
             type: 'element',
             tagName: 'span',
-            properties: { className: 'keyword' },
-            children: [{ type: 'text', value: 'const' }],
+            properties: { className: 'line', dataLn: 1 },
+            children: [
+              { type: 'text', value: 'hello ' },
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: 'keyword' },
+                children: [{ type: 'text', value: 'const' }],
+              },
+            ],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 2 },
+            children: [{ type: 'text', value: 'world' }],
           },
         ],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [{ type: 'text', value: 'world' }],
       },
     ]);
   });
@@ -159,22 +195,31 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
-        children: [{ type: 'text', value: 'line1' }],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 3 },
-        children: [{ type: 'text', value: 'line3' }],
+        properties: {
+          className: 'frame',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 1 },
+            children: [{ type: 'text', value: 'line1' }],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 2 },
+            children: [],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 3 },
+            children: [{ type: 'text', value: 'line3' }],
+          },
+        ],
       },
     ]);
   });
@@ -196,15 +241,24 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
-        children: [{ type: 'text', value: 'line1' }],
-      },
-      { type: 'text', value: '\r\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [{ type: 'text', value: 'line2' }],
+        properties: {
+          className: 'frame',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 1 },
+            children: [{ type: 'text', value: 'line1' }],
+          },
+          { type: 'text', value: '\r\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 2 },
+            children: [{ type: 'text', value: 'line2' }],
+          },
+        ],
       },
     ]);
   });
@@ -226,17 +280,26 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
-        children: [{ type: 'text', value: 'line1' }],
+        properties: {
+          className: 'frame',
+        },
+        children: [
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 1 },
+            children: [{ type: 'text', value: 'line1' }],
+          },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 2 },
+            children: [{ type: 'text', value: 'line2' }],
+          },
+          { type: 'text', value: '\n' },
+        ],
       },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [{ type: 'text', value: 'line2' }],
-      },
-      { type: 'text', value: '\n' },
     ]);
   });
 
@@ -276,19 +339,28 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
+        properties: {
+          className: 'frame',
+        },
         children: [
           {
             type: 'element',
             tagName: 'span',
-            properties: { className: 'keyword' },
-            children: [{ type: 'text', value: 'const' }],
-          },
-          {
-            type: 'element',
-            tagName: 'span',
-            properties: { className: 'variable' },
-            children: [{ type: 'text', value: 'x' }],
+            properties: { className: 'line', dataLn: 1 },
+            children: [
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: 'keyword' },
+                children: [{ type: 'text', value: 'const' }],
+              },
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: 'variable' },
+                children: [{ type: 'text', value: 'x' }],
+              },
+            ],
           },
         ],
       },
@@ -332,40 +404,49 @@ describe('starryNightGutter', () => {
       {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 1 },
+        properties: {
+          className: 'frame',
+        },
         children: [
-          { type: 'text', value: 'function ' },
           {
             type: 'element',
             tagName: 'span',
-            properties: { className: 'function-name' },
-            children: [{ type: 'text', value: 'example' }],
+            properties: { className: 'line', dataLn: 1 },
+            children: [
+              { type: 'text', value: 'function ' },
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: 'function-name' },
+                children: [{ type: 'text', value: 'example' }],
+              },
+              { type: 'text', value: '() {' },
+            ],
           },
-          { type: 'text', value: '() {' },
-        ],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 2 },
-        children: [
-          { type: 'text', value: '  return ' },
+          { type: 'text', value: '\n' },
           {
             type: 'element',
             tagName: 'span',
-            properties: { className: 'string' },
-            children: [{ type: 'text', value: '"hello"' }],
+            properties: { className: 'line', dataLn: 2 },
+            children: [
+              { type: 'text', value: '  return ' },
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: { className: 'string' },
+                children: [{ type: 'text', value: '"hello"' }],
+              },
+              { type: 'text', value: ';' },
+            ],
           },
-          { type: 'text', value: ';' },
+          { type: 'text', value: '\n' },
+          {
+            type: 'element',
+            tagName: 'span',
+            properties: { className: 'line', dataLn: 3 },
+            children: [{ type: 'text', value: '}' }],
+          },
         ],
-      },
-      { type: 'text', value: '\n' },
-      {
-        type: 'element',
-        tagName: 'span',
-        properties: { className: 'line', dataLineNumber: 3 },
-        children: [{ type: 'text', value: '}' }],
       },
     ]);
   });
@@ -410,21 +491,31 @@ describe('starryNightGutter', () => {
 
     starryNightGutter(tree);
 
-    // Should have 3 lines with proper line numbers
-    const lineElements = tree.children.filter(
-      (child) =>
-        child.type === 'element' &&
-        child.tagName === 'span' &&
-        child.properties?.className === 'line',
-    );
-    expect(lineElements).toHaveLength(3);
+    // Should have 1 frame containing 3 lines (single frame, so no dataAsString)
+    expect(tree.children).toHaveLength(1);
+    const frame = tree.children[0];
+    expect(frame.type).toBe('element');
+    if (frame.type === 'element') {
+      expect(frame.tagName).toBe('span');
+      expect(frame.properties?.className).toBe('frame');
+      expect(frame.properties?.dataAsString).toBeUndefined(); // No dataAsString for single frame
 
-    // Verify line numbers are correct
-    lineElements.forEach((element, index) => {
-      if (element.type === 'element') {
-        expect(element.properties?.dataLineNumber).toBe(index + 1);
-      }
-    });
+      // Count line elements within the frame
+      const lineElements = frame.children.filter(
+        (child) =>
+          child.type === 'element' &&
+          child.tagName === 'span' &&
+          child.properties?.className === 'line',
+      );
+      expect(lineElements).toHaveLength(3);
+
+      // Verify line numbers are correct
+      lineElements.forEach((element, index) => {
+        if (element.type === 'element') {
+          expect(element.properties?.dataLn).toBe(index + 1);
+        }
+      });
+    }
 
     // Verify total line count is stored in root data
     expect((tree.data as any)?.totalLines).toBe(3);
@@ -445,6 +536,114 @@ describe('starryNightGutter', () => {
     starryNightGutter(tree);
 
     expect((tree.data as any)?.totalLines).toBe(5);
+  });
+
+  // Test frame splitting for large content
+  it('should split lines into frames of 120 lines', () => {
+    // Create a tree with 250 lines to test frame splitting
+    const lines = Array.from({ length: 250 }, (_, i) => `line${i + 1}`);
+    const sourceText = lines.join('\n');
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'text',
+          value: sourceText,
+        },
+      ],
+    };
+
+    starryNightGutter(tree, lines, 120);
+
+    // Should have 3 frames: 120 + 120 + 10 lines
+    expect(tree.children).toHaveLength(3);
+
+    // Check first frame (lines 1-120)
+    const firstFrame = tree.children[0];
+    expect(firstFrame.type).toBe('element');
+    if (firstFrame.type === 'element') {
+      expect(firstFrame.tagName).toBe('span');
+      expect(firstFrame.properties?.className).toBe('frame');
+
+      // Should have dataAsString since there are multiple frames
+      expect(firstFrame.properties?.dataAsString).toBeDefined();
+      expect(typeof firstFrame.properties?.dataAsString).toBe('string');
+
+      const firstFrameLines = firstFrame.children.filter(
+        (child) =>
+          child.type === 'element' &&
+          child.tagName === 'span' &&
+          child.properties?.className === 'line',
+      );
+      expect(firstFrameLines).toHaveLength(120);
+
+      // Check line numbers in first frame
+      if (firstFrameLines[0].type === 'element') {
+        expect(firstFrameLines[0].properties?.dataLn).toBe(1);
+      }
+      if (firstFrameLines[119].type === 'element') {
+        expect(firstFrameLines[119].properties?.dataLn).toBe(120);
+      }
+    }
+
+    // Check second frame (lines 121-240)
+    const secondFrame = tree.children[1];
+    expect(secondFrame.type).toBe('element');
+    if (secondFrame.type === 'element') {
+      expect(secondFrame.tagName).toBe('span');
+      expect(secondFrame.properties?.className).toBe('frame');
+
+      // Should have dataAsString since there are multiple frames
+      expect(secondFrame.properties?.dataAsString).toBeDefined();
+      expect(typeof secondFrame.properties?.dataAsString).toBe('string');
+
+      const secondFrameLines = secondFrame.children.filter(
+        (child) =>
+          child.type === 'element' &&
+          child.tagName === 'span' &&
+          child.properties?.className === 'line',
+      );
+      expect(secondFrameLines).toHaveLength(120);
+
+      // Check line numbers in second frame
+      if (secondFrameLines[0].type === 'element') {
+        expect(secondFrameLines[0].properties?.dataLn).toBe(121);
+      }
+      if (secondFrameLines[119].type === 'element') {
+        expect(secondFrameLines[119].properties?.dataLn).toBe(240);
+      }
+    }
+
+    // Check third frame (lines 241-250)
+    const thirdFrame = tree.children[2];
+    expect(thirdFrame.type).toBe('element');
+    if (thirdFrame.type === 'element') {
+      expect(thirdFrame.tagName).toBe('span');
+      expect(thirdFrame.properties?.className).toBe('frame');
+
+      // Should have dataAsString since there are multiple frames
+      expect(thirdFrame.properties?.dataAsString).toBeDefined();
+      expect(typeof thirdFrame.properties?.dataAsString).toBe('string');
+
+      const thirdFrameLines = thirdFrame.children.filter(
+        (child) =>
+          child.type === 'element' &&
+          child.tagName === 'span' &&
+          child.properties?.className === 'line',
+      );
+      expect(thirdFrameLines).toHaveLength(10);
+
+      // Check line numbers in third frame
+      if (thirdFrameLines[0].type === 'element') {
+        expect(thirdFrameLines[0].properties?.dataLn).toBe(241);
+      }
+      if (thirdFrameLines[9].type === 'element') {
+        expect(thirdFrameLines[9].properties?.dataLn).toBe(250);
+      }
+    }
+
+    // Verify total line count
+    expect((tree.data as any)?.totalLines).toBe(250);
   });
 });
 

--- a/packages/docs-infra/src/pipeline/parseSource/parseSource.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/parseSource.ts
@@ -31,7 +31,8 @@ export const parseSource: ParseSource = (source, fileName) => {
   }
 
   const highlighted = starryNight.highlight(source, extensionMap[fileType]);
-  starryNightGutter(highlighted); // mutates the tree to add line gutters
+  const sourceLines = source.split(/\r?\n|\r/);
+  starryNightGutter(highlighted, sourceLines); // mutates the tree to add line gutters
 
   return highlighted;
 };

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import * as React from 'react';
+import { toText } from 'hast-util-to-text';
+import { ElementContent } from 'hast';
+import type { HastRoot, VariantSource } from '../CodeHighlighter/types';
+import { hastToJsx } from '../pipeline/hastUtils';
+
+export function Pre({
+  children,
+  className,
+  ref,
+  shouldHighlight,
+  hydrateMargin = '200px 0px 200px 0px',
+}: {
+  children: VariantSource;
+  className?: string;
+  ref?: React.Ref<HTMLPreElement>;
+  shouldHighlight?: boolean;
+  hydrateMargin?: string;
+}): React.ReactNode {
+  const hast = React.useMemo(() => {
+    if (typeof children === 'string') {
+      return null;
+    }
+
+    if ('hastJson' in children) {
+      return JSON.parse(children.hastJson) as HastRoot;
+    }
+
+    return children;
+  }, [children]);
+
+  const [visibleFrames, setVisibleFrames] = React.useState<{ [key: number]: boolean }>({
+    [0]: true,
+  });
+
+  const observer = React.useRef<IntersectionObserver | null>(null);
+  const bindIntersectionObserver = React.useCallback(
+    (root: HTMLPreElement | null) => {
+      if (!root) {
+        if (observer.current) {
+          observer.current.disconnect();
+        }
+        observer.current = null;
+
+        return;
+      }
+
+      observer.current = new IntersectionObserver(
+        (entries) =>
+          setVisibleFrames((prev) => {
+            const visible: number[] = [];
+            const invisible: number[] = [];
+
+            entries.forEach((entry) => {
+              if (entry.isIntersecting) {
+                visible.push(Number(entry.target.getAttribute('data-frame')));
+              } else {
+                invisible.push(Number(entry.target.getAttribute('data-frame')));
+              }
+            });
+
+            // avoid mutating the object if nothing changed
+            let frames: { [key: number]: boolean } | undefined;
+            visible.forEach((frame) => {
+              if (prev[frame] !== true) {
+                if (!frames) {
+                  frames = { ...prev };
+                }
+                frames[frame] = true;
+              }
+            });
+
+            invisible.forEach((frame) => {
+              if (prev[frame]) {
+                if (!frames) {
+                  frames = { ...prev };
+                }
+                delete frames[frame];
+              }
+            });
+
+            return frames || prev;
+          }),
+        { rootMargin: hydrateMargin },
+      );
+
+      root.childNodes.forEach((node) => {
+        if (node.nodeType === Node.ELEMENT_NODE) {
+          const element = node as Element;
+          observer.current?.observe(element);
+        }
+      });
+
+      if (ref) {
+        if (typeof ref === 'function') {
+          ref(root);
+        } else {
+          ref.current = root;
+        }
+      }
+    },
+    [ref, hydrateMargin],
+  );
+
+  const observeFrame = React.useCallback((node: HTMLSpanElement | null) => {
+    if (observer.current && node) {
+      observer.current.observe(node);
+    }
+  }, []);
+
+  const hastChildrenCache = React.useMemo<undefined | Array<React.ReactNode | null>>(
+    () => hast?.children.map(() => null),
+    [hast],
+  );
+  const textChildrenCache = React.useMemo<undefined | Array<string | null>>(
+    () => hast?.children.map(() => null),
+    [hast],
+  );
+  const renderCode = React.useCallback(
+    (index: number, hastChildren: ElementContent[], renderHast?: boolean, text?: string) => {
+      if (renderHast) {
+        const cached = hastChildrenCache?.[index];
+        if (cached) {
+          return cached;
+        }
+
+        const jsx = hastToJsx({ type: 'root', children: hastChildren });
+        if (hastChildrenCache) {
+          hastChildrenCache[index] = jsx;
+        }
+
+        return jsx;
+      }
+
+      if (text !== undefined) {
+        return text;
+      }
+
+      const cached = textChildrenCache?.[index];
+      if (cached) {
+        return cached;
+      }
+
+      const txt = toText({ type: 'root', children: hastChildren }, { whitespace: 'pre' });
+      if (textChildrenCache) {
+        textChildrenCache[index] = txt;
+      }
+
+      return txt;
+    },
+    [hastChildrenCache, textChildrenCache],
+  );
+
+  const frames = React.useMemo(() => {
+    return hast?.children.map((child, index) => {
+      if (child.type !== 'element') {
+        return null;
+      }
+
+      if (child.properties.className === 'frame') {
+        const isVisible = Boolean(visibleFrames[index]);
+
+        return (
+          <span key={index} className="frame" data-frame={index} ref={observeFrame}>
+            {renderCode(
+              index,
+              child.children,
+              shouldHighlight && isVisible,
+              child.properties?.dataAsString ? String(child.properties?.dataAsString) : undefined,
+            )}
+          </span>
+        );
+      }
+
+      return (
+        <React.Fragment key={index}>
+          {shouldHighlight ? hastToJsx(child) : toText(child, { whitespace: 'pre' })}
+        </React.Fragment>
+      );
+    });
+  }, [hast, renderCode, observeFrame, shouldHighlight, visibleFrames]);
+
+  return (
+    <pre ref={bindIntersectionObserver} className={className}>
+      {typeof children === 'string' ? children : frames}
+    </pre>
+  );
+}

--- a/packages/docs-infra/src/useCode/useCode.ts
+++ b/packages/docs-infra/src/useCode/useCode.ts
@@ -11,7 +11,9 @@ import { useCopyFunctionality } from './useCopyFunctionality';
 import { useSourceEditing } from './useSourceEditing';
 import { UseCopierOpts } from '../useCopier';
 
-type UseCodeOpts = {
+export type UseCodeOpts = {
+  preClassName?: string;
+  preRef?: React.Ref<HTMLPreElement>;
   defaultOpen?: boolean;
   copy?: UseCopierOpts;
   githubUrlPrefix?: string;
@@ -48,7 +50,14 @@ export function useCode<T extends {} = {}>(
   contentProps: ContentProps<T>,
   opts?: UseCodeOpts,
 ): UseCodeResult<T> {
-  const { copy: copyOpts, defaultOpen = false, initialVariant, initialTransform } = opts || {};
+  const {
+    copy: copyOpts,
+    defaultOpen = false,
+    initialVariant,
+    initialTransform,
+    preClassName,
+    preRef,
+  } = opts || {};
 
   // Safely try to get context values - will be undefined if not in context
   const context = useCodeHighlighterContextOptional();
@@ -122,6 +131,8 @@ export function useCode<T extends {} = {}>(
     variantKeys: variantSelection.variantKeys,
     initialVariant,
     shouldHighlight,
+    preClassName,
+    preRef,
   });
 
   // Sub-hook: Copy Functionality

--- a/packages/docs-infra/src/useCode/useFileNavigation.test.ts
+++ b/packages/docs-infra/src/useCode/useFileNavigation.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useFileNavigation } from './useFileNavigation';
+import { Pre } from './Pre';
 import type { VariantCode } from '../CodeHighlighter/types';
 
 // Mock the useUrlHashState hook to prevent browser API issues
@@ -72,17 +73,35 @@ describe('useFileNavigation', () => {
         {
           name: 'checkbox-basic.tsx',
           slug: 'basic:checkbox-basic.tsx',
-          component: 'const BasicCheckbox = () => <div>Basic</div>;',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'const BasicCheckbox = () => <div>Basic</div>;',
+            }),
+          }),
         },
         {
           name: 'styles.css',
           slug: 'basic:styles.css',
-          component: 'body { margin: 0; }',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'body { margin: 0; }',
+            }),
+          }),
         },
         {
           name: 'helper.ts',
           slug: 'basic:helper.ts',
-          component: 'export const helper = () => {};',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'export const helper = () => {};',
+            }),
+          }),
         },
       ]);
     });
@@ -112,12 +131,24 @@ describe('useFileNavigation', () => {
         {
           name: 'checkbox-tailwind.tsx',
           slug: 'basic:tailwind:checkbox-tailwind.tsx',
-          component: 'const TailwindCheckbox = () => <div className="p-4">Tailwind</div>;',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'const TailwindCheckbox = () => <div className="p-4">Tailwind</div>;',
+            }),
+          }),
         },
         {
           name: 'tailwind.config.js',
           slug: 'basic:tailwind:tailwind.config.js',
-          component: 'module.exports = {};',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'module.exports = {};',
+            }),
+          }),
         },
       ]);
     });
@@ -148,17 +179,35 @@ describe('useFileNavigation', () => {
         {
           name: 'checkbox.test.tsx',
           slug: 'advanced-checkbox:testing:checkbox.test.tsx',
-          component: 'test content',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'test content',
+            }),
+          }),
         },
         {
           name: 'component.d.ts',
           slug: 'advanced-checkbox:testing:component.d.ts',
-          component: 'type definitions',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'type definitions',
+            }),
+          }),
         },
         {
           name: 'style.module.css',
           slug: 'advanced-checkbox:testing:style.module.css',
-          component: 'css module',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'css module',
+            }),
+          }),
         },
       ]);
     });
@@ -185,7 +234,13 @@ describe('useFileNavigation', () => {
         {
           name: 'component.tsx',
           slug: 'component.tsx',
-          component: 'test content',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'test content',
+            }),
+          }),
         },
       ]);
     });
@@ -212,7 +267,13 @@ describe('useFileNavigation', () => {
         {
           name: 'checkbox-special.tsx',
           slug: 'basic:checkbox-special.tsx', // Should be treated as initial variant
-          component: 'const SpecialCheckbox = () => <div>Special</div>;',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'const SpecialCheckbox = () => <div>Special</div>;',
+            }),
+          }),
         },
       ]);
     });
@@ -243,17 +304,35 @@ describe('useFileNavigation', () => {
         {
           name: 'BasicCode.tsx',
           slug: 'basic:basic-code.tsx',
-          component: 'const BasicCode = () => <div>Basic</div>;',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'const BasicCode = () => <div>Basic</div>;',
+            }),
+          }),
         },
         {
           name: 'helperUtils.js',
           slug: 'basic:helper-utils.js',
-          component: 'export const helper = () => {};',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'export const helper = () => {};',
+            }),
+          }),
         },
         {
           name: 'MyComponent.test.tsx',
           slug: 'basic:my-component.test.tsx',
-          component: 'test content',
+          component: expect.objectContaining({
+            type: Pre,
+            props: expect.objectContaining({
+              shouldHighlight: true,
+              children: 'test content',
+            }),
+          }),
         },
       ]);
     });
@@ -662,13 +741,46 @@ describe('useFileNavigation', () => {
       );
 
       expect(result.current.files).toHaveLength(2);
-      // With shouldHighlight=false, HAST nodes should be converted to plain text strings
-      expect(typeof result.current.files[0].component).toBe('string');
-      expect(result.current.files[0].component).toBe('const x = 1;');
-      expect(typeof result.current.files[1].component).toBe('string');
-      expect(result.current.files[1].component).toBe('export const util = () => {};');
-      expect(typeof result.current.selectedFileComponent).toBe('string');
-      expect(result.current.selectedFileComponent).toBe('const x = 1;');
+      // With shouldHighlight=false, still returns JSX objects (Pre components)
+      expect(typeof result.current.files[0].component).toBe('object');
+      expect(result.current.files[0].component).toEqual(
+        expect.objectContaining({
+          type: Pre,
+          props: expect.objectContaining({
+            shouldHighlight: false,
+            children: expect.objectContaining({
+              type: 'root',
+              children: expect.any(Array),
+            }),
+          }),
+        }),
+      );
+      expect(typeof result.current.files[1].component).toBe('object');
+      expect(result.current.files[1].component).toEqual(
+        expect.objectContaining({
+          type: Pre,
+          props: expect.objectContaining({
+            shouldHighlight: false,
+            children: expect.objectContaining({
+              type: 'root',
+              children: expect.any(Array),
+            }),
+          }),
+        }),
+      );
+      expect(typeof result.current.selectedFileComponent).toBe('object');
+      expect(result.current.selectedFileComponent).toEqual(
+        expect.objectContaining({
+          type: Pre,
+          props: expect.objectContaining({
+            shouldHighlight: false,
+            children: expect.objectContaining({
+              type: 'root',
+              children: expect.any(Array),
+            }),
+          }),
+        }),
+      );
     });
 
     it('should handle shouldHighlight behavior when switching between files', () => {
@@ -716,19 +828,41 @@ describe('useFileNavigation', () => {
         }),
       );
 
-      // Initially on main file - should be plain text
+      // Initially on main file - should be JSX object (Pre component)
       expect(result.current.selectedFileName).toBe('main.js');
-      expect(typeof result.current.selectedFileComponent).toBe('string');
-      expect(result.current.selectedFileComponent).toBe('const main = true;');
+      expect(typeof result.current.selectedFileComponent).toBe('object');
+      expect(result.current.selectedFileComponent).toEqual(
+        expect.objectContaining({
+          type: Pre,
+          props: expect.objectContaining({
+            shouldHighlight: false,
+            children: expect.objectContaining({
+              type: 'root',
+              children: expect.any(Array),
+            }),
+          }),
+        }),
+      );
 
-      // Switch to helper file - should also be plain text
+      // Switch to helper file - should also be JSX object (Pre component)
       act(() => {
         result.current.selectFileName('helper.js');
       });
 
       expect(result.current.selectedFileName).toBe('helper.js');
-      expect(typeof result.current.selectedFileComponent).toBe('string');
-      expect(result.current.selectedFileComponent).toBe('const helper = false;');
+      expect(typeof result.current.selectedFileComponent).toBe('object');
+      expect(result.current.selectedFileComponent).toEqual(
+        expect.objectContaining({
+          type: Pre,
+          props: expect.objectContaining({
+            shouldHighlight: false,
+            children: expect.objectContaining({
+              type: 'root',
+              children: expect.any(Array),
+            }),
+          }),
+        }),
+      );
     });
 
     it('should apply shouldHighlight to selectedFileComponent when switching files', () => {

--- a/packages/docs-infra/src/useDemo/useDemo.ts
+++ b/packages/docs-infra/src/useDemo/useDemo.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import kebabCase from 'kebab-case';
 
 import { useCode } from '../useCode';
-import { UseCopierOpts } from '../useCopier';
+import type { UseCodeOpts } from '../useCode';
 import type { ContentProps } from '../CodeHighlighter/types';
 import { CodeHighlighterContext } from '../CodeHighlighter/CodeHighlighterContext';
 import { createStackBlitz } from './createStackBlitz';
@@ -26,14 +26,9 @@ import { flattenVariant } from './flattenVariant';
  * createCodeSandboxDemo({ title, description, flattenedFiles, useTypescript })
  */
 
-type UseDemoOpts = {
-  defaultOpen?: boolean;
-  copy?: UseCopierOpts;
-  githubUrlPrefix?: string;
+type UseDemoOpts = UseCodeOpts & {
   codeSandboxUrlPrefix?: string;
   stackBlitzPrefix?: string;
-  initialVariant?: string;
-  initialTransform?: string;
   /** Common export configuration applied to both StackBlitz and CodeSandbox */
   export?: ExportConfig;
   /** StackBlitz-specific export configuration (merged with common export config) */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       vscode-oniguruma:
         specifier: ^2.0.1
         version: 2.0.1
+      web-vitals:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
       '@next/bundle-analyzer':
         specifier: ^15.5.2
@@ -12405,6 +12408,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-vitals@5.1.0:
+    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -15499,7 +15505,7 @@ snapshots:
       '@mui/system': 6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/utils': 6.4.9(@types/react@19.1.12)(react@19.1.1)
       '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-data-grid-pro': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid-pro': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/x-internals': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@mui/x-license': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@types/format-util': 1.0.4
@@ -15515,19 +15521,17 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@mui/x-data-grid-premium@7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@mui/x-data-grid-pro@7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.4
-      '@mui/material': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/system': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
+      '@mui/material': 6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/system': 6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/utils': 6.4.9(@types/react@19.1.12)(react@19.1.1)
-      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-data-grid-pro': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/x-internals': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@mui/x-license': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@types/format-util': 1.0.4
       clsx: 2.1.1
-      exceljs: 4.4.0
       prop-types: 15.8.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
@@ -15544,7 +15548,7 @@ snapshots:
       '@mui/material': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/system': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/utils': 6.4.9(@types/react@19.1.12)(react@19.1.1)
-      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/x-internals': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@mui/x-license': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@types/format-util': 1.0.4
@@ -15553,6 +15557,25 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       reselect: 5.1.1
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-data-grid@7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/material': 6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/system': 6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
+      '@mui/utils': 6.4.9(@types/react@19.1.12)(react@19.1.1)
+      '@mui/x-internals': 7.26.0(@types/react@19.1.12)(react@19.1.1)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.5.0(react@19.1.1)
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
@@ -15617,27 +15640,6 @@ snapshots:
       '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       dayjs: 1.11.13
-      luxon: 3.7.1
-    transitivePeerDependencies:
-      - '@types/react'
-
-  '@mui/x-date-pickers@7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(dayjs@1.11.18)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@babel/runtime': 7.28.4
-      '@mui/material': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/system': 7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      '@mui/utils': 6.4.9(@types/react@19.1.12)(react@19.1.1)
-      '@mui/x-internals': 7.26.0(@types/react@19.1.12)(react@19.1.1)
-      '@types/react-transition-group': 4.4.12(@types/react@19.1.12)
-      clsx: 2.1.1
-      prop-types: 15.8.1
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      react-transition-group: 4.4.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-    optionalDependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.12)(react@19.1.1)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
-      dayjs: 1.11.18
       luxon: 3.7.1
     transitivePeerDependencies:
       - '@types/react'
@@ -18104,16 +18106,16 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@toolpad/core@0.13.0(77706d775f52f39635ce681c6c90b98e)':
+  '@toolpad/core@0.13.0(3a28507820f91f62cac5d679418f560e)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mui/icons-material': 6.4.7(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@types/react@19.1.12)(react@19.1.1)
       '@mui/material': 6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/utils': 7.0.0-beta.3(@types/react@19.1.12)(react@19.1.1)
-      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-data-grid-premium': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid-premium': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/x-data-grid-pro': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-date-pickers': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(dayjs@1.11.18)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-date-pickers': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(dayjs@1.11.13)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@standard-schema/spec': 1.0.0
       '@toolpad/utils': 0.13.0(react@19.1.1)
       '@vitejs/plugin-react': 4.3.4(vite@5.4.14(@types/node@20.19.12)(terser@5.44.0))
@@ -18210,15 +18212,15 @@ snapshots:
       '@mui/types': 7.2.21(@types/react@19.1.12)
       '@mui/utils': 6.4.6(@types/react@19.1.12)(react@19.1.1)
       '@mui/x-charts': 7.27.1(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-data-grid-premium': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@mui/x-date-pickers': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@7.3.2(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(dayjs@1.11.18)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-data-grid-premium': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@mui/x-date-pickers': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(dayjs@1.11.13)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/x-date-pickers-pro': 7.27.3(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(dayjs@1.11.13)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@mui/x-license': 7.26.0(@types/react@19.1.12)(react@19.1.1)
       '@mui/x-tree-view': 7.26.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-query': 5.67.2(react@19.1.1)
       '@tanstack/react-query-devtools': 5.67.2(@tanstack/react-query@5.67.2(react@19.1.1))(react@19.1.1)
-      '@toolpad/core': 0.13.0(77706d775f52f39635ce681c6c90b98e)
+      '@toolpad/core': 0.13.0(3a28507820f91f62cac5d679418f560e)
       '@toolpad/studio-components': 0.13.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(luxon@3.7.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vm-browserify@1.1.2)
       '@toolpad/studio-runtime': 0.13.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react@19.1.1))(@types/react@19.1.12)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vm-browserify@1.1.2)
       '@toolpad/utils': 0.13.0(react@19.1.1)
@@ -27333,6 +27335,8 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@5.1.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
Add a benchmarking page at http://localhost:3000/docs-infra/components/code-highlighter/bench

This page shows the code needed to reproduce the benchmark and a button that opens the bench dialog

<img width="2297" height="1708" alt="Screenshot From 2025-09-15 19-47-01" src="https://github.com/user-attachments/assets/22dd6c4c-d795-4517-9bc8-d6d013f8b2fd" />

Demo code can be opened in a dialog. The demo page is loaded into an iframe which reports [web vitals](https://web.dev/articles/vitals) like First Contentful Paint (FCP), Largest Contentful Paint (LCP), Cumulative Layout Shift (CLS), Interaction to Next Paint (INP), [Time to Interactive (TTI)](https://web.dev/articles/tti), [Total Blocking Time (TBT)](https://web.dev/articles/tbt). Long tasks considered blocking (longer than 50ms) are also logged. After the 5 seconds needed to calculate TTI, the user can interact with the benchmark frame. This is helpful to see if any long tasks are reported.

<img width="2297" height="1708" alt="Screenshot From 2025-09-15 19-47-16" src="https://github.com/user-attachments/assets/0388c02b-cccf-4f46-a1d1-7a7f3f78bc68" />

The benchmark can be opened directly for more advanced profiling at http://localhost:3000/bench/docs-infra/components/code-highlighter/demos/code