### PR TITLE
[babel-plugin-minify-errors] Add TypeError support

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "7.27.1",
+    "baseline-browser-mapping": "^2.9.17",
     "eslint-plugin-n": "17.23.2",
     "markdownlint-cli2": "0.20.0",
     "stylelint": "16.26.1"

--- a/packages/babel-plugin-minify-errors/__fixtures__/type-error/error-codes.json
+++ b/packages/babel-plugin-minify-errors/__fixtures__/type-error/error-codes.json
@@ -1,0 +1,4 @@
+{
+  "1": "MUI: Expected a valid string argument.",
+  "2": "MUI: Invalid type provided."
+}

--- a/packages/babel-plugin-minify-errors/__fixtures__/type-error/input.js
+++ b/packages/babel-plugin-minify-errors/__fixtures__/type-error/input.js
@@ -1,0 +1,4 @@
+throw /* minify-error */ new TypeError(
+  'MUI: Expected a valid string argument.',
+);
+throw /* minify-error */ new TypeError(`MUI: Invalid type provided.`);

--- a/packages/babel-plugin-minify-errors/__fixtures__/type-error/output.js
+++ b/packages/babel-plugin-minify-errors/__fixtures__/type-error/output.js
@@ -1,0 +1,9 @@
+import _formatErrorMessage from '@mui/utils/formatMuiErrorMessage';
+throw new TypeError(
+  process.env.NODE_ENV !== 'production'
+    ? 'MUI: Expected a valid string argument.'
+    : _formatErrorMessage(1),
+);
+throw new TypeError(
+  process.env.NODE_ENV !== 'production' ? `MUI: Invalid type provided.` : _formatErrorMessage(2),
+);

--- a/packages/babel-plugin-minify-errors/index.js
+++ b/packages/babel-plugin-minify-errors/index.js
@@ -26,6 +26,7 @@ function pathToNodeImportSpecifier(importPath) {
 
 const COMMENT_OPT_IN_MARKER = 'minify-error';
 const COMMENT_OPT_OUT_MARKER = 'minify-error-disabled';
+const SUPPORTED_ERROR_CONSTRUCTORS = new Set(['Error', 'TypeError']);
 
 /**
  * @typedef {import('@babel/core')} babel
@@ -109,7 +110,8 @@ function handleUnminifyableError(missingError, path) {
  * @returns {null | { messageNode: babel.types.Expression; messagePath: babel.NodePath<babel.types.ArgumentPlaceholder | babel.types.SpreadElement | babel.types.Expression>; message: { message: string; expressions: babel.types.Expression[] } }}
  */
 function findMessageNode(t, newExpressionPath, { detection, missingError }) {
-  if (!newExpressionPath.get('callee').isIdentifier({ name: 'Error' })) {
+  const callee = newExpressionPath.get('callee');
+  if (!callee.isIdentifier() || !SUPPORTED_ERROR_CONSTRUCTORS.has(callee.node.name)) {
     return null;
   }
 

--- a/packages/babel-plugin-minify-errors/index.test.js
+++ b/packages/babel-plugin-minify-errors/index.test.js
@@ -36,6 +36,15 @@ pluginTester({
       output: readOutputFixtureSync('literal', 'output.js'),
     },
     {
+      title: 'type-error',
+      pluginOptions: {
+        errorCodesPath: path.join(fixturePath, 'type-error', 'error-codes.json'),
+        runtimeModule: '@mui/utils/formatMuiErrorMessage',
+      },
+      fixture: path.join(fixturePath, 'type-error', 'input.js'),
+      output: readOutputFixtureSync('type-error', 'output.js'),
+    },
+    {
       title: 'interpolation',
       pluginOptions: {
         errorCodesPath: path.join(fixturePath, 'interpolation', 'error-codes.json'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@babel/plugin-transform-react-constant-elements':
         specifier: 7.27.1
         version: 7.27.1(@babel/core@7.28.6)
+      baseline-browser-mapping:
+        specifier: ^2.9.17
+        version: 2.9.17
       eslint-plugin-n:
         specifier: 17.23.2
         version: 17.23.2(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
@@ -6290,8 +6293,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.24:
-    resolution: {integrity: sha512-uUhTRDPXamakPyghwrUcjaGvvBqGrWvBHReoiULMIpOJVM9IYzQh83Xk2Onx5HlGI2o10NNCzcs9TG/S3TkwrQ==}
+  baseline-browser-mapping@2.9.17:
+    resolution: {integrity: sha512-agD0MgJFUP/4nvjqzIB29zRPUuCF7Ge6mEv9s8dHrtYD7QWXRcx75rOADE/d5ah1NI+0vkDl0yorDd5U852IQQ==}
     hasBin: true
 
   basic-auth@2.0.1:
@@ -11100,10 +11103,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -18429,7 +18434,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.24: {}
+  baseline-browser-mapping@2.9.17: {}
 
   basic-auth@2.0.1:
     dependencies:
@@ -18525,7 +18530,7 @@ snapshots:
 
   browserslist@4.27.0:
     dependencies:
-      baseline-browser-mapping: 2.8.24
+      baseline-browser-mapping: 2.9.17
       caniuse-lite: 1.0.30001764
       electron-to-chromium: 1.5.244
       node-releases: 2.0.27
@@ -22412,7 +22417,7 @@ snapshots:
     dependencies:
       '@next/env': 16.1.2
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.8.24
+      baseline-browser-mapping: 2.9.17
       caniuse-lite: 1.0.30001764
       postcss: 8.4.31
       react: 19.2.3


### PR DESCRIPTION
## Summary
Add support for minifying `new TypeError(...)` in addition to `new Error(...)`

See https://github.com/mui/material-ui/blob/b09d704dcdc0de3ea0d54b10e1c0803e8256b415/packages/mui-lab/src/TabList/TabList.js#L11