### PR TITLE
[code-infra] Special case `@mui/material` in `set-version-overrides` cmd

### DIFF
--- a/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
+++ b/packages/code-infra/src/cli/cmdSetVersionOverrides.mjs
@@ -51,6 +51,22 @@ async function processPackageOverride(packageSpec) {
     if (reactMajor === 17) {
       overrides['@testing-library/react'] = await resolveVersion('@testing-library/react@^12.1.0');
     }
+  } else if (packageName === '@mui/material') {
+    // Special case for MUI - also override related packages
+    overrides['@mui/material'] = await resolveVersion(`@mui/material@${version}`);
+    overrides['@mui/system'] = await resolveVersion(`@mui/system@${version}`);
+    overrides['@mui/icons-material'] = await resolveVersion(`@mui/icons-material@${version}`);
+    overrides['@mui/utils'] = await resolveVersion(`@mui/utils@${version}`);
+    overrides['@mui/material-nextjs'] = await resolveVersion(`@mui/material-nextjs@${version}`);
+
+    const latest = await resolveVersion(`@mui/material@latest`);
+    const latestMajor = semver.major(latest);
+    const muiMajor = semver.major(overrides['@mui/material']);
+    if (muiMajor < latestMajor) {
+      overrides['@mui/lab'] = await resolveVersion(`@mui/lab@latest-v${muiMajor}`);
+    } else {
+      overrides['@mui/lab'] = await resolveVersion(`@mui/lab@latest`);
+    }
   } else {
     // Generic case for other packages
     overrides[packageName] = await resolveVersion(packageSpec);


### PR DESCRIPTION
Fix the logic as reported in https://github.com/mui/mui-x/pull/19894#discussion_r2434843791

Technically we could run these concurrenlty, but let's not overcomplicate the code too much?