### PR TITLE
[code-infra] Use BASE_BRANCH env var in dedupe and prettier checks

### DIFF
--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -143,7 +143,7 @@ commands:
           name: '`pnpm dedupe` was run?'
           command: |
             # #default-branch-switch
-            if [[ $(git diff --name-status master | grep -E 'pnpm-workspace\.yaml|pnpm-lock.yaml|package\.json') == "" ]];
+            if [[ $(git diff --name-status "${BASE_BRANCH:-master}" | grep -E 'pnpm-workspace\.yaml|pnpm-lock.yaml|package\.json') == "" ]];
             then
                 echo "No changes to dependencies detected. Skipping..."
             else
@@ -157,7 +157,7 @@ commands:
           name: '`pnpm prettier` changes committed?'
           command: |
             # #default-branch-switch
-            if [[ $(git diff --name-status master | grep pnpm-lock) == "" ]];
+            if [[ $(git diff --name-status "${BASE_BRANCH:-master}" | grep pnpm-lock) == "" ]];
             then
                 pnpm prettier --check
             else


### PR DESCRIPTION
Use the `BASE_BRANCH` environment variable (with a `master` fallback) in the `pnpm-dedupe` and `prettier` orb commands instead of hardcoding `master`.

This allows repos that maintain multiple base branches (e.g. `v8.x`, `next`) to set `BASE_BRANCH` in their CircleCI config so the diff is computed against the correct branch.