### PR TITLE
[docs-infra] Copy the other repositories

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "@mui/internal-infra-docs",
-  "version": "0.1.0",
+  "name": "docs",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
This seems closer to how it's done on the other repositories. A quick follow-up on #431.

**Off-topic**. When it comes to dogfooding our own docs deploy infra, I guess it's a WIP. I couldn't find an issue for it, so: #946 created.