### PR TITLE
[code-infra] Allow renovate to run for gh actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,10 @@
     {
       "matchPackageNames": ["https://github.com/mui/mui-public"],
       "enabled": false
+    },
+    {
+      "matchDepNames": ["code-infra-gh-actions"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
in this repo to update hashes from master. I identified an issue where we are still referring to `master` in the workflow `.github/workflows/ci-base.yml` which is not correct.

This is just a trial to see if it works.