### PR TITLE
[code-infra] Fix the lag while typing in filter inputs for diff explorer

### DIFF
--- a/apps/code-infra-dashboard/src/components/FileDiff.tsx
+++ b/apps/code-infra-dashboard/src/components/FileDiff.tsx
@@ -79,7 +79,7 @@ function processDiff(
   };
 }
 
-export default function FileDiff({
+const FileDiff = React.memo(function FileDiff({
   oldValue,
   newValue,
   filePath,
@@ -166,4 +166,6 @@ export default function FileDiff({
       </Box>
     </Paper>
   );
-}
+});
+
+export default FileDiff;

--- a/apps/code-infra-dashboard/src/components/FileExplorer.tsx
+++ b/apps/code-infra-dashboard/src/components/FileExplorer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { RichTreeView } from '@mui/x-tree-view/RichTreeView';
-import type { TreeViewBaseItem } from '@mui/x-tree-view/models';
+import type { TreeViewDefaultItemModelProperties } from '@mui/x-tree-view/models';
 import { escapeHtmlId } from '../utils/escapeHtmlId';
 
 interface FileExplorerProps {
@@ -16,7 +16,7 @@ interface TreeNode {
   children: Map<string, TreeNode>;
 }
 
-function buildTreeItems(files: { path: string }[]): TreeViewBaseItem[] {
+function buildTreeItems(files: { path: string }[]): TreeViewDefaultItemModelProperties[] {
   const root: TreeNode = { id: '', label: '', children: new Map() };
 
   for (const file of files) {
@@ -39,10 +39,10 @@ function buildTreeItems(files: { path: string }[]): TreeViewBaseItem[] {
     }
   }
 
-  function toItems(node: TreeNode): TreeViewBaseItem[] {
-    const items: TreeViewBaseItem[] = [];
+  function toItems(node: TreeNode): TreeViewDefaultItemModelProperties[] {
+    const items: TreeViewDefaultItemModelProperties[] = [];
     for (const child of node.children.values()) {
-      const item: TreeViewBaseItem = {
+      const item: TreeViewDefaultItemModelProperties = {
         id: child.id,
         label: child.label,
       };
@@ -57,7 +57,7 @@ function buildTreeItems(files: { path: string }[]): TreeViewBaseItem[] {
   return toItems(root);
 }
 
-function collectFolderIds(items: TreeViewBaseItem[]): string[] {
+function collectFolderIds(items: TreeViewDefaultItemModelProperties[]): string[] {
   const ids: string[] = [];
   for (const item of items) {
     if (item.children && item.children.length > 0) {
@@ -68,7 +68,7 @@ function collectFolderIds(items: TreeViewBaseItem[]): string[] {
   return ids;
 }
 
-export default function FileExplorer({ files, title }: FileExplorerProps) {
+const FileExplorer = React.memo(function FileExplorer({ files, title }: FileExplorerProps) {
   const treeItems = React.useMemo(() => buildTreeItems(files), [files]);
   const folderIds = React.useMemo(() => collectFolderIds(treeItems), [treeItems]);
 
@@ -118,4 +118,6 @@ export default function FileExplorer({ files, title }: FileExplorerProps) {
       />
     </Box>
   );
-}
+});
+
+export default FileExplorer;

--- a/apps/code-infra-dashboard/src/views/DiffPackage.tsx
+++ b/apps/code-infra-dashboard/src/views/DiffPackage.tsx
@@ -110,6 +110,11 @@ export default function DiffPackage() {
     [filesToDiff, fileFilterFn],
   );
 
+  const explorerFiles = React.useMemo(
+    () => filteredFilesToDiff.map(({ filePath }) => ({ path: filePath })),
+    [filteredFilesToDiff],
+  );
+
   const loading = pkg1Query.isLoading || pkg2Query.isLoading;
   const error = pkg1Query.error || pkg2Query.error;
 
@@ -281,10 +286,7 @@ export default function DiffPackage() {
           <Box sx={{ display: 'flex', gap: 2 }}>
             {filteredFilesToDiff.length > 0 && !loading ? (
               <Box sx={{ display: { xs: 'none', md: 'block' } }}>
-                <FileExplorer
-                  files={filteredFilesToDiff.map(({ filePath }) => ({ path: filePath }))}
-                  title="Changed Files"
-                />
+                <FileExplorer files={explorerFiles} title="Changed Files" />
               </Box>
             ) : null}
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1, minWidth: 0 }}>


### PR DESCRIPTION
Felt the issue while debugging flat build.

* Show file diffs only for first 5 files and then show diffs incrementally as and when user clicks on the file in explorer.
* Also added file/folder status (+,-,~) to the file explorer

<img width="1944" height="1199" alt="Screenshot 2026-02-24 at 5 18 39 PM" src="https://github.com/user-attachments/assets/ee088dee-227a-4dd7-9bc2-df856861c7f7" />

