### PR TITLE
[code-infra] Fix fail-on-console breaking with --no-isolate --no-file-parallelism

### DIFF
--- a/packages/test-utils/src/setupVitest.ts
+++ b/packages/test-utils/src/setupVitest.ts
@@ -64,6 +64,10 @@ export default function setupVitest({
     });
   }
 
+  // Don't call test lifecycle hooks (afterEach/afterAll/beforeEach/beforeAll/...) after this point
+  // Make sure none of (transitive) dependencies call lifecycle hooks either, otherwise they won't be
+  // registered and thus won't run when using `--no-isolate --no-file-parallelism`.
+
   if (isInitialized) {
     return;
   }
@@ -71,8 +75,6 @@ export default function setupVitest({
   isInitialized = true;
 
   configure(config);
-
-  // Don't call test lifecycle hooks (afterEach/afterAll/beforeEach/beforeAll/...) after this point
 
   chai.use(chaiPlugin);
 


### PR DESCRIPTION
It sets up lifecycle hooks but they get cleared by `--no-isolate --no-file-parallelism`. we need to make sure to set them up on each run.

We just [fixed](https://github.com/mui/material-ui/pull/47929) 100+ broken tests in core that were hidden by this bug.