### PR TITLE
[code-infra] Add build-env export which represents our build tool

### DIFF
--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -43,6 +43,9 @@
     "./brokenLinksChecker": {
       "types": "./build/brokenLinksChecker/index.d.mts",
       "default": "./src/brokenLinksChecker/index.mjs"
+    },
+    "./build-env": {
+      "types": "./src/build-env.d.ts"
     }
   },
   "bin": {

--- a/packages/code-infra/src/build-env.d.ts
+++ b/packages/code-infra/src/build-env.d.ts
@@ -1,0 +1,13 @@
+export {};
+
+declare global {
+  interface Env {
+    NODE_ENV?: 'production' | undefined;
+  }
+
+  interface Process {
+    env: Env;
+  }
+
+  const process: Process;
+}


### PR DESCRIPTION
Centralize ambient types for our build tool. Packages built with the tool can configure `@mui/internal-code-infra/build-env` in their `compilerOptions.types` in `tsconfig.json`

See https://github.com/mui/base-ui/pull/4257#discussion_r2894852166