### PR TITLE
[docs-infra] Move requestIdleCallback logic inside useEffect hook

### DIFF
--- a/packages/docs-infra/src/CodeHighlighter/CodeHighlighterClient.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/CodeHighlighterClient.tsx
@@ -14,9 +14,6 @@ import * as Errors from './errors';
 
 const DEBUG = false; // Set to true for debugging purposes
 
-const requestIdleCallback = window.requestIdleCallback ?? setTimeout;
-const cancelIdleCallback = window.cancelIdleCallback ?? clearTimeout;
-
 function useInitialData({
   variants,
   variantName,
@@ -362,6 +359,9 @@ function useCodeParsing({
 
   React.useEffect(() => {
     if (highlightAfter === 'idle') {
+      const requestIdleCallback = window.requestIdleCallback ?? setTimeout;
+      const cancelIdleCallback = window.cancelIdleCallback ?? clearTimeout;
+
       const idleRequest = requestIdleCallback(() => {
         setIsHighlightAllowed(true);
       });
@@ -865,6 +865,9 @@ export function CodeHighlighterClient(props: CodeHighlighterClientProps) {
 
   React.useEffect(() => {
     if (enhanceAfter === 'idle') {
+      const requestIdleCallback = window.requestIdleCallback ?? setTimeout;
+      const cancelIdleCallback = window.cancelIdleCallback ?? clearTimeout;
+
       const idleRequest = requestIdleCallback(() => {
         setIsEnhanceAllowed(true);
       });


### PR DESCRIPTION
Followup on https://github.com/mui/mui-public/pull/769

```
11:14:52 AM: Error occurred prerendering page "/menu". Read more: https://nextjs.org/docs/messages/prerender-error
11:14:52 AM: ReferenceError: window is not defined
11:14:52 AM:     at 27260 (.next/server/chunks/6322.js:1:86468)
11:14:52 AM:     at Object.c [as require] (.next/server/webpack-runtime.js:1:128) {
11:14:52 AM:   digest: '4261433363'
11:14:52 AM: }
11:14:52 AM: Export encountered an error on /menu/page: /menu, exiting the build.
```