### PR TITLE
[code-infra] Add eslint rule `no-selector-default-parameters`

### DIFF
--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -418,6 +418,7 @@ export function createCoreConfig(options = {}) {
         'mui/consistent-production-guard': 'error',
         'mui/add-undef-to-optional': 'off',
         'mui/flatten-parentheses': 'warn',
+        'mui/no-selector-default-parameters': 'error',
 
         'react-hooks/exhaustive-deps': [
           'error',

--- a/packages/code-infra/src/eslint/mui/index.mjs
+++ b/packages/code-infra/src/eslint/mui/index.mjs
@@ -11,6 +11,7 @@ import rulesOfUseThemeVariants from './rules/rules-of-use-theme-variants.mjs';
 import straightQuotes from './rules/straight-quotes.mjs';
 import addUndefToOptional from './rules/add-undef-to-optional.mjs';
 import flattenParentheses from './rules/flatten-parentheses.mjs';
+import noSelectorDefaultParameters from './rules/no-selector-default-parameters.mjs';
 
 /** @type {import('eslint').ESLint.Plugin} */
 const muiPlugin = {
@@ -33,6 +34,7 @@ const muiPlugin = {
     // Some discrepancies between TypeScript and ESLint types - casting to any
     'add-undef-to-optional': /** @type {any} */ (addUndefToOptional),
     'flatten-parentheses': /** @type {any} */ (flattenParentheses),
+    'no-selector-default-parameters': noSelectorDefaultParameters,
   },
 };
 

--- a/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.mjs
@@ -1,0 +1,87 @@
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow default parameters in selector combiners because Function.length ignores them, breaking memoization.',
+    },
+    messages: {
+      'no-default-param':
+        'Default parameters in selector combiners break memoization because Function.length ignores them. Pass the default value at the call site instead.',
+    },
+    schema: [],
+  },
+  create(context) {
+    const SELECTOR_FUNCTIONS = new Set(['createSelector', 'createSelectorMemoized']);
+
+    /**
+     * Recursively find and report AssignmentPattern nodes within a parameter.
+     * @param {import('estree').Node} node
+     */
+    function reportDefaultPatterns(node) {
+      if (node.type === 'AssignmentPattern') {
+        context.report({ node, messageId: 'no-default-param' });
+        // Also check the left side for nested defaults (e.g. { field = 'name' } = {})
+        reportDefaultPatterns(node.left);
+      } else if (node.type === 'ObjectPattern') {
+        for (const prop of node.properties) {
+          reportDefaultPatterns(prop.type === 'Property' ? prop.value : prop);
+        }
+      } else if (node.type === 'ArrayPattern') {
+        for (const element of node.elements) {
+          if (element) {
+            reportDefaultPatterns(element);
+          }
+        }
+      }
+    }
+
+    /**
+     * Check if any parameters of a function node use default values (AssignmentPattern).
+     * @param {import('estree').Function} node
+     */
+    function checkFunctionParams(node) {
+      for (const param of node.params) {
+        reportDefaultPatterns(param);
+      }
+    }
+
+    /**
+     * Given call arguments, check if the last argument is a function with default params.
+     * @param {import('estree').CallExpression['arguments']} args
+     */
+    function checkLastArg(args) {
+      if (args.length === 0) {
+        return;
+      }
+      const lastArg = args[args.length - 1];
+      if (lastArg.type === 'ArrowFunctionExpression' || lastArg.type === 'FunctionExpression') {
+        checkFunctionParams(lastArg);
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+
+        // createSelector(...) or createSelectorMemoized(...)
+        if (callee.type === 'Identifier' && SELECTOR_FUNCTIONS.has(callee.name)) {
+          checkLastArg(node.arguments);
+          return;
+        }
+
+        // createSelectorMemoizedWithOptions()(...) — the outer call returns a function that is then called
+        if (
+          callee.type === 'CallExpression' &&
+          callee.callee.type === 'Identifier' &&
+          callee.callee.name === 'createSelectorMemoizedWithOptions'
+        ) {
+          checkLastArg(node.arguments);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.mjs
@@ -10,10 +10,34 @@ const rule = {
       'no-default-param':
         'Default parameters in selector combiners break memoization because Function.length ignores them. Pass the default value at the call site instead.',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          selectorFunctions: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Function names that create selectors (last arg is the combiner).',
+          },
+          selectorFactories: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Factory function names that return selector creators, e.g. createSelectorMemoizedWithOptions()(...)',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   create(context) {
-    const SELECTOR_FUNCTIONS = new Set(['createSelector', 'createSelectorMemoized']);
+    const options = context.options[0] || {};
+    const selectorFunctions = new Set(
+      options.selectorFunctions || ['createSelector', 'createSelectorMemoized'],
+    );
+    const selectorFactories = new Set(
+      options.selectorFactories || ['createSelectorMemoizedWithOptions'],
+    );
 
     /**
      * Recursively find and report AssignmentPattern nodes within a parameter.
@@ -65,17 +89,17 @@ const rule = {
       CallExpression(node) {
         const { callee } = node;
 
-        // createSelector(...) or createSelectorMemoized(...)
-        if (callee.type === 'Identifier' && SELECTOR_FUNCTIONS.has(callee.name)) {
+        // Direct selector creators: createSelector(...), createSelectorMemoized(...)
+        if (callee.type === 'Identifier' && selectorFunctions.has(callee.name)) {
           checkLastArg(node.arguments);
           return;
         }
 
-        // createSelectorMemoizedWithOptions()(...) — the outer call returns a function that is then called
+        // Selector factories: createSelectorMemoizedWithOptions()(...)
         if (
           callee.type === 'CallExpression' &&
           callee.callee.type === 'Identifier' &&
-          callee.callee.name === 'createSelectorMemoizedWithOptions'
+          selectorFactories.has(callee.callee.name)
         ) {
           checkLastArg(node.arguments);
         }

--- a/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.test.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.test.mjs
@@ -1,0 +1,70 @@
+import eslint from 'eslint';
+import parser from '@typescript-eslint/parser';
+import rule from './no-selector-default-parameters.mjs';
+
+const ruleTester = new eslint.RuleTester({
+  languageOptions: {
+    parser,
+  },
+});
+
+ruleTester.run('no-selector-default-parameters', rule, {
+  valid: [
+    {
+      name: 'createSelector with no default params',
+      code: `createSelector(inputSelector, (data, param) => data)`,
+    },
+    {
+      name: 'createSelectorMemoized with no default params',
+      code: `createSelectorMemoized(inputSelector, (data, param) => data)`,
+    },
+    {
+      name: 'createSelectorMemoizedWithOptions with no default params',
+      code: `createSelectorMemoizedWithOptions()(inputSelector, (data, param) => data)`,
+    },
+    {
+      name: 'regular function with default params (not a selector)',
+      code: `someOtherFunction(inputSelector, (data, param = 'default') => data)`,
+    },
+    {
+      name: 'createSelector with no arguments',
+      code: `createSelector()`,
+    },
+    {
+      name: 'createSelector where last arg is not a function',
+      code: `createSelector(inputSelector, someVariable)`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'createSelector with arrow function default param',
+      code: `createSelector(inputSelector, (data, param = 'default') => data)`,
+      errors: [{ messageId: 'no-default-param' }],
+    },
+    {
+      name: 'createSelectorMemoized with arrow function default param',
+      code: `createSelectorMemoized(inputSelector, (data, param = 'default') => data)`,
+      errors: [{ messageId: 'no-default-param' }],
+    },
+    {
+      name: 'createSelectorMemoizedWithOptions with arrow function default param',
+      code: `createSelectorMemoizedWithOptions()(inputSelector, (data, param = 'default') => data)`,
+      errors: [{ messageId: 'no-default-param' }],
+    },
+    {
+      name: 'createSelector with function expression default param',
+      code: `createSelector(inputSelector, function(data, param = 'default') { return data; })`,
+      errors: [{ messageId: 'no-default-param' }],
+    },
+    {
+      name: 'createSelector with destructured default',
+      code: `createSelector(inputSelector, (data, { field = 'name' } = {}) => data)`,
+      errors: [{ messageId: 'no-default-param' }, { messageId: 'no-default-param' }],
+    },
+    {
+      name: 'createSelector with multiple default params',
+      code: `createSelector(inputSelector, (data, a = 1, b = 2) => data)`,
+      errors: [{ messageId: 'no-default-param' }, { messageId: 'no-default-param' }],
+    },
+  ],
+});

--- a/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.test.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-selector-default-parameters.test.mjs
@@ -66,5 +66,17 @@ ruleTester.run('no-selector-default-parameters', rule, {
       code: `createSelector(inputSelector, (data, a = 1, b = 2) => data)`,
       errors: [{ messageId: 'no-default-param' }, { messageId: 'no-default-param' }],
     },
+    {
+      name: 'custom selectorFunctions option',
+      code: `myCustomSelector(inputSelector, (data, param = 'default') => data)`,
+      options: [{ selectorFunctions: ['myCustomSelector'] }],
+      errors: [{ messageId: 'no-default-param' }],
+    },
+    {
+      name: 'custom selectorFactories option',
+      code: `myFactory()(inputSelector, (data, param = 'default') => data)`,
+      options: [{ selectorFactories: ['myFactory'] }],
+      errors: [{ messageId: 'no-default-param' }],
+    },
   ],
 });


### PR DESCRIPTION
In createSelectorMemoized (packages/x-internals/src/store/createSelector.ts:125), the number of extra arguments a combiner expects is determined by combiner.length:

`const argsLength = Math.max(combiner.length - nSelectors, 0);`

In JavaScript, `Function.length` does not count parameters with default values. So a combiner like `(data, param = 'default') => ...` reports `length = 1` instead of `2`, causing `argsLength = 0`.

This means the memoization logic won't track the argument, breaking memoization silently.