### PR TITLE
[code-infra] Include vitest-browser-react in Vite & Vitest renovate group

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -110,7 +110,7 @@
     },
     {
       "groupName": "Vite & Vitest",
-      "matchPackageNames": ["esbuild"]
+      "matchPackageNames": ["esbuild", "vitest-browser-react"]
     },
     {
       "matchPackageNames": ["eslint-config-prettier"],


### PR DESCRIPTION
Grouped `vitest-browser-react` alongside other Vite-related libraries to reduce the number of open PRs.