### PR TITLE
[code-infra] Ignore publish-preview for all renovate commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
   publish-preview:
     if: >
       github.event_name == 'schedule'
-      || (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'Bump '))
+      || (github.event_name == 'push' && github.event.head_commit.author.name != 'renovate[bot]')
       || (github.event_name == 'workflow_dispatch' && inputs.preview == true)
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
I saw that a release was triggered for `Lockfile maintenance` PR merge.
