### PR TITLE
[code-infra] Prevent PRs until released longer than 3 days

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -6,7 +6,8 @@
     ":semanticCommitsDisabled",
     "group:definitelyTyped",
     "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "helpers:pinGitHubActionDigests",
+    "npm:unpublishSafe"
   ],
   "automerge": false,
   "commitMessageAction": "Bump",


### PR DESCRIPTION
Minimum 3 days, to exceed the unpublish period npm uses. Should also mitigate a bit supply-chain attacks