### PR TITLE
[code-infra] Remove jsdom as a dependency of test utils

### DIFF
--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -34,7 +34,6 @@
     "dom-accessibility-api": "^0.7.1",
     "es-toolkit": "^1.45.1",
     "format-util": "^1.0.5",
-    "jsdom": "^28.1.0",
     "prop-types": "^15.8.1",
     "vitest-fail-on-console": "^0.10.1"
   },
@@ -45,7 +44,8 @@
     "@types/jsdom": "28.0.0",
     "@types/prop-types": "15.7.15",
     "@types/react": "19.2.14",
-    "@types/react-dom": "19.2.3"
+    "@types/react-dom": "19.2.3",
+    "jsdom": "^28.1.0"
   },
   "peerDependencies": {
     "@emotion/cache": "11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,9 +894,6 @@ importers:
       format-util:
         specifier: ^1.0.5
         version: 1.0.5
-      jsdom:
-        specifier: ^28.1.0
-        version: 28.1.0
       prop-types:
         specifier: ^15.8.1
         version: 15.8.1
@@ -931,6 +928,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
     publishDirectory: build
 
   test/bundle-size:


### PR DESCRIPTION
Shouldn't dictate jsdom version on consumers