### PR TITLE
[code-infra] Expand export globs only for flat builds

### DIFF
--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -277,7 +277,7 @@ export async function createPackageExports({
     typeof packageExports === 'string' || Array.isArray(packageExports)
       ? { '.': packageExports }
       : packageExports || {};
-  const originalExports = await expandExportGlobs(rawExports, cwd);
+  const originalExports = isFlat ? await expandExportGlobs(rawExports, cwd) : rawExports;
   /**
    * @type {import('../cli/packageJson').PackageJson.ExportConditions}
    */

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -567,6 +567,36 @@ describe('createPackageExports', () => {
       });
     });
 
+    it('does not expand glob patterns when isFlat is false', async () => {
+      await withTempDir(async (cwd) => {
+        const outputDir = path.join(cwd, 'build');
+
+        await Promise.all([
+          createFile(path.join(cwd, 'src/Button.ts')),
+          createFile(path.join(cwd, 'src/TextField.ts')),
+        ]);
+
+        const { exports: packageExports } = await createPackageExports({
+          exports: {
+            './*': './src/*.ts',
+          },
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: false,
+        });
+
+        // Glob should NOT be expanded to individual files
+        expect(packageExports['./Button']).toBeUndefined();
+        expect(packageExports['./TextField']).toBeUndefined();
+        // The raw glob pattern is passed through as-is
+        expect(packageExports['./*']).toEqual({
+          require: './*.js',
+          default: './*.js',
+        });
+      });
+    });
+
     it('passes through glob key when value has no wildcard', async () => {
       await withTempDir(async (cwd) => {
         const outputDir = path.join(cwd, 'build');


### PR DESCRIPTION
Its breaking core packages without the flat build migration.