### PR TITLE
[code-infra] Auto add security label on security deps PR

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -54,6 +54,9 @@
       "datasourceTemplate": "docker"
     }
   ],
+  "vulnerabilityAlerts": {
+    "addLabels": ["security"]
+  },
   "packageRules": [
     {
       "matchDepTypes": ["peerDependencies"],


### PR DESCRIPTION
I had to add it manually in https://github.com/mui/mui-x/pull/20555, we might as well automate it. The goal is to make those PRs easier to prioritize.

- Docs: https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts
- Prior art: https://github.com/mui/toolpad/blob/c1039b5b4d1edd96da284798c811d54fdf7c8d70/renovate.json#L161