### PR TITLE
Fix country label for Czech Republic in queryAbout.ts

### DIFF
--- a/apps/tools-public/toolpad/resources/queryAbout.ts
+++ b/apps/tools-public/toolpad/resources/queryAbout.ts
@@ -86,8 +86,8 @@ export async function queryAbout() {
 
   // Fix country label
   countryToISO['Czech Republic'] = 'cz';
-  countryToISO['US'] = 'us';
-  countryToISO['UK'] = 'gb';
+  countryToISO.US = 'us';
+  countryToISO.UK = 'gb';
 
   return peopleData.employees
     .sort((a, b) => parseFloat(b.work.tenureDurationYears) - parseFloat(a.work.tenureDurationYears))


### PR DESCRIPTION
It seems the country is missing from Vadym in https://tools-public.mui.com/prod/pages/muicomabout causing a 404 on [mui.com/about](http://mui.com/about) for the flag image

Fix verified here: https://mui-tools-public-pr-1065.onrender.com/prod/pages/muicomabout