### PR TITLE
[code-infra] Add custom ignorePaths for renovate to update the dependencies

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -1,6 +1,6 @@
 # Renovate
 
-The `packageRules` is a hard to understand beast. In this READMNE we'll document all of our findings on how to do effective grouping of packages.
+The `packageRules` is a hard to understand beast. In this README we'll document all of our findings on how to do effective grouping of packages.
 
 ## How does it work
 

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -9,6 +9,13 @@
     "helpers:pinGitHubActionDigests",
     "npm:unpublishSafe"
   ],
+  "ignorePresets": [":ignoreModulesAndTests"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/__fixtures__/**"
+  ],
   "automerge": false,
   "commitMessageAction": "Bump",
   "commitMessageExtra": "to {{newValue}}",


### PR DESCRIPTION
Also add `:ignoreModulesAndTests` to the `ignorePresets` key so that it doesn't include the `**/test/**` string in the `ignorePaths`.