### PR TITLE
[code-infra] Add transformer to add explicit undefined to optional types

### DIFF
--- a/packages/code-infra/src/utils/tsAddExplicitUndefined.mjs
+++ b/packages/code-infra/src/utils/tsAddExplicitUndefined.mjs
@@ -1,0 +1,175 @@
+import * as fs from 'node:fs/promises';
+import { globby } from 'globby';
+import ts from 'typescript';
+import { mapConcurrently } from './build.mjs';
+
+const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+/**
+ * Check if a type node contains undefined by analyzing the type structure
+ * and resolving type references using the type checker
+ *
+ * @param {ts.TypeNode} typeNode
+ * @param {ts.TypeChecker} checker
+ * @returns {boolean}
+ */
+function containsUndefined(typeNode, checker) {
+  // Direct undefined keyword
+  if (typeNode.kind === ts.SyntaxKind.UndefinedKeyword) {
+    return true;
+  }
+
+  // Literal undefined
+  if (ts.isLiteralTypeNode(typeNode) && typeNode.literal.kind === ts.SyntaxKind.UndefinedKeyword) {
+    return true;
+  }
+
+  // Parenthesized type
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return containsUndefined(typeNode.type, checker);
+  }
+
+  // Union type - check each member
+  if (ts.isUnionTypeNode(typeNode)) {
+    return typeNode.types.some((t) => containsUndefined(t, checker));
+  }
+
+  // Type reference (e.g., imported types, type aliases)
+  // Need to resolve the symbol to check if it's a type alias that includes undefined
+  if (ts.isTypeReferenceNode(typeNode)) {
+    // Try to get the symbol and resolve type aliases
+    const symbol = checker.getSymbolAtLocation(typeNode.typeName);
+    if (symbol && symbol.declarations && symbol.declarations.length > 0) {
+      const decl = symbol.declarations[0];
+      // If it's a type alias, recursively check the aliased type
+      if (ts.isTypeAliasDeclaration(decl) && decl.type) {
+        return containsUndefined(decl.type, checker);
+      }
+    }
+
+    // Fallback: check the resolved type
+    const type = checker.getTypeFromTypeNode(typeNode);
+    if (type.isUnion()) {
+      return type.types.some((t) => {
+        // eslint-disable-next-line no-bitwise
+        return (t.flags & ts.TypeFlags.Undefined) !== 0;
+      });
+    }
+
+    // eslint-disable-next-line no-bitwise
+    return (type.flags & ts.TypeFlags.Undefined) !== 0;
+  }
+
+  return false;
+}
+
+/**
+ * Adds the undefined type to the given type node.
+ * @param {ts.NodeFactory} factory
+ * @param {ts.TypeNode} typeNode
+ * @returns {ts.TypeNode}
+ */
+function addUndefinedToType(factory, typeNode) {
+  const undefinedNode = factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword);
+
+  if (ts.isUnionTypeNode(typeNode)) {
+    const unionMembers = [...typeNode.types, undefinedNode];
+    return factory.createUnionTypeNode(unionMembers);
+  }
+
+  return factory.createUnionTypeNode([typeNode, undefinedNode]);
+}
+
+/**
+ *
+ * @param {ts.TypeChecker} checker
+ * @returns {ts.TransformerFactory<ts.SourceFile>}
+ */
+function createTransformer(checker) {
+  return (context) => {
+    const { factory } = context;
+
+    /**
+     * @type {ts.Visitor}
+     */
+    const visitor = (node) => {
+      if (
+        (ts.isPropertySignature(node) || ts.isPropertyDeclaration(node)) &&
+        node.questionToken &&
+        node.type &&
+        !containsUndefined(node.type, checker)
+      ) {
+        const updatedType = addUndefinedToType(factory, node.type);
+
+        if (ts.isPropertySignature(node)) {
+          return factory.updatePropertySignature(
+            node,
+            node.modifiers,
+            node.name,
+            node.questionToken,
+            updatedType,
+          );
+        }
+
+        return factory.updatePropertyDeclaration(
+          node,
+          node.modifiers,
+          node.name,
+          node.questionToken,
+          updatedType,
+          node.initializer,
+        );
+      }
+
+      return ts.visitEachChild(node, visitor, context);
+    };
+
+    return (node) => /** @type {ts.SourceFile} */ (ts.visitNode(node, visitor));
+  };
+}
+
+/**
+ * @param {string} filePath
+ * @param {ts.Program} program
+ * @returns {Promise<void>}
+ */
+async function processFile(filePath, program) {
+  const sourceFile = program.getSourceFile(filePath);
+
+  if (!sourceFile) {
+    console.warn(`Could not find source file for ${filePath}`);
+    return;
+  }
+
+  const checker = program.getTypeChecker();
+  const result = ts.transform(sourceFile, [createTransformer(checker)]);
+  const [transformedFile] = result.transformed;
+  result.dispose();
+
+  const updatedContent = printer.printFile(transformedFile);
+
+  await fs.writeFile(filePath, updatedContent);
+}
+
+/**
+ * @param {string} dtsDirectory
+ */
+export async function tsAddExplicitUndefined(dtsDirectory) {
+  const dtsFiles = await globby('**/*.d.*', {
+    absolute: true,
+    cwd: dtsDirectory,
+  });
+  if (dtsFiles.length === 0) {
+    console.warn(`No .d.ts files found in directory: ${dtsDirectory}`);
+    return;
+  }
+  const program = ts.createProgram(dtsFiles, {
+    target: ts.ScriptTarget.Latest,
+    module: ts.ModuleKind.ESNext,
+    allowJs: false,
+    skipLibCheck: true,
+    skipDefaultLibCheck: true,
+  });
+
+  await mapConcurrently(dtsFiles, async (filePath) => processFile(filePath, program), 20);
+}

--- a/packages/code-infra/src/utils/tsAddExplicitUndefined.test.ts
+++ b/packages/code-infra/src/utils/tsAddExplicitUndefined.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+
+// eslint-disable-next-line import/extensions
+import { transformSourceFile } from './tsAddExplicitUndefined.mjs';
+
+/**
+ * Transform source code string by adding explicit undefined to optional properties.
+ */
+export function transformSourceCode(sourceCode: string, fileName = 'test.ts'): string {
+  const sourceFile = ts.createSourceFile(fileName, sourceCode, ts.ScriptTarget.Latest, true);
+
+  // Create a minimal program for the single file to get a type checker
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.LineFeed,
+  });
+  const program = ts.createProgram(
+    [fileName],
+    {
+      target: ts.ScriptTarget.Latest,
+      module: ts.ModuleKind.ESNext,
+      allowJs: false,
+      skipLibCheck: true,
+      skipDefaultLibCheck: true,
+    },
+    {
+      getSourceFile: (name) => (name === fileName ? sourceFile : undefined),
+      writeFile: () => {},
+      getCurrentDirectory: () => '',
+      getDirectories: () => [],
+      fileExists: () => true,
+      readFile: () => '',
+      getCanonicalFileName: (name) => name,
+      useCaseSensitiveFileNames: () => true,
+      getNewLine: () => '\n',
+      getDefaultLibFileName: () => 'lib.d.ts',
+    },
+  );
+
+  const checker = program.getTypeChecker();
+  return transformSourceFile(sourceFile, checker, printer);
+}
+
+describe('transformSourceCode', () => {
+  describe('basic optional properties', () => {
+    it('should add undefined to simple optional property', () => {
+      const input = `interface Foo {
+  bar?: string;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | undefined;');
+    });
+
+    it('should add undefined to multiple optional properties', () => {
+      const input = `interface Foo {
+  bar?: string;
+  baz?: number;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | undefined;');
+      expect(output).toContain('baz?: number | undefined;');
+    });
+
+    it('should not modify properties that already have undefined', () => {
+      const input = `interface Foo {
+  bar?: string | undefined;
+}`;
+      const output = transformSourceCode(input);
+      // The transformation should preserve the undefined type
+      expect(output).toContain('bar?: string | undefined;');
+      // Should not add another undefined
+      expect(output).not.toContain('bar?: string | undefined | undefined;');
+    });
+
+    it('should not modify required properties', () => {
+      const input = `interface Foo {
+  bar: string;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar: string;');
+      expect(output).not.toContain('bar?: string');
+    });
+  });
+
+  describe('union types', () => {
+    it('should add undefined to optional property with union type', () => {
+      const input = `interface Foo {
+  bar?: string | number;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | number | undefined;');
+    });
+
+    it('should not add undefined if union already includes it', () => {
+      const input = `interface Foo {
+  bar?: string | number | undefined;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | number | undefined;');
+      // Should not add duplicate undefined
+      expect(output).not.toContain('bar?: string | number | undefined | undefined;');
+    });
+
+    it('should handle null in union types', () => {
+      const input = `interface Foo {
+  bar?: string | null;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | null | undefined;');
+    });
+  });
+
+  describe('complex types', () => {
+    it('should handle optional properties with function types', () => {
+      const input = `interface Foo {
+  onClick?: (event: MouseEvent) => void;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('onClick?: ((event: MouseEvent) => void) | undefined;');
+    });
+
+    it('should handle optional properties with array types', () => {
+      const input = `interface Foo {
+  items?: string[];
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('items?: string[] | undefined;');
+    });
+
+    it('should handle optional properties with object types', () => {
+      const input = `interface Foo {
+  config?: { enabled: boolean };
+}`;
+      const output = transformSourceCode(input);
+      // The printer may format this differently, so just check that undefined was added
+      expect(output).toContain('config?:');
+      expect(output).toContain('| undefined');
+      expect(output).toContain('enabled: boolean');
+    });
+
+    it('should handle optional properties with generic types', () => {
+      const input = `interface Foo<T> {
+  value?: T;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('value?: T | undefined;');
+    });
+  });
+
+  describe('type aliases', () => {
+    it('should handle optional properties in type aliases', () => {
+      const input = `type Foo = {
+  bar?: string;
+};`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | undefined;');
+    });
+  });
+
+  describe('class properties', () => {
+    it('should handle optional class properties', () => {
+      const input = `class Foo {
+  bar?: string;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: string | undefined;');
+    });
+
+    it('should handle optional class properties with initializers', () => {
+      const input = `class Foo {
+  bar?: string = 'default';
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain("bar?: string | undefined = 'default';");
+    });
+  });
+
+  describe('parenthesized types', () => {
+    it('should handle parenthesized types', () => {
+      const input = `interface Foo {
+  bar?: (string | number);
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('bar?: (string | number) | undefined;');
+    });
+  });
+
+  describe('nested interfaces', () => {
+    it('should handle top-level optional properties with nested object types', () => {
+      const input = `interface Outer {
+  inner?: {
+    value?: string;
+  };
+}`;
+      const output = transformSourceCode(input);
+      // The outer property should get undefined added
+      expect(output).toContain('inner?:');
+      expect(output).toContain('| undefined');
+      // Note: nested properties inside object literal types are not transformed
+      // This is expected behavior - the transformation only handles interface/type properties
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty interfaces', () => {
+      const input = `interface Foo {}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('interface Foo');
+    });
+
+    it('should handle interfaces with only required properties', () => {
+      const input = `interface Foo {
+    bar: string;
+    baz: number;
+}
+`;
+      const output = transformSourceCode(input);
+      expect(output).toBe(input);
+    });
+
+    it('should handle mixed required and optional properties', () => {
+      const input = `interface Foo {
+  required: string;
+  optional?: number;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('required: string;');
+      expect(output).toContain('optional?: number | undefined;');
+    });
+
+    it('should preserve comments', () => {
+      const input = `interface Foo {
+  /**
+   * This is a comment
+   */
+  bar?: string;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('This is a comment');
+      expect(output).toContain('bar?: string | undefined;');
+    });
+
+    it('should handle readonly optional properties', () => {
+      const input = `interface Foo {
+  readonly bar?: string;
+}`;
+      const output = transformSourceCode(input);
+      expect(output).toContain('readonly bar?: string | undefined;');
+    });
+  });
+
+  describe('literal undefined', () => {
+    it('should detect literal undefined in union', () => {
+      const input = `interface Foo {
+    bar?: undefined;
+}
+`;
+      const output = transformSourceCode(input);
+      expect(output).toBe(input);
+    });
+  });
+
+  describe('pre-existing undefined', () => {
+    it('should not add undefined to pre-existing unions containing undefined', () => {
+      const input = `type Test = string | undefined;
+interface Foo {
+    bar?: Test;
+}
+`;
+      const output = transformSourceCode(input);
+      expect(output).toBe(input);
+    });
+  });
+});

--- a/packages/code-infra/src/utils/typescript.mjs
+++ b/packages/code-infra/src/utils/typescript.mjs
@@ -8,7 +8,9 @@ import { globby } from 'globby';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
 import { mapConcurrently } from '../utils/build.mjs';
+import { tsAddExplicitUndefined } from './tsAddExplicitUndefined.mjs';
 
 const $$ = $({ stdio: 'inherit' });
 
@@ -155,6 +157,8 @@ export async function createTypes({ bundles, srcDir, buildDir, cwd, skipTsc, isM
       console.log(`Building types for ${tsconfigPath} in ${tmpDir}`);
       await emitDeclarations(tsconfigPath, tmpDir);
     }
+
+    await tsAddExplicitUndefined(tmpDir);
 
     for (const bundle of bundles) {
       const { type: bundleType, dir: bundleOutDir } = bundle;


### PR DESCRIPTION
Currently, `undefined` is added to all optional properties and static check is done within the file and not across imports. Actual resolution of type across files would be quite slow anyways.

We could also narrow down `undefined` addition to just the exported types/interfaces or even variable names that specify certain patterns like ending with `Props` etc.