### PR TITLE
Revert "[code-infra] Remove obsolete renovate setting"

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -60,6 +60,15 @@
   },
   "packageRules": [
     {
+      "description": "Do not require Minimum Release Age for dependency pinning",
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["pin"],
+      "prBodyNotes": [
+        "⚠️ Renovate's pinning functionality [does not currently](https://github.com/renovatebot/renovate/discussions/39058) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s)."
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "widen"
     },


### PR DESCRIPTION
Reverts mui/mui-public#1027. Seems like https://github.com/renovatebot/renovate/pull/40289 isn't live on mend yet