### PR TITLE
[code-infra] Add bundler define option

### DIFF
--- a/packages/bundle-size-checker/src/builder.js
+++ b/packages/bundle-size-checker/src/builder.js
@@ -29,9 +29,10 @@ const rootDir = process.cwd();
  * Creates vite configuration for bundle size checking
  * @param {ObjectEntry} entry - Entry point (string or object)
  * @param {CommandLineArgs} args
+ * @param {NormalizedBundleSizeCheckerConfig} config
  * @returns {Promise<import('vite').InlineConfig>}
  */
-async function createViteConfig(entry, args) {
+async function createViteConfig(entry, args, config) {
   const entryName = entry.id;
   let entryContent;
 
@@ -108,6 +109,7 @@ async function createViteConfig(entry, args) {
     },
 
     define: {
+      ...config.define,
       'process.env.NODE_ENV': JSON.stringify('production'),
     },
     logLevel: args.verbose ? 'info' : 'silent',
@@ -240,11 +242,12 @@ async function processBundleSizes(output, entryName) {
  * Get sizes for a vite bundle
  * @param {ObjectEntry} entry - The entry configuration
  * @param {CommandLineArgs} args - Command line arguments
+ * @param {NormalizedBundleSizeCheckerConfig} config - The normalized configuration
  * @returns {Promise<Map<string, SizeSnapshotEntry>>}
  */
-export async function getBundleSizes(entry, args) {
+export async function getBundleSizes(entry, args, config) {
   // Create vite configuration
-  const configuration = await createViteConfig(entry, args);
+  const configuration = await createViteConfig(entry, args, config);
 
   // Run vite build
   const { output } = /** @type {import('vite').Rollup.RollupOutput} */ (await build(configuration));

--- a/packages/bundle-size-checker/src/cli.js
+++ b/packages/bundle-size-checker/src/cli.js
@@ -85,7 +85,7 @@ async function getBundleSizes(args, config) {
 
   const sizeArrays = await Promise.all(
     validEntries.map((entry, index) =>
-      worker.run({ entry, args, index, total: validEntries.length }),
+      worker.run({ entry, args, config, index, total: validEntries.length }),
     ),
   );
 

--- a/packages/bundle-size-checker/src/configLoader.js
+++ b/packages/bundle-size-checker/src/configLoader.js
@@ -225,6 +225,7 @@ async function applyConfigDefaults(config, configPath) {
     entrypoints: await normalizeEntries(config.entrypoints, configPath),
     upload: null, // Default to disabled
     comment: config.comment !== undefined ? config.comment : true, // Default to enabled
+    define: config.define || {}, // Default to empty object
   };
 
   // Handle different types of upload value

--- a/packages/bundle-size-checker/src/types.d.ts
+++ b/packages/bundle-size-checker/src/types.d.ts
@@ -32,6 +32,7 @@ interface BundleSizeCheckerConfigObject {
   entrypoints: EntryPoint[];
   upload?: UploadConfig | boolean | null;
   comment?: boolean; // Whether to post PR comments (defaults to true)
+  define?: Record<string, any>; // Vite define option for global replacements
 }
 
 type BundleSizeCheckerConfig =
@@ -44,6 +45,7 @@ interface NormalizedBundleSizeCheckerConfig {
   entrypoints: ObjectEntry[];
   upload: NormalizedUploadConfig | null; // null means upload is disabled
   comment: boolean; // Whether to post PR comments
+  define: Record<string, any>; // Vite define option for global replacements
 }
 
 // Command line argument types

--- a/packages/bundle-size-checker/src/worker.js
+++ b/packages/bundle-size-checker/src/worker.js
@@ -56,10 +56,10 @@ async function getPeerDependencies(packageName) {
 
 /**
  * Get sizes for a bundle
- * @param {{ entry: ObjectEntry, args: CommandLineArgs, index: number, total: number }} options
+ * @param {{ entry: ObjectEntry, args: CommandLineArgs, config: NormalizedBundleSizeCheckerConfig, index: number, total: number }} options
  * @returns {Promise<Array<[string, SizeSnapshotEntry]>>}
  */
-export default async function getSizes({ entry, args, index, total }) {
+export default async function getSizes({ entry, args, config, index, total }) {
   // eslint-disable-next-line no-console -- process monitoring
   console.log(chalk.blue(`Compiling ${index + 1}/${total}: ${chalk.bold(`[${entry.id}]`)}`));
 
@@ -82,7 +82,7 @@ export default async function getSizes({ entry, args, index, total }) {
   }
 
   try {
-    const sizeMap = await getBundleSizes(entry, args);
+    const sizeMap = await getBundleSizes(entry, args, config);
 
     // Create a concise log message showing import details
     let entryDetails = '';


### PR DESCRIPTION
Enables stabilizing bundles in X, e.g.:

```diff
diff --git a/test/bundle-size/bundle-size-checker.config.mjs b/test/bundle-size/bundle-size-checker.config.mjs
index 617db4610f..e6d658af09 100644
--- a/test/bundle-size/bundle-size-checker.config.mjs
+++ b/test/bundle-size/bundle-size-checker.config.mjs
@@ -6,6 +6,8 @@
 import path from 'path';
 import glob from 'fast-glob';
 import { defineConfig } from '@mui/internal-bundle-size-checker';
+// eslint-disable-next-line import/no-relative-packages
+import generateReleaseInfo from '../../packages/x-license/generateReleaseInfo.js';
 
 const rootDir = path.resolve(import.meta.dirname, '../..');
 
@@ -74,6 +76,9 @@ export default defineConfig(async () => {
       '@mui/x-tree-view-pro',
       ...treeViewProComponents,
     ],
+    define: {
+      [JSON.stringify(generateReleaseInfo())]: JSON.stringify('xxxxxxxxxxx'),
+    },
     upload: !!process.env.CI,
     comment: false,
   };
```