### PR TITLE
[code-infra] Make sure only mui-public packages follow canary tag

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -108,11 +108,6 @@
     {
       "matchPackageNames": ["eslint-config-prettier"],
       "allowedVersions": ">=10.1.8"
-    },
-    {
-      "groupName": "globby",
-      "description": "Fix issue in X where globby is both a dependency and a devdependency",
-      "matchSourceUrls": ["https://github.com/sindresorhus/globby"]
     }
   ]
 }


### PR DESCRIPTION
e.g. `@mui/internal-test-utils` is not updating because there is no canary tag

~Also make sure `globby` stays grouped even if it's both a dpeendneydependency and a dev dependency. (there appears to be no way to group by sourceUrl without specifying one)~ Removed, do this on `mui/base-ui` directly