### PR TITLE
[frontend-public] Improve GitHub audit tool

### DIFF
--- a/apps/tools-public/package.json
+++ b/apps/tools-public/package.json
@@ -10,6 +10,7 @@
     "@googleapis/sheets": "^9.8.0",
     "@mui/system": "^7.3.6",
     "@mui/x-charts": "^8.21.0",
+    "@mui/x-data-grid-v8": "npm:@mui/x-data-grid@^8.23.0",
     "@octokit/core": "^7.0.6",
     "@toolpad/studio": "^0.13.0",
     "dayjs": "^1.11.19",

--- a/apps/tools-public/toolpad/components/AutoDataGrid.tsx
+++ b/apps/tools-public/toolpad/components/AutoDataGrid.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import { DataGrid, GridColDef } from '@mui/x-data-grid-v8';
+import { createComponent } from '@toolpad/studio/browser';
+
+export interface AutoDataGridProps {
+  rows: any[];
+  loading?: boolean;
+}
+
+function AutoDataGrid(props: AutoDataGridProps) {
+  const columns = React.useMemo<GridColDef[]>(() => {
+    if (!props.rows || props.rows.length === 0) {
+      return [];
+    }
+
+    const firstRow = props.rows[0];
+    return Object.keys(firstRow).map((key) => {
+      const value = firstRow[key];
+      let type: 'string' | 'number' | 'boolean' | 'dateTime' | 'date' = 'string';
+
+      if (typeof value === 'number') {
+        type = 'number';
+      } else if (typeof value === 'boolean') {
+        type = 'boolean';
+      } else if (value instanceof Date) {
+        type = 'dateTime';
+      }
+
+      return {
+        field: key,
+        width: 150,
+        type,
+      };
+    });
+  }, [props.rows]);
+
+  const rowsWithId = React.useMemo(() => {
+    return props.rows.map((row, index) => {
+      return { ...row, id: index };
+    });
+  }, [props.rows]);
+
+  return (
+    <div style={{ height: 500, width: '100%' }}>
+      <DataGrid
+        rows={rowsWithId}
+        columns={columns}
+        loading={props.loading}
+        disableRowSelectionOnClick
+        density="compact"
+      />
+    </div>
+  );
+}
+
+export default createComponent(AutoDataGrid, {
+  argTypes: {
+    rows: {
+      type: 'array',
+      default: [],
+    },
+  },
+  loadingPropSource: ['rows'],
+  loadingProp: 'loading',
+});

--- a/apps/tools-public/toolpad/components/Textarea.tsx
+++ b/apps/tools-public/toolpad/components/Textarea.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { createComponent } from '@toolpad/studio/browser';
+
+export interface TextareaProps {
+  value?: string;
+  onValueChange: (value: string) => {};
+}
+
+function Textarea(props: TextareaProps) {
+  return (
+    <textarea
+      style={{ width: '100%', height: 250 }}
+      value={props.value}
+      onChange={(event) => {
+        props.onValueChange(event.target.value);
+      }}
+    />
+  );
+}
+
+export default createComponent(Textarea, {
+  argTypes: {
+    value: {
+      type: 'string',
+      default: '',
+      onChangeProp: 'onValueChange',
+    },
+  },
+});

--- a/apps/tools-public/toolpad/pages/auditClosedIssues/page.yml
+++ b/apps/tools-public/toolpad/pages/auditClosedIssues/page.yml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/mui/toolpad/v0.13.0/docs/schemas/v1/definitions.json#properties/Page
+
+apiVersion: v1
+kind: page
+spec:
+  displayName: Audit closed issues
+  alias:
+    - xj43hyd
+  title: Audit closed Issue
+  content:
+    - component: PageRow
+      name: pageRow1
+      children:
+        - component: Text
+          name: text
+          layout:
+            columnSize: 0.6565656565656566
+            verticalAlign: center
+          props:
+            value: 'Filter for GitHub slug:'
+        - component: TextField
+          name: gitHubSlug
+          layout:
+            columnSize: 1.3434343434343434
+          props:
+            label: GitHub slug
+            defaultValue: linear
+            fullWidth: true
+    - component: Text
+      name: text1
+      layout:
+        columnSize: 1
+      props:
+        mode: markdown
+        value: Find issues closed by a slug.
+    - component: DataGrid
+      name: dataGrid
+      layout:
+        columnSize: 1
+        height: 548
+      props:
+        rows:
+          $$jsExpression: >-
+            queryAuditClosedIssues.rows
+              .filter((issue) => {
+                return issue.timelineItems.some((event) => event.actor === gitHubSlug.value)
+              })
+              .map((issue) => ({
+                ...issue,
+                closedAt: issue.timelineItems[0].createdAt,
+              }))
+        columns:
+          - field: title
+            type: string
+            width: 279
+            headerName: Title
+          - field: url
+            type: link
+            width: 362
+            headerName: URL
+          - field: closedAt
+            type: string
+            width: 200
+            headerName: Closed at
+        height: 480
+  queries:
+    - name: queryAuditClosedIssues
+      mode: query
+      query:
+        function: queryAuditClosedIssues.ts#queryAuditClosedIssues
+        kind: local

--- a/apps/tools-public/toolpad/pages/auditLabelChanges/page.yml
+++ b/apps/tools-public/toolpad/pages/auditLabelChanges/page.yml
@@ -3,7 +3,10 @@
 apiVersion: v1
 kind: page
 spec:
-  title: Label activity
+  displayName: Audit label activity
+  alias:
+    - xj43hyd
+  title: Audit label activity
   content:
     - component: PageRow
       name: pageRow1
@@ -31,7 +34,7 @@ spec:
         mode: markdown
         value: "Build for:
           https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a8\
-          4fdf50e44595afc55343dac00fca#0711365e6f2343bfbbb0c9c78bb2bc8d"
+          4fdf50e44595afc55343dac00fca#0711365e6f2343bfbbb0c9c78bb2bc8d."
     - component: DataGrid
       name: dataGrid
       layout:
@@ -40,7 +43,7 @@ spec:
       props:
         rows:
           $$jsExpression: >
-            queryLabelsActivity.rows
+            queryAuditLabelChanges.rows
               .filter((issue) => {
                 return issue.timelineItems.some((event) => event.actor === gitHubSlug.value)
               })
@@ -51,19 +54,19 @@ spec:
         columns:
           - field: title
             type: string
-            width: 279
+            width: 321
+            headerName: Title
           - field: url
             type: link
-            width: 362
+            width: 341
+            headerName: URL
           - field: timelineItems
             type: json
-            width: 263
+            width: 515
+            headerName: Labels
         height: 480
   queries:
-    - name: queryLabelsActivity
+    - name: queryAuditLabelChanges
       query:
-        function: queryLabelsActivity.ts#queryLabelsActivity
+        function: queryAuditLabelChanges.ts#queryAuditLabelChanges
         kind: local
-  alias:
-    - xj43hyd
-  displayName: Label activity

--- a/apps/tools-public/toolpad/pages/queryOssInsight/page.yml
+++ b/apps/tools-public/toolpad/pages/queryOssInsight/page.yml
@@ -1,0 +1,80 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/mui/toolpad/v0.13.0/docs/schemas/v1/definitions.json#properties/Page
+
+apiVersion: v1
+kind: page
+spec:
+  title: Query OSS Insight
+  display: shell
+  authorization:
+    allowAll: true
+  content:
+    - component: TextField
+      name: slug
+      props:
+        label: Repository slug
+        defaultValue: mui/material-ui
+      layout:
+        columnSize: 1
+    - component: Text
+      name: text
+      layout:
+        columnSize: 1
+        horizontalAlign: start
+        verticalAlign: center
+      props:
+        value:
+          $$jsExpression: |
+            (() => {
+              if (getRepositoryDetails.data) {
+                return `Repository ID: ${getRepositoryDetails.data.data.id}`
+              } else {
+                return "Not found"
+              }
+            })()
+    - component: codeComponent.Textarea
+      name: textarea
+    - component: Button
+      name: button
+      props:
+        content: Run query
+        onClick:
+          $$jsExpressionAction: queryOssInsight.fetch()
+        loading:
+          $$jsExpression: queryOssInsight.isLoading
+    - component: Paper
+      name: paper
+      children:
+        - component: Text
+          name: text1
+          props:
+            value:
+              $$jsExpression: queryOssInsight.error?.message ?? ''
+    - component: codeComponent.AutoDataGrid
+      name: autoDataGrid
+      props:
+        rows:
+          $$jsExpression: queryOssInsight.rows
+  queries:
+    - name: queryOssInsight
+      mode: mutation
+      query:
+        function: queryOssInsight.ts#queryOssInsight
+        kind: local
+      parameters:
+        - name: repositoryId
+          value:
+            $$jsExpression: getRepositoryDetails.data?.data?.id
+        - name: query
+          value:
+            $$jsExpression: textarea.value
+      enabled: true
+    - name: getRepositoryDetails
+      query:
+        function: functions.ts#getRepositoryDetails
+        kind: local
+      parameters:
+        - name: slug
+          value:
+            $$jsExpression: |
+              slug.value
+  displayName: Query OSS Insight

--- a/apps/tools-public/toolpad/resources/queryAuditClosedIssues.ts
+++ b/apps/tools-public/toolpad/resources/queryAuditClosedIssues.ts
@@ -1,0 +1,101 @@
+import { request } from 'graphql-request';
+
+interface CloseTimelineItem {
+  actor: {
+    login: string;
+  };
+  createdAt: string;
+}
+
+interface Issue {
+  number: number;
+  url: string;
+  title: string;
+  timelineItems: {
+    nodes: CloseTimelineItem[];
+  };
+}
+
+const query1 = `
+issues(first: 100, orderBy: { direction: DESC, field: UPDATED_AT }) {
+  nodes {
+    number
+    url
+    title
+    timelineItems(itemTypes: CLOSED_EVENT, last: 10) {
+      nodes {
+        ... on ClosedEvent {
+          actor {
+            login
+          }
+          createdAt
+        }
+      }
+    }
+  }
+}
+`;
+
+export async function queryAuditClosedIssues(githubUser?: string) {
+  if (!process.env.GITHUB_TOKEN) {
+    throw new Error(`Env variable GITHUB_TOKEN not configured`);
+  }
+
+  const endpoint = 'https://api.github.com/graphql';
+  const token = process.env.GITHUB_TOKEN;
+
+  const query = `
+    {
+      base_ui: repository(owner: "mui", name: "base-ui") {
+        ${query1}
+      }
+      mui_public: repository(owner: "mui", name: "mui-public") {
+        ${query1}
+      }
+      material_ui: repository(owner: "mui", name: "material-ui") {
+        ${query1}
+      }
+      mui_x: repository(owner: "mui", name: "mui-x") {
+        ${query1}
+      }
+      pigment_css: repository(owner: "mui", name: "pigment-css") {
+        ${query1}
+      }
+    }
+  `;
+
+  const response: any = await request(
+    endpoint,
+    query,
+    {},
+    {
+      Authorization: `Bearer ${token}`,
+    },
+  );
+
+  const data = [
+    ...response.base_ui.issues.nodes,
+    ...response.mui_public.issues.nodes,
+    ...response.material_ui.issues.nodes,
+    ...response.mui_x.issues.nodes,
+    ...response.pigment_css.issues.nodes,
+  ]
+    .map((issue: Issue) => ({
+      ...issue,
+      timelineItems: issue.timelineItems.nodes
+        .map((item: CloseTimelineItem) => {
+          return {
+            createdAt: item.createdAt,
+            // An actor can delete his account.
+            actor: item.actor?.login,
+          };
+        })
+        .filter((item) => !githubUser || item.actor === githubUser),
+    }))
+    .filter((issue) => issue.timelineItems.length > 0)
+    .sort((a, b) => {
+      return a.timelineItems[0].createdAt < b.timelineItems[0].createdAt ? 1 : -1;
+    });
+
+  return data;
+}

--- a/apps/tools-public/toolpad/resources/queryOssInsight.ts
+++ b/apps/tools-public/toolpad/resources/queryOssInsight.ts
@@ -1,0 +1,18 @@
+export async function queryOssInsight(repositoryId: string, query: string) {
+  const res = await fetch('https://api.ossinsight.io/q/playground', {
+    headers: {
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify({
+      type: 'repo',
+      sql: query,
+      id: repositoryId,
+    }),
+  });
+  if (res.status !== 200) {
+    throw new Error(`HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`);
+  }
+  const json = await res.json();
+  return json.data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@mui/x-charts':
         specifier: ^8.21.0
         version: 8.21.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@mui/material@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@mui/x-data-grid-v8':
+        specifier: npm:@mui/x-data-grid@^8.23.0
+        version: '@mui/x-data-grid@8.23.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@mui/material@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)'
       '@octokit/core':
         specifier: ^7.0.6
         version: 7.0.6
@@ -3399,6 +3402,22 @@ packages:
       '@emotion/styled':
         optional: true
 
+  '@mui/x-data-grid@8.23.0':
+    resolution: {integrity: sha512-fv8AiibTgwPKJsXtYdc5bYDDW3EQp/ieQ0iUejvZ2JbYikMIPTYjI4pHy7zW3F3RDsi6DGQnw5AW6LeoDcT0fA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
   '@mui/x-date-pickers-pro@7.27.3':
     resolution: {integrity: sha512-gbCq5gSt8Bcs3EENSUK66mPwYNv8z9+P8gHj/9iW9F+a0bnPyYjoy+wl/UAItgXLBdxZuCbGO0Qp8Tcc5/5N0w==}
     engines: {node: '>=14.0.0'}
@@ -3488,6 +3507,12 @@ packages:
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@mui/x-internals@8.23.0':
+    resolution: {integrity: sha512-FN7wdqwTxqq1tJBYVz8TA/HMcViuaHS0Jphr4pEjT/8Iuf94Yt3P82WbsTbXyYrgOQDQl07UqE7qWcJetRcHcg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mui/x-license@7.26.0':
     resolution: {integrity: sha512-WxwBGk6xXF0vi4IGCCojMHjQsAXvltjP+YgFTTgWVFhIpDFDu89xLOwRnSWrhCwD6dlK/BwKgn2UgxTE8BZGFQ==}
     engines: {node: '>=14.0.0'}
@@ -3519,6 +3544,13 @@ packages:
         optional: true
       '@emotion/styled':
         optional: true
+
+  '@mui/x-virtualizer@0.3.0':
+    resolution: {integrity: sha512-ScQ3xullKQAtbIT9N7PVhgW9BDTo2Hu8fr/+N08TdRMJcq8bsVJB25mlcHk6zxjlgCuojqaeGfw71S1FOvyCXQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@napi-rs/keyring-darwin-arm64@1.2.0':
     resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
@@ -15109,6 +15141,25 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-data-grid@8.23.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@mui/material@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/material': 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@mui/system': 7.3.6(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0)
+      '@mui/utils': 7.3.6(@types/react@19.2.7)(react@19.2.0)
+      '@mui/x-internals': 8.23.0(@types/react@19.2.7)(react@19.2.0)
+      '@mui/x-virtualizer': 0.3.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.0)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mui/x-date-pickers-pro@7.27.3(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@mui/material@6.4.7(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(@mui/system@6.4.7(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(dayjs@1.11.13)(luxon@3.7.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -15195,6 +15246,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mui/x-internals@8.23.0(@types/react@19.2.7)(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/utils': 7.3.6(@types/react@19.2.7)(react@19.2.0)
+      react: 19.2.0
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mui/x-license@7.26.0(@types/react@19.2.7)(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
@@ -15239,6 +15300,16 @@ snapshots:
     optionalDependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.0)
       '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-virtualizer@0.3.0(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@mui/utils': 7.3.6(@types/react@19.2.7)(react@19.2.0)
+      '@mui/x-internals': 8.23.0(@types/react@19.2.7)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - '@types/react'
 


### PR DESCRIPTION
https://tools-public.mui.com/prod/pages/labelActivity doesn't work anymore. This PR solves that. Preview:
1. https://mui-tools-public-pr-991.onrender.com/prod/pages/auditLabelChanges

---

I'm also going beyond to have tools to audit GitHub events more precisely, e.g. what happens with Linear closing isues. Preview:

2. https://mui-tools-public-pr-991.onrender.com/prod/pages/auditClosedIssues. From it, we can find the issues that Linear auto-closed, and reopen them: 

<img width="862" height="250" alt="SCR-20251229-blni" src="https://github.com/user-attachments/assets/1d80af52-e9c3-4148-93d9-8f4aca8eeb9a" />

3. https://mui-tools-public-pr-991.onrender.com/prod/pages/queryOssInsight. From it, we can use the OSS Insight database, e.g. https://ossinsight.io/explore/?id=1c905228-cb16-4dbb-9c2d-fa7cc4e616ef and make custom queries, and find the same issue:

<img width="868" height="551" alt="SCR-20251229-brwt" src="https://github.com/user-attachments/assets/eacc9955-87bd-48dd-beba-33938fdefaad" />

However, one interesting point is that the OSS Insight database has data gaps; it lacks records of this event https://github.com/mui/mui-public/issues/351#event-21382195604. Better use the GitHub GraphQL event API with 2.

4. I was also curious to see what data we have about GitHub events from our Devlake instance. The data model is https://devlake.apache.org/docs/DataModels/DevLakeDomainLayerSchema#schema-diagram. The closest table to what we want is `issue_status_history`, but it doesn't record who made the change (introduced in https://github.com/apache/incubator-devlake/issues/7542), so it can't be used here.