### PR TITLE
[code-infra] Add `:pinDevDependencies` to Renovate config

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,6 +4,7 @@
   "extends": [
     "github>mui/mui-public//renovate/base",
     ":semanticCommitsDisabled",
+    ":pinDevDependencies",
     "group:definitelyTyped",
     "config:recommended",
     "helpers:pinGitHubActionDigests",


### PR DESCRIPTION
Minimize the potential for lockfile updates to break CI. Instead let the weekly schedule make individual renovate PRs to update these dependencies. Or the catch-all devDependencies group if not individually grouped.

See https://github.com/mui/material-ui/pull/47454#discussion_r2605671882

🤔 `:pinOnlyDevDependencies` may even make sense for us, but maybe we want to retain more control