### PR TITLE
[code-infra] Remove check for ref prop

### DIFF
--- a/packages/code-infra/src/eslint/material-ui/rules/disallow-react-api-in-server-components.mjs
+++ b/packages/code-infra/src/eslint/material-ui/rules/disallow-react-api-in-server-components.mjs
@@ -125,16 +125,6 @@ export default /** @type {import('eslint').Rule.RuleModule} */ ({
           reportForbiddenApi(node, node.callee.name);
         }
       },
-      JSXAttribute(node) {
-        if (hasUseClientDirective) {
-          return;
-        }
-
-        // Check for ref prop in JSX
-        if (node.name.type === 'JSXIdentifier' && node.name.name === 'ref') {
-          reportForbiddenApi(node, 'ref');
-        }
-      },
     };
   },
   meta: {

--- a/packages/code-infra/src/eslint/material-ui/rules/disallow-react-api-in-server-components.test.mjs
+++ b/packages/code-infra/src/eslint/material-ui/rules/disallow-react-api-in-server-components.test.mjs
@@ -76,17 +76,6 @@ useIsoLayoutEffect(() => {});`,
       name: 'custom hook is allowed',
       code: `import { useCustomHook } from './hooks';`,
     },
-    // ref prop with 'use client' directive is allowed
-    {
-      name: 'ref prop with use client directive',
-      code: `'use client';
-const Component = () => <input ref={myRef} />;`,
-    },
-    // non-ref props are allowed without 'use client' directive
-    {
-      name: 'non-ref props are allowed',
-      code: `const Component = () => <input className="test" />;`,
-    },
   ],
   invalid: [
     // React.* API calls without 'use client' directive
@@ -308,29 +297,6 @@ import { useIsoLayoutEffect } from '@mui/utils';`,
         {
           message:
             "Using 'useIsoLayoutEffect' is forbidden if the file doesn't have a 'use client' directive.",
-        },
-      ],
-      output: null,
-    },
-    // ref prop without 'use client' directive
-    {
-      name: 'ref prop without use client directive',
-      code: `const Component = () => <input ref={myRef} />;`,
-      errors: [
-        {
-          message: "Using 'ref' is forbidden if the file doesn't have a 'use client' directive.",
-        },
-      ],
-      output: `'use client';
-const Component = () => <input ref={myRef} />;`,
-    },
-    {
-      name: 'ref prop in use server file (no autofix)',
-      code: `'use server';
-const Component = () => <input ref={myRef} />;`,
-      errors: [
-        {
-          message: "Using 'ref' is forbidden if the file doesn't have a 'use client' directive.",
         },
       ],
       output: null,


### PR DESCRIPTION
I was wrong, this could be a valid pattern in RSCs. e.g.

```tsx
export const MyComponent = React.forwardRef(props, ref) => {
  return <div ref={ref} {...props} />
});