### PR TITLE
[code-infra] Fix dection of new Error() that can't be minified

### DIFF
--- a/packages/babel-plugin-minify-errors/index.js
+++ b/packages/babel-plugin-minify-errors/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const helperModuleImports = require('@babel/helper-module-imports');
+const { generate } = require('@babel/generator');
 const fs = require('fs');
 const nodePath = require('path');
 const finder = require('find-package-json');
@@ -92,11 +93,19 @@ function handleUnminifyableError(missingError, path) {
       );
       break;
     case 'throw':
+    case 'write': {
+      const code = generate(path.node).code;
       throw new Error(
-        'Unminifyable error. You can only use literal strings and template strings as error messages.',
+        [
+          'The source has a code flow with a problem:',
+          '',
+          `throw ${code}`,
+          '',
+          'This is unminifyable in production. Today, only literal strings and template strings as supported as error messages.',
+          'Please update the source.',
+        ].join('\n'),
       );
-    case 'write':
-      break;
+    }
     default:
       throw new Error(`Unknown missingError option: ${missingError}`);
   }

--- a/packages/babel-plugin-minify-errors/index.test.js
+++ b/packages/babel-plugin-minify-errors/index.test.js
@@ -79,8 +79,7 @@ pluginTester({
       title: 'can throw on unminifyable errors',
       // babel prefixes with filename.
       // We're only interested in the message.
-      error:
-        /: Unminifyable error. You can only use literal strings and template strings as error messages./,
+      error: /The source has a code flow with a problem/,
       fixture: path.join(fixturePath, 'unminifyable-throw', 'input.js'),
       pluginOptions: {
         errorCodesPath: path.join(fixturePath, 'unminifyable-throw', 'error-codes.json'),

--- a/packages/babel-plugin-minify-errors/package.json
+++ b/packages/babel-plugin-minify-errors/package.json
@@ -18,7 +18,9 @@
   },
   "scripts": {},
   "dependencies": {
+    "@babel/generator": "^7.28.6",
     "@babel/helper-module-imports": "^7.28.6",
+    "@types/babel__generator": "^7.27.0",
     "find-package-json": "^1.2.0"
   },
   "devDependencies": {

--- a/packages/code-infra/src/utils/extractErrorCodes.mjs
+++ b/packages/code-infra/src/utils/extractErrorCodes.mjs
@@ -73,7 +73,7 @@ async function extractErrorCodesForWorkspace(files, errors, detection = 'opt-in'
           const { message } =
             findMessageNode(babelTypes, newExpressionPath, {
               detection,
-              missingError: 'annotate',
+              missingError: 'throw',
             }) ?? {};
           if (message) {
             errors.add(message.message);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,9 +333,15 @@ importers:
 
   packages/babel-plugin-minify-errors:
     dependencies:
+      '@babel/generator':
+        specifier: ^7.28.6
+        version: 7.28.6
       '@babel/helper-module-imports':
         specifier: ^7.28.6
         version: 7.28.6
+      '@types/babel__generator':
+        specifier: ^7.27.0
+        version: 7.27.0
       find-package-json:
         specifier: ^1.2.0
         version: 1.2.0


### PR DESCRIPTION
I noticed the regression from https://github.com/mui/base-ui/pull/3856 in https://github.com/mui/base-ui/pull/3856/files#diff-306df000d65d30bf99eee804bcc06dba33ffd68176ac235b1dd4a7dbec7c7471R144. The error message minification in production was not working, which was expected, but the CI needs to report it.

To fix this, I changed the source of mui-public inside the base-ui, up until I would get a good error message, and then I added  `/* minify-error-disabled */` to make sure it was solved, and last, I ported the change in this PR.