### PR TITLE
[code-infra] Add utility to dump html from tests to file

### DIFF
--- a/packages/test-utils/src/dumpHTML.ts
+++ b/packages/test-utils/src/dumpHTML.ts
@@ -21,7 +21,10 @@ export function dumpHTML({
   filePath?: string;
   fileName?: string;
 } = {}): string {
-  const html = prettyDOM(container, Infinity) || '';
+  const html =
+    prettyDOM(container, Infinity, {
+      highlight: false,
+    }) || '';
 
   const resolvedPath = filePath ?? path.join(DEFAULT_OUTPUT_DIR, `${fileName ?? Date.now()}.html`);
 

--- a/packages/test-utils/src/dumpHTML.ts
+++ b/packages/test-utils/src/dumpHTML.ts
@@ -1,6 +1,6 @@
 import { prettyDOM } from '@testing-library/react';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), 'test', 'html-dumps');
 

--- a/packages/test-utils/src/dumpHTML.ts
+++ b/packages/test-utils/src/dumpHTML.ts
@@ -1,0 +1,32 @@
+import { prettyDOM } from '@testing-library/react';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DEFAULT_OUTPUT_DIR = path.join(process.cwd(), 'test', 'html-dumps');
+
+/**
+ * Dumps the HTML of a container (or `document.body`) to a file for debugging.
+ *
+ * @param options.container - The element to dump. Defaults to `document.body`.
+ * @param options.filePath - Absolute path for the output file. When omitted a file is
+ *   created inside `test/html-dumps/` using the provided `fileName` (or a timestamp).
+ * @param options.fileName - Name of the file (without extension) when `filePath` is not set.
+ */
+export function dumpHTML({
+  container = document.body,
+  filePath,
+  fileName,
+}: {
+  container?: HTMLElement;
+  filePath?: string;
+  fileName?: string;
+} = {}): string {
+  const html = prettyDOM(container, Infinity) || '';
+
+  const resolvedPath = filePath ?? path.join(DEFAULT_OUTPUT_DIR, `${fileName ?? Date.now()}.html`);
+
+  fs.mkdirSync(path.dirname(resolvedPath), { recursive: true });
+  fs.writeFileSync(resolvedPath, html, 'utf-8');
+
+  return resolvedPath;
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -16,3 +16,4 @@ export { fireEvent as fireDiscreteEvent } from '@testing-library/react/pure.js';
 export { flushMicrotasks } from './flushMicrotasks';
 export * from './env';
 export { ignoreActWarnings } from './ignoreActWarnings';
+export * from './dumpHTML';


### PR DESCRIPTION
Creates a new `dumpHTML` function in `@mui/internal-test-utils`