### PR TITLE
[support-infra] Removd `support: commercial` label from script

### DIFF
--- a/apps/tools-public/toolpad/pages/issueWithoutProductScope/page.yml
+++ b/apps/tools-public/toolpad/pages/issueWithoutProductScope/page.yml
@@ -29,7 +29,7 @@ spec:
         rows:
           $$jsExpression: >-
             (() => {
-              const nonProductScopeLabels = ['support: commercial', 'support: docs-feedback']
+              const nonProductScopeLabels = ['support: docs-feedback']
 
               return materialUI.rows
                 .concat(muix.rows)


### PR DESCRIPTION
This removes the `support: commercial` label from an inline script. 

Fixes #429 