### PR TITLE
[code-infra] Create custom rule for undefined in optional props

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@tsconfig/node24": "^24.0.0",
     "@types/node": "^22.18.13",
     "@types/semver": "^7.7.1",
-    "@typescript-eslint/eslint-plugin": "8.51.0",
+    "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",
     "@vitest/coverage-v8": "^4.0.16",
     "eslint": "^9.39.2",

--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -78,6 +78,8 @@
     "@octokit/rest": "^22.0.1",
     "@pnpm/find-workspace-dir": "^1000.1.3",
     "@vitest/eslint-plugin": "^1.6.4",
+    "@typescript-eslint/types": "^8.51.0",
+    "@typescript-eslint/utils": "^8.51.0",
     "babel-plugin-optimize-clsx": "^2.6.2",
     "babel-plugin-react-compiler": "^1.0.0",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
@@ -130,13 +132,13 @@
     "@types/estree-jsx": "1.0.5",
     "@types/regexp.escape": "2.0.0",
     "@types/yargs": "17.0.35",
-    "@typescript-eslint/parser": "8.49.0",
-    "@typescript-eslint/rule-tester": "8.49.0",
+    "@typescript-eslint/parser": "8.51.0",
+    "@typescript-eslint/rule-tester": "8.51.0",
     "eslint": "9.39.1",
     "get-port": "7.1.0",
     "prettier": "3.7.4",
     "serve": "14.2.5",
-    "typescript-eslint": "^8.49.0"
+    "typescript-eslint": "8.51.0"
   },
   "files": [
     "bin",

--- a/packages/code-infra/src/eslint/material-ui/config.mjs
+++ b/packages/code-infra/src/eslint/material-ui/config.mjs
@@ -409,6 +409,7 @@ export function createCoreConfig(options = {}) {
         'material-ui/no-empty-box': 'error',
         'material-ui/no-styled-box': 'error',
         'material-ui/straight-quotes': 'off',
+        'material-ui/add-undef-to-optional': 'off',
 
         'react-hooks/exhaustive-deps': [
           'error',

--- a/packages/code-infra/src/eslint/material-ui/index.mjs
+++ b/packages/code-infra/src/eslint/material-ui/index.mjs
@@ -7,6 +7,7 @@ import noRestrictedResolvedImports from './rules/no-restricted-resolved-imports.
 import noStyledBox from './rules/no-styled-box.mjs';
 import rulesOfUseThemeVariants from './rules/rules-of-use-theme-variants.mjs';
 import straightQuotes from './rules/straight-quotes.mjs';
+import addUndefToOptional from './rules/add-undef-to-optional.mjs';
 
 export default /** @type {import('eslint').ESLint.Plugin} */ ({
   meta: {
@@ -23,5 +24,7 @@ export default /** @type {import('eslint').ESLint.Plugin} */ ({
     'straight-quotes': straightQuotes,
     'disallow-react-api-in-server-components': disallowReactApiInServerComponents,
     'no-restricted-resolved-imports': noRestrictedResolvedImports,
+    // Some discrepancies between TypeScript and ESLint types - casting to unknown
+    'add-undef-to-optional': /** @type {unknown} */ (addUndefToOptional),
   },
 });

--- a/packages/code-infra/src/eslint/material-ui/rules/add-undef-to-optional.test.mjs
+++ b/packages/code-infra/src/eslint/material-ui/rules/add-undef-to-optional.test.mjs
@@ -1,0 +1,367 @@
+import { afterAll, it, describe } from 'vitest';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import TSESlintParser from '@typescript-eslint/parser';
+import rule from './add-undef-to-optional.mjs';
+
+RuleTester.afterAll = afterAll;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+RuleTester.describe = describe;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: TSESlintParser,
+  },
+});
+
+ruleTester.run('add-undef-to-optional', rule, {
+  valid: [
+    {
+      name: 'optional property with undefined',
+      code: `
+    export type Hello = {
+      name?: string | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with undefined in union',
+      code: `
+    export type Hello = {
+      name?: (string | number) | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with undefined and type reference',
+      code: `
+    type NameArg = string | number;
+    export type Hello = {
+      name?: NameArg | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with type reference including undefined',
+      code: `
+    type NameArg = string | number | undefined;
+    export type Hello = {
+      name?: NameArg;
+    };
+        `,
+    },
+    {
+      name: 'optional property with built-in type reference and explicit undefined',
+      code: `
+    export type Hello = {
+      data?: Record<string, string> | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with generic type reference and explicit undefined',
+      code: `
+    export type Hello<T> = {
+      value?: T | undefined;
+    };
+        `,
+    },
+    {
+      name: 'required property without undefined',
+      code: `
+    export type Hello = {
+      name: string | number;
+    };
+        `,
+    },
+    {
+      name: 'optional property with null and undefined',
+      code: `
+    export type Hello = {
+      name?: string | null | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with complex union including undefined',
+      code: `
+    export type Hello = {
+      name?: (string | number | boolean) | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with nested type reference including undefined',
+      code: `
+    type Inner = string | undefined;
+    type Outer = Inner | number;
+    export type Hello = {
+      name?: Outer;
+    };
+        `,
+    },
+    {
+      name: 'optional property with type reference in interface',
+      code: `
+    type NameArg = string | undefined;
+    export interface Hello {
+      name?: NameArg;
+    }
+        `,
+    },
+    {
+      name: 'multiple optional properties with mixed scenarios',
+      code: `
+    type WithUndef = string | undefined;
+    type WithoutUndef = string | number;
+    export type Hello = {
+      a?: WithUndef;
+      b?: WithoutUndef | undefined;
+      c?: string | undefined;
+    };
+        `,
+    },
+    {
+      name: 'optional property with any type',
+      code: `
+    export type Hello = {
+      value?: any;
+    };
+        `,
+    },
+    {
+      name: 'optional property with unknown type',
+      code: `
+    export type Hello = {
+      value?: unknown;
+    };
+        `,
+    },
+    {
+      name: 'optional property with any in union',
+      code: `
+    export type Hello = {
+      value?: string | any;
+    };
+        `,
+    },
+    {
+      name: 'optional property with unknown in union',
+      code: `
+    export type Hello = {
+      value?: string | unknown;
+    };
+        `,
+    },
+    {
+      name: 'optional property with type reference to any',
+      code: `
+    type AnyType = any;
+    export type Hello = {
+      value?: AnyType;
+    };
+        `,
+    },
+    {
+      name: 'optional property with type reference to unknown',
+      code: `
+    type UnknownType = unknown;
+    export type Hello = {
+      value?: UnknownType;
+    };
+        `,
+    },
+    {
+      name: 'optional property with ReactNode',
+      code: `
+    import { ReactNode } from 'react';
+    export type Hello = {
+      children?: ReactNode;
+    };
+        `,
+    },
+    {
+      name: 'optional property with React.ReactNode',
+      code: `
+    import React from 'react';
+    export type Hello = {
+      children?: React.ReactNode;
+    };
+        `,
+    },
+    {
+      name: 'optional property with ReactNode without import',
+      code: `
+    export type Hello = {
+      content?: ReactNode;
+    };
+        `,
+    },
+    {
+      name: 'optional property with React.ReactNode in union',
+      code: `
+    import React from 'react';
+    export type Hello = {
+      value?: string | React.ReactNode;
+    };
+        `,
+    },
+  ],
+  invalid: [
+    {
+      name: 'optional property without undefined',
+      code: `export type Hello = {
+  name?: string | number;
+};
+    `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello = {
+  name?: (string | number) | undefined;
+};
+    `,
+    },
+    {
+      name: 'optional property with simple type',
+      code: `export type Hello = {
+  name?: string;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello = {
+  name?: (string) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with local type reference without undefined',
+      code: `type NameArg = string | number;
+export type Hello = {
+  name?: NameArg;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 3, column: 3 }],
+      output: `type NameArg = string | number;
+export type Hello = {
+  name?: (NameArg) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property in interface without undefined',
+      code: `export interface Hello {
+  name?: string;
+}
+      `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export interface Hello {
+  name?: (string) | undefined;
+}
+      `,
+    },
+    {
+      name: 'multiple optional properties missing undefined',
+      code: `export type Hello = {
+  name?: string;
+  age?: number;
+};
+      `,
+      errors: [
+        { messageId: 'addUndefined', line: 2, column: 3 },
+        { messageId: 'addUndefined', line: 3, column: 3 },
+      ],
+      output: `export type Hello = {
+  name?: (string) | undefined;
+  age?: (number) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with union but no undefined',
+      code: `export type Hello = {
+  value?: string | number | boolean;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello = {
+  value?: (string | number | boolean) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with nested type reference without undefined',
+      code: `type Inner = string | number;
+type Outer = Inner | boolean;
+export type Hello = {
+  value?: Outer;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 4, column: 3 }],
+      output: `type Inner = string | number;
+type Outer = Inner | boolean;
+export type Hello = {
+  value?: (Outer) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with null but no undefined',
+      code: `export type Hello = {
+  value?: string | null;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello = {
+  value?: (string | null) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with imported type reference',
+      code: `import { SomeType } from './other';
+export type Hello = {
+  name?: SomeType;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 3, column: 3 }],
+      output: `import { SomeType } from './other';
+export type Hello = {
+  name?: (SomeType) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with built-in type reference',
+      code: `export type Hello = {
+  data?: Record<string, string>;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello = {
+  data?: (Record<string, string>) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with generic type parameter',
+      code: `export type Hello<T> = {
+  value?: T;
+};
+      `,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello<T> = {
+  value?: (T) | undefined;
+};
+      `,
+    },
+    {
+      name: 'optional property with function type without undefined',
+      code: `export type Hello = {
+  onPressedChange?: (pressed: boolean, eventDetails: Toggle.ChangeEventDetails) => void;
+}`,
+      errors: [{ messageId: 'addUndefined', line: 2, column: 3 }],
+      output: `export type Hello = {
+  onPressedChange?: ((pressed: boolean, eventDetails: Toggle.ChangeEventDetails) => void) | undefined;
+}`,
+    },
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       '@typescript-eslint/eslint-plugin':
-        specifier: 8.51.0
+        specifier: ^8.51.0
         version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser':
         specifier: ^8.51.0
@@ -507,6 +507,12 @@ importers:
       '@pnpm/find-workspace-dir':
         specifier: ^1000.1.3
         version: 1000.1.3
+      '@typescript-eslint/types':
+        specifier: ^8.51.0
+        version: 8.51.0
+      '@typescript-eslint/utils':
+        specifier: ^8.51.0
+        version: 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/eslint-plugin':
         specifier: ^1.6.4
         version: 1.6.4(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.17(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jiti@2.6.1)(jsdom@27.4.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
@@ -545,13 +551,13 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-module-utils:
         specifier: ^2.12.1
-        version: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+        version: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-compat:
         specifier: ^6.0.2
         version: 6.0.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.1(jiti@2.6.1))
@@ -647,11 +653,11 @@ importers:
         specifier: 17.0.35
         version: 17.0.35
       '@typescript-eslint/parser':
-        specifier: 8.49.0
-        version: 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.51.0
+        version: 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/rule-tester':
-        specifier: 8.49.0
-        version: 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+        specifier: 8.51.0
+        version: 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint:
         specifier: 9.39.1
         version: 9.39.1(jiti@2.6.1)
@@ -5665,24 +5671,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.49.0':
-    resolution: {integrity: sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
   '@typescript-eslint/parser@8.51.0':
     resolution: {integrity: sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.49.0':
-    resolution: {integrity: sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/project-service@8.51.0':
@@ -5691,25 +5684,15 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/rule-tester@8.49.0':
-    resolution: {integrity: sha512-2wu6JO/ND/QCg/zMNE04xCx1a5O6wOeklztpuqme8DPtjH1sejOIeHqyVW5I8pKx28D/Y0v+/N+B3I5NoO2I5g==}
+  '@typescript-eslint/rule-tester@8.51.0':
+    resolution: {integrity: sha512-iMEcUgzOcVhNo68VelLiZNdBGp91bG3CcLvFR0kJokMooRU82PkWT+ISGDHuph2eMnUucYkf6QTr71IFQ6aB+w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
-  '@typescript-eslint/scope-manager@8.49.0':
-    resolution: {integrity: sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/scope-manager@8.51.0':
     resolution: {integrity: sha512-JhhJDVwsSx4hiOEQPeajGhCWgBMBwVkxC/Pet53EpBVs7zHHtayKefw1jtPaNRXpI9RA2uocdmpdfE7T+NrizA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.49.0':
-    resolution: {integrity: sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/tsconfig-utils@8.51.0':
     resolution: {integrity: sha512-Qi5bSy/vuHeWyir2C8u/uqGMIlIDu8fuiYWv48ZGlZ/k+PRPHtaAu7erpc7p5bzw2WNNSniuxoMSO4Ar6V9OXw==}
@@ -5724,31 +5707,14 @@ packages:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.49.0':
-    resolution: {integrity: sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/types@8.51.0':
     resolution: {integrity: sha512-TizAvWYFM6sSscmEakjY3sPqGwxZRSywSsPEiuZF6d5GmGD9Gvlsv0f6N8FvAAA0CD06l3rIcWNbsN1e5F/9Ag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.49.0':
-    resolution: {integrity: sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/typescript-estree@8.51.0':
     resolution: {integrity: sha512-1qNjGqFRmlq0VW5iVlcyHBbCjPB7y6SxpBkrbhNWMy/65ZoncXCEPJxkRZL8McrseNH6lFhaxCIaX+vBuFnRng==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/utils@8.49.0':
-    resolution: {integrity: sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
   '@typescript-eslint/utils@8.51.0':
@@ -5757,10 +5723,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/visitor-keys@8.49.0':
-    resolution: {integrity: sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@typescript-eslint/visitor-keys@8.51.0':
     resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
@@ -17791,18 +17753,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/visitor-keys': 8.49.0
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1(jiti@2.6.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.51.0
@@ -17827,15 +17777,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.49.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.51.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.51.0
-      debug: 4.4.3(supports-color@8.1.1)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/project-service@8.51.0(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.51.0(typescript@5.9.3)
@@ -17845,11 +17786,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/rule-tester@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/rule-tester@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.51.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       ajv: 6.12.6
       eslint: 9.39.1(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
@@ -17859,19 +17800,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/scope-manager@8.49.0':
-    dependencies:
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/visitor-keys': 8.49.0
-
   '@typescript-eslint/scope-manager@8.51.0':
     dependencies:
       '@typescript-eslint/types': 8.51.0
       '@typescript-eslint/visitor-keys': 8.51.0
-
-  '@typescript-eslint/tsconfig-utils@8.49.0(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
 
   '@typescript-eslint/tsconfig-utils@8.51.0(typescript@5.9.3)':
     dependencies:
@@ -17901,24 +17833,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.49.0': {}
-
   '@typescript-eslint/types@8.51.0': {}
-
-  '@typescript-eslint/typescript-estree@8.49.0(typescript@5.9.3)':
-    dependencies:
-      '@typescript-eslint/project-service': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.49.0(typescript@5.9.3)
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/visitor-keys': 8.49.0
-      debug: 4.4.3(supports-color@8.1.1)
-      minimatch: 9.0.5
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@typescript-eslint/typescript-estree@8.51.0(typescript@5.9.3)':
     dependencies:
@@ -17931,17 +17846,6 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.39.1(jiti@2.6.1))
-      '@typescript-eslint/scope-manager': 8.49.0
-      '@typescript-eslint/types': 8.49.0
-      '@typescript-eslint/typescript-estree': 8.49.0(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -17967,11 +17871,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/visitor-keys@8.49.0':
-    dependencies:
-      '@typescript-eslint/types': 8.49.0
-      eslint-visitor-keys: 4.2.1
 
   '@typescript-eslint/visitor-keys@8.51.0':
     dependencies:
@@ -19767,15 +19666,15 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
@@ -19801,7 +19700,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-compat-utils: 0.5.1(eslint@9.39.2(jiti@2.6.1))
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19812,7 +19711,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19824,7 +19723,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.51.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
This rule naively checks for all optional properties in interface and types and provides autofix to add `| undefined` wherever it doesn't exist.
One optimization is added where locally defined types are also checked for `| undefined` and if it already has `undefined`, its not added at places where the type is used. This cannot be expanded to also look within the imported modules.

See tests for scenarios. We can optimize the discovery further by allowing options to, for example, only affect optional properties of exported types/interface.

Integration PR in Base UI - https://github.com/mui/base-ui/pull/3302