### PR TITLE
[docs-infra] Remove eslint settings from next.js config

### DIFF
--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -1,5 +1,10 @@
 import type { NextConfig } from 'next';
+import pkgJson from 'next/package.json' with { type: 'json' };
 import * as os from 'node:os';
+
+// Read Next.js version to handle version-specific config
+const nextMajorVersion = parseInt(pkgJson.version.split('.')[0], 10);
+
 /**
  * See the docs of the Netlify environment variables:
  * https://docs.netlify.com/configure-builds/environment-variables/#build-metadata.
@@ -72,12 +77,16 @@ export function withDeploymentConfig<T extends NextConfig>(nextConfig: T): T {
         : {}),
       ...nextConfig.experimental,
     },
-    // TODO remove, this is for versions before Next.js v16
-    // https://nextjs.org/blog/next-16
-    eslint: {
-      ignoreDuringBuilds: true,
-      ...(nextConfig as any).eslint,
-    },
+    ...(nextMajorVersion < 16
+      ? {
+          // TODO remove this once all our projects are on Next.js 16+
+          // https://nextjs.org/blog/next-16
+          eslint: {
+            ignoreDuringBuilds: true,
+            ...(nextConfig as any).eslint,
+          },
+        }
+      : {}),
     typescript: {
       // Motivated by https://github.com/vercel/next.js/issues/7687
       ignoreBuildErrors: true,

--- a/packages/docs-infra/tsconfig.json
+++ b/packages/docs-infra/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "skipLibCheck": true,
-    "module": "es2020",
+    "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "types": ["react", "node"]


### PR DESCRIPTION
We anyways don't use next.js's built in linter even for older versions.