### PR TITLE
[docs-infra] Rewrite Hash Navigation

### DIFF
--- a/packages/docs-infra/src/pipeline/loaderUtils/processRelativeImports.test.ts
+++ b/packages/docs-infra/src/pipeline/loaderUtils/processRelativeImports.test.ts
@@ -273,6 +273,23 @@ describe('processRelativeImports', () => {
       './styles.module.css': 'file:///src/styles/index.module.css',
     });
   });
+
+  it('should handle _index.module.css files as direct index imports in flat mode', () => {
+    const source = `import styles from '../../dir/_index.module.css';`;
+    const importResult = {
+      '../../dir/_index.module.css': { path: '/src/dir/_index.module.css', names: [] },
+    };
+    const resolvedPathsMap = new Map([
+      ['/src/dir/_index.module.css', '/src/dir/_index.module.css'],
+    ]);
+
+    const result = processRelativeImports(source, importResult, 'flat', true, resolvedPathsMap);
+
+    // _index.module.css should be treated as a direct index import and become "./index.module.css"
+    expect(result.extraFiles).toEqual({
+      './index.module.css': 'file:///src/dir/_index.module.css',
+    });
+  });
 });
 
 describe('processCssImports', () => {

--- a/packages/docs-infra/src/pipeline/loaderUtils/processRelativeImports.ts
+++ b/packages/docs-infra/src/pipeline/loaderUtils/processRelativeImports.ts
@@ -50,10 +50,15 @@ function processFlatMode(
   for (const file of fileMapping) {
     const fileName = file.segments[file.segments.length - 1];
     const isIndexFile = fileName.startsWith('index.');
+    const isUnderscoreIndexFile = fileName.startsWith('_index.');
 
     let candidateName: string;
 
-    if (isIndexFile) {
+    if (isUnderscoreIndexFile) {
+      // Files starting with "_index." should be treated as direct index imports
+      // e.g., "../../dir/_index.module.css" -> "index.module.css"
+      candidateName = `index${file.extension}`;
+    } else if (isIndexFile) {
       // Check if the original import was a direct index file (e.g., "./index.ext")
       const originalImportParts = file.originalImportPath.split('/');
       const isDirectIndexImport =
@@ -142,10 +147,14 @@ function processFlatMode(
               for (const file of longerFiles) {
                 const fileName = file.segments[file.segments.length - 1];
                 const isIndexFile = fileName.startsWith('index.');
+                const isUnderscoreIndexFile = fileName.startsWith('_index.');
                 const distinguishingSegment = file.segments[distinguishingIndex];
 
                 let finalName: string;
-                if (isIndexFile) {
+                if (isUnderscoreIndexFile) {
+                  // Files starting with "_index." should always use "index" as the base name
+                  finalName = `${distinguishingSegment}/index${file.extension}`;
+                } else if (isIndexFile) {
                   // Check if this was a direct index import
                   const originalImportParts = file.originalImportPath.split('/');
                   const isDirectIndexImport =
@@ -197,10 +206,14 @@ function processFlatMode(
       for (const file of conflictingFiles) {
         const fileName = file.segments[file.segments.length - 1];
         const isIndexFile = fileName.startsWith('index.');
+        const isUnderscoreIndexFile = fileName.startsWith('_index.');
         const distinguishingSegment = file.segments[distinguishingIndex];
 
         let finalName: string;
-        if (isIndexFile) {
+        if (isUnderscoreIndexFile) {
+          // Files starting with "_index." should always use "index" as the base name
+          finalName = `${distinguishingSegment}/index${file.extension}`;
+        } else if (isIndexFile) {
           // Check if this was a direct index import
           const originalImportParts = file.originalImportPath.split('/');
           const isDirectIndexImport =

--- a/packages/docs-infra/src/useCode/useCode.ts
+++ b/packages/docs-infra/src/useCode/useCode.ts
@@ -19,6 +19,19 @@ export type UseCodeOpts = {
   githubUrlPrefix?: string;
   initialVariant?: string;
   initialTransform?: string;
+  /**
+   * Controls hash removal behavior when user interacts with file tabs:
+   * - 'remove-hash': Remove entire hash (default)
+   * - 'remove-filename': Remove only filename, keep variant in hash
+   */
+  fileHashMode?: 'remove-hash' | 'remove-filename';
+  /**
+   * Controls when to save hash variant to localStorage:
+   * - 'on-load': Save immediately when page loads with hash
+   * - 'on-interaction': Save only when user clicks a tab (default)
+   * - 'never': Never save hash variant to localStorage
+   */
+  saveHashVariantToLocalStorage?: 'on-load' | 'on-interaction' | 'never';
 };
 
 type UserProps<T extends {} = {}> = T & {
@@ -58,6 +71,8 @@ export function useCode<T extends {} = {}>(
     initialTransform,
     preClassName,
     preRef,
+    fileHashMode = 'remove-hash',
+    saveHashVariantToLocalStorage = 'on-interaction',
   } = opts || {};
 
   // Safely try to get context values - will be undefined if not in context
@@ -103,8 +118,8 @@ export function useCode<T extends {} = {}>(
     } as UserProps<T>;
   }, [contentProps, context?.url]);
 
-  // Sub-hook: UI State Management
-  const uiState = useUIState({ defaultOpen });
+  // Sub-hook: UI State Management (needs slug to check for relevant hash)
+  const uiState = useUIState({ defaultOpen, mainSlug: userProps.slug });
 
   // Sub-hook: Variant Selection
   const variantSelection = useVariantSelection({
@@ -112,6 +127,7 @@ export function useCode<T extends {} = {}>(
     initialVariant,
     variantType: contentProps.variantType,
     mainSlug: userProps.slug,
+    saveHashVariantToLocalStorage,
   });
 
   // Sub-hook: Transform Management
@@ -132,11 +148,14 @@ export function useCode<T extends {} = {}>(
     selectedVariantKey: variantSelection.selectedVariantKey,
     selectVariant: variantSelection.selectVariantProgrammatic,
     variantKeys: variantSelection.variantKeys,
-    initialVariant,
     shouldHighlight,
     preClassName,
     preRef,
     effectiveCode,
+    fileHashMode,
+    saveHashVariantToLocalStorage,
+    saveVariantToLocalStorage: variantSelection.saveVariantToLocalStorage,
+    hashVariant: variantSelection.hashVariant,
   });
 
   // Sub-hook: Copy Functionality

--- a/packages/docs-infra/src/useCode/useUIState.test.ts
+++ b/packages/docs-infra/src/useCode/useUIState.test.ts
@@ -1,0 +1,404 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useUIState } from './useUIState';
+
+// Mock the useUrlHashState hook to prevent browser API issues
+// JSDOM doesn't fully support hash change events, so we mock this to control hash values in tests
+let mockHashValue: string | null = null;
+let mockSetHash = vi.fn();
+
+vi.mock('../useUrlHashState', () => ({
+  useUrlHashState: () => [mockHashValue, mockSetHash],
+}));
+
+describe('useUIState', () => {
+  beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
+    mockHashValue = null;
+    mockSetHash = vi.fn();
+  });
+
+  describe('initial state', () => {
+    it('should start collapsed when defaultOpen is false and no relevant hash', () => {
+      mockHashValue = null;
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('should start expanded when defaultOpen is true', () => {
+      mockHashValue = null;
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: true,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should auto-expand when relevant hash is present on mount', () => {
+      // Hash is relevant to this demo
+      mockHashValue = 'demo:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      // Should auto-expand because hash is relevant
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should not auto-expand when hash is for different demo', () => {
+      // Hash is for a different demo
+      mockHashValue = 'other-demo:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      // Should not expand because hash is not relevant
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('should handle missing mainSlug gracefully', () => {
+      mockHashValue = 'demo:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          // mainSlug not provided
+        }),
+      );
+
+      // Should not expand because mainSlug is undefined
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('should handle empty mainSlug gracefully', () => {
+      mockHashValue = 'demo:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: '',
+        }),
+      );
+
+      // Should not expand because mainSlug is empty
+      expect(result.current.expanded).toBe(false);
+    });
+  });
+
+  describe('expand function', () => {
+    it('should expand when expand function is called', () => {
+      mockHashValue = null;
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      act(() => {
+        result.current.expand();
+      });
+
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should be stable and not cause re-renders', () => {
+      mockHashValue = null;
+
+      const { result, rerender } = renderHook(() => {
+        return useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        });
+      });
+
+      const firstExpand = result.current.expand;
+      rerender();
+      const secondExpand = result.current.expand;
+
+      // expand function should be stable (same reference)
+      expect(firstExpand).toBe(secondExpand);
+    });
+  });
+
+  describe('setExpanded function', () => {
+    it('should allow manual control of expanded state', () => {
+      mockHashValue = null;
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      act(() => {
+        result.current.setExpanded(true);
+      });
+
+      expect(result.current.expanded).toBe(true);
+
+      act(() => {
+        result.current.setExpanded(false);
+      });
+
+      expect(result.current.expanded).toBe(false);
+    });
+
+    it('should support functional updates', () => {
+      mockHashValue = null;
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      act(() => {
+        result.current.setExpanded((prev) => !prev);
+      });
+
+      expect(result.current.expanded).toBe(true);
+
+      act(() => {
+        result.current.setExpanded((prev) => !prev);
+      });
+
+      expect(result.current.expanded).toBe(false);
+    });
+  });
+
+  describe('hash change behavior', () => {
+    it('should auto-expand when hash becomes relevant', () => {
+      mockHashValue = null;
+
+      const { result, rerender } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      // Hash becomes relevant
+      mockHashValue = 'demo:file.tsx';
+      rerender();
+
+      // Should auto-expand
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should not auto-expand if already expanded', () => {
+      mockHashValue = null;
+
+      const { result, rerender } = renderHook(() =>
+        useUIState({
+          defaultOpen: true,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(true);
+
+      // Hash becomes relevant, but already expanded
+      mockHashValue = 'demo:file.tsx';
+      rerender();
+
+      // Should still be expanded
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should not collapse when hash becomes irrelevant', () => {
+      // Start with relevant hash
+      mockHashValue = 'demo:file.tsx';
+
+      const { result, rerender } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(true);
+
+      // Hash becomes irrelevant
+      mockHashValue = 'other-demo:file.tsx';
+      rerender();
+
+      // Should NOT auto-collapse - user may have manually expanded
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should not collapse when hash is removed', () => {
+      // Start with relevant hash
+      mockHashValue = 'demo:file.tsx';
+
+      const { result, rerender } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(true);
+
+      // Hash is removed
+      mockHashValue = null;
+      rerender();
+
+      // Should NOT auto-collapse
+      expect(result.current.expanded).toBe(true);
+    });
+  });
+
+  describe('kebab-case slug matching', () => {
+    it('should match PascalCase mainSlug with kebab-case hash', () => {
+      mockHashValue = 'my-complex-demo:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'MyComplexDemo',
+        }),
+      );
+
+      // Should auto-expand because "MyComplexDemo" converts to "my-complex-demo"
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should match camelCase mainSlug with kebab-case hash', () => {
+      mockHashValue = 'my-demo-name:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'myDemoName',
+        }),
+      );
+
+      // Should auto-expand because "myDemoName" converts to "my-demo-name"
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should handle hash with variant in the middle', () => {
+      mockHashValue = 'demo:typescript:file.tsx';
+
+      const { result } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      // Should auto-expand because hash starts with "demo:"
+      expect(result.current.expanded).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle rapid hash changes', () => {
+      mockHashValue = null;
+
+      const { result, rerender } = renderHook(() =>
+        useUIState({
+          defaultOpen: false,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      // Rapid hash changes
+      mockHashValue = 'demo:file1.tsx';
+      rerender();
+      expect(result.current.expanded).toBe(true);
+
+      mockHashValue = 'demo:file2.tsx';
+      rerender();
+      expect(result.current.expanded).toBe(true);
+
+      mockHashValue = 'demo:file3.tsx';
+      rerender();
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should handle manual collapse followed by relevant hash', () => {
+      mockHashValue = null;
+
+      const { result, rerender } = renderHook(() =>
+        useUIState({
+          defaultOpen: true,
+          mainSlug: 'demo',
+        }),
+      );
+
+      expect(result.current.expanded).toBe(true);
+
+      // User manually collapses
+      act(() => {
+        result.current.setExpanded(false);
+      });
+
+      expect(result.current.expanded).toBe(false);
+
+      // Hash becomes relevant - should re-expand
+      mockHashValue = 'demo:file.tsx';
+      rerender();
+
+      expect(result.current.expanded).toBe(true);
+    });
+
+    it('should handle defaultOpen changing', () => {
+      mockHashValue = null;
+
+      const { result, rerender } = renderHook(
+        ({ defaultOpen }) =>
+          useUIState({
+            defaultOpen,
+            mainSlug: 'demo',
+          }),
+        {
+          initialProps: { defaultOpen: false },
+        },
+      );
+
+      expect(result.current.expanded).toBe(false);
+
+      // Changing defaultOpen doesn't affect current state (only initial state)
+      rerender({ defaultOpen: true });
+
+      // State shouldn't change - defaultOpen only affects initial render
+      expect(result.current.expanded).toBe(false);
+    });
+  });
+});

--- a/packages/docs-infra/src/useCode/useUIState.ts
+++ b/packages/docs-infra/src/useCode/useUIState.ts
@@ -1,7 +1,10 @@
 import * as React from 'react';
+import { useUrlHashState } from '../useUrlHashState';
+import { isHashRelevantToDemo } from './useFileNavigation';
 
 interface UseUIStateProps {
   defaultOpen?: boolean;
+  mainSlug?: string;
 }
 
 export interface UseUIStateResult {
@@ -12,10 +15,21 @@ export interface UseUIStateResult {
 
 /**
  * Hook for managing UI state like expansion and focus
+ * Auto-expands if there's a relevant hash for this demo
  */
-export function useUIState({ defaultOpen = false }: UseUIStateProps): UseUIStateResult {
-  const [expanded, setExpanded] = React.useState(defaultOpen);
+export function useUIState({ defaultOpen = false, mainSlug }: UseUIStateProps): UseUIStateResult {
+  const [hash] = useUrlHashState();
+  const hasRelevantHash = isHashRelevantToDemo(hash, mainSlug);
+
+  const [expanded, setExpanded] = React.useState(defaultOpen || hasRelevantHash);
   const expand = React.useCallback(() => setExpanded(true), []);
+
+  // Auto-expand if hash becomes relevant
+  React.useEffect(() => {
+    if (hasRelevantHash && !expanded) {
+      setExpanded(true);
+    }
+  }, [hasRelevantHash, expanded]);
 
   return {
     expanded,

--- a/packages/docs-infra/src/useCode/useVariantSelection.ts
+++ b/packages/docs-infra/src/useCode/useVariantSelection.ts
@@ -2,13 +2,70 @@ import * as React from 'react';
 import type { Code, VariantCode } from '../CodeHighlighter/types';
 import { usePreference } from '../usePreference';
 import { useUrlHashState } from '../useUrlHashState';
-import { isHashRelevantToDemo } from './useFileNavigation';
+import { isHashRelevantToDemo, toKebabCase } from './useFileNavigation';
+
+/**
+ * Parses the variant name from a URL hash
+ * Hash formats:
+ * - slug:file.tsx -> "Default"
+ * - slug:variant:file.tsx -> "variant"
+ * - slug:variant -> "variant"
+ * @param urlHash - The URL hash (without '#')
+ * @param mainSlug - The main slug for the demo (optional, used to determine if hash is relevant for file selection)
+ * @param variantKeys - Available variant keys
+ * @returns The variant name or null if not found/parseable
+ */
+function parseVariantFromHash(
+  urlHash: string | null,
+  mainSlug: string | undefined,
+  variantKeys: string[],
+): string | null {
+  if (!urlHash) {
+    return null;
+  }
+
+  const parts = urlHash.split(':');
+
+  // If there are 3 parts (slug:variant:file), the variant is in the middle
+  if (parts.length === 3) {
+    const variantPart = parts[1];
+    // Find matching variant key (case-insensitive kebab match)
+    const matchingVariant = variantKeys.find(
+      (key) => toKebabCase(key) === variantPart.toLowerCase(),
+    );
+    return matchingVariant || null;
+  }
+
+  // If there are 2 parts, could be slug:variant or slug:file
+  if (parts.length === 2) {
+    const secondPart = parts[1];
+    // Try to match as a variant first
+    const matchingVariant = variantKeys.find(
+      (key) => toKebabCase(key) === secondPart.toLowerCase(),
+    );
+    if (matchingVariant) {
+      return matchingVariant;
+    }
+    // If no matching variant and it looks like a filename, assume Default
+    if (secondPart.includes('.')) {
+      return 'Default';
+    }
+  }
+
+  // Just the slug with no other parts, assume Default
+  if (parts.length === 1) {
+    return 'Default';
+  }
+
+  return null;
+}
 
 interface UseVariantSelectionProps {
   effectiveCode: Code;
   initialVariant?: string;
   variantType?: string;
   mainSlug?: string;
+  saveHashVariantToLocalStorage?: 'on-load' | 'on-interaction' | 'never';
 }
 
 export interface UseVariantSelectionResult {
@@ -17,17 +74,21 @@ export interface UseVariantSelectionResult {
   selectedVariant: VariantCode | null;
   selectVariant: React.Dispatch<React.SetStateAction<string>>;
   selectVariantProgrammatic: React.Dispatch<React.SetStateAction<string>>;
+  saveVariantToLocalStorage: (variant: string) => void;
+  hashVariant: string | null;
 }
 
 /**
  * Hook for managing variant selection and providing variant-related data
- * Uses React state as source of truth, with localStorage for persistence
+ * Priority: URL hash > localStorage > initialVariant > first variant
+ * When hash has a variant, it overrides localStorage and is saved to localStorage
  */
 export function useVariantSelection({
   effectiveCode,
   initialVariant,
   variantType,
   mainSlug,
+  saveHashVariantToLocalStorage = 'on-interaction',
 }: UseVariantSelectionProps): UseVariantSelectionResult {
   // Get variant keys from effective code
   const variantKeys = React.useMemo(() => {
@@ -37,12 +98,11 @@ export function useVariantSelection({
     });
   }, [effectiveCode]);
 
-  // Check if there's a URL hash present that's relevant to this demo
-  // Only override localStorage if hash starts with this demo's slug
-  const [urlHash] = useUrlHashState();
-  const hasRelevantUrlHash = React.useMemo(
-    () => isHashRelevantToDemo(urlHash, mainSlug),
-    [urlHash, mainSlug],
+  // Get URL hash and parse variant from it
+  const [urlHash, setUrlHash] = useUrlHashState();
+  const hashVariant = React.useMemo(
+    () => parseVariantFromHash(urlHash, mainSlug, variantKeys),
+    [urlHash, mainSlug, variantKeys],
   );
 
   // Use localStorage hook for variant persistence
@@ -50,74 +110,121 @@ export function useVariantSelection({
     return null;
   });
 
-  // Initialize state - will be updated by effect if localStorage should be used
+  // Track if the last change was user-initiated (to prevent hash from overriding)
+  const isUserInitiatedChange = React.useRef(false);
+  // Track previous hash variant to detect hash changes
+  const prevHashVariant = React.useRef<string | null>(hashVariant);
+  // Track previous storedValue to detect localStorage changes
+  const prevStoredValue = React.useRef<string | null>(storedValue);
+
+  // Determine initial variant: hash > localStorage > initialVariant > first variant
   const [selectedVariantKey, setSelectedVariantKeyState] = React.useState(() => {
-    // Use initial variant if provided and valid
+    // Priority 1: Hash variant
+    if (hashVariant && variantKeys.includes(hashVariant)) {
+      return hashVariant;
+    }
+    // Priority 2: localStorage
+    if (storedValue && variantKeys.includes(storedValue)) {
+      return storedValue;
+    }
+    // Priority 3: initialVariant prop
     if (initialVariant && variantKeys.includes(initialVariant)) {
       return initialVariant;
     }
-
-    // Final fallback: use first available variant
+    // Priority 4: First available variant
     return variantKeys[0] || '';
   });
 
-  // On mount, check if we should restore from localStorage
-  // This needs to be in an effect because we need to check hasRelevantUrlHash which depends on urlHash
-  const [hasInitialized, setHasInitialized] = React.useState(false);
+  // Track selected variant key in a ref for use in effect without causing re-runs
+  const selectedVariantKeyRef = React.useRef(selectedVariantKey);
   React.useEffect(() => {
-    if (hasInitialized) {
+    selectedVariantKeyRef.current = selectedVariantKey;
+  });
+
+  // When hash changes and has a variant, override current selection
+  // When hash is removed, fall back to localStorage
+  React.useEffect(() => {
+    // Skip if this was a user-initiated change
+    if (isUserInitiatedChange.current) {
+      // Only reset the flag once the hash has actually been cleared
+      if (hashVariant === null && urlHash === null) {
+        isUserInitiatedChange.current = false;
+      }
+      prevHashVariant.current = hashVariant;
       return;
     }
-    setHasInitialized(true);
 
-    // If there's a relevant URL hash, don't use localStorage - hash takes priority
-    if (hasRelevantUrlHash) {
+    // Only apply hash if it actually changed (not just a re-render with same hash)
+    const hashChanged = prevHashVariant.current !== hashVariant;
+    const storedValueChanged = prevStoredValue.current !== storedValue;
+    prevHashVariant.current = hashVariant;
+    prevStoredValue.current = storedValue;
+
+    if (!hashChanged && !storedValueChanged) {
       return;
     }
 
-    // If we have a stored value, use it (localStorage takes priority over initialVariant)
-    if (storedValue && variantKeys.includes(storedValue)) {
+    if (
+      hashVariant &&
+      variantKeys.includes(hashVariant) &&
+      hashVariant !== selectedVariantKeyRef.current
+    ) {
+      // Hash has a variant - use it
+      setSelectedVariantKeyState(hashVariant);
+      // Save hash variant to localStorage based on configuration
+      if (saveHashVariantToLocalStorage === 'on-load' && hashVariant !== storedValue) {
+        setStoredValue(hashVariant);
+      }
+    } else if (
+      !hashVariant &&
+      !urlHash && // Only fall back to localStorage when hash is truly empty
+      storedValue &&
+      variantKeys.includes(storedValue) &&
+      storedValue !== selectedVariantKeyRef.current
+    ) {
+      // Hash is empty but localStorage has a variant - use it
       setSelectedVariantKeyState(storedValue);
     }
-  }, [hasInitialized, hasRelevantUrlHash, storedValue, variantKeys]);
+  }, [
+    hashVariant,
+    urlHash,
+    variantKeys,
+    // Note: selectedVariantKey is intentionally NOT in dependencies
+    // to avoid effect running when user manually changes variant
+    storedValue,
+    setStoredValue,
+    saveHashVariantToLocalStorage,
+  ]);
 
-  // Sync with localStorage changes (but don't override programmatic changes or when hash is present)
-  // Only sync when storedValue changes, not when selectedVariantKey changes
-  const prevStoredValue = React.useRef(storedValue);
-  React.useEffect(() => {
-    // Don't sync from localStorage when a relevant URL hash is present - hash takes absolute priority
-    if (hasRelevantUrlHash) {
-      return;
-    }
-    if (storedValue !== prevStoredValue.current) {
-      prevStoredValue.current = storedValue;
-      if (storedValue && variantKeys.includes(storedValue) && storedValue !== selectedVariantKey) {
-        setSelectedVariantKeyState(storedValue);
-      }
-    }
-  }, [storedValue, variantKeys, selectedVariantKey, hasRelevantUrlHash]);
-
+  // Programmatic setter: doesn't save to localStorage (used for hash-driven changes)
   const setSelectedVariantKeyProgrammatic = React.useCallback(
     (value: React.SetStateAction<string>) => {
       const resolvedValue = typeof value === 'function' ? value(selectedVariantKey) : value;
       if (variantKeys.includes(resolvedValue)) {
-        // Only update React state, not localStorage
-        // This prevents conflicts with hash-driven navigation
         setSelectedVariantKeyState(resolvedValue);
       }
     },
     [selectedVariantKey, variantKeys],
   );
 
+  // User setter: saves to localStorage (used for user-initiated changes like dropdown)
   const setSelectedVariantKeyAsUser = React.useCallback(
     (value: React.SetStateAction<string>) => {
       const resolvedValue = typeof value === 'function' ? value(selectedVariantKey) : value;
       if (variantKeys.includes(resolvedValue)) {
+        // Mark as user-initiated to prevent hash effect from overriding
+        isUserInitiatedChange.current = true;
+        // Clear hash if it exists and is relevant to this demo
+        if (urlHash && mainSlug && isHashRelevantToDemo(urlHash, mainSlug)) {
+          setUrlHash(null);
+          // Update prevHashVariant to reflect that hash is now null
+          prevHashVariant.current = null;
+        }
         setSelectedVariantKeyState(resolvedValue);
         setStoredValue(resolvedValue);
       }
     },
-    [setStoredValue, selectedVariantKey, variantKeys],
+    [setStoredValue, selectedVariantKey, variantKeys, urlHash, mainSlug, setUrlHash],
   );
 
   const selectedVariant = React.useMemo(() => {
@@ -131,11 +238,19 @@ export function useVariantSelection({
   // Safety check: if selectedVariant doesn't exist, fall back to first variant
   React.useEffect(() => {
     if (!selectedVariant && variantKeys.length > 0) {
-      // Don't mark this as a user selection - it's just a fallback
-      // Use programmatic setter to avoid localStorage save
       setSelectedVariantKeyProgrammatic(variantKeys[0]);
     }
   }, [selectedVariant, variantKeys, setSelectedVariantKeyProgrammatic]);
+
+  // Function to save variant to localStorage (used for on-interaction mode)
+  const saveVariantToLocalStorage = React.useCallback(
+    (variant: string) => {
+      if (saveHashVariantToLocalStorage === 'on-interaction' && variant !== storedValue) {
+        setStoredValue(variant);
+      }
+    },
+    [saveHashVariantToLocalStorage, storedValue, setStoredValue],
+  );
 
   return {
     variantKeys,
@@ -143,5 +258,7 @@ export function useVariantSelection({
     selectedVariant,
     selectVariant: setSelectedVariantKeyAsUser,
     selectVariantProgrammatic: setSelectedVariantKeyProgrammatic,
+    saveVariantToLocalStorage,
+    hashVariant,
   };
 }


### PR DESCRIPTION
The base-ui team wants to avoid populating the hash with URLs, so we can just fallback to the behavior of native `<a href>` elements to copy the URL.

Now we should not add the hash to the address bar, and if there's a hash remove it after a user clicks another tab

Always uses variant in URL e.g. `#demo:variantA:file.ts` and `#demo:variantB:file.ts` unless there is only a single variant

Reimplements https://github.com/mui/mui-public/pull/776 using discussion from https://github.com/mui/base-ui/pull/2443#issuecomment-3480545300