### PR TITLE
[support-infra] Fix duplicate GitHub Action running on PR comments

### DIFF
--- a/.github/workflows/mark-duplicate.yml
+++ b/.github/workflows/mark-duplicate.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   mark-duplicate:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
We have this GitHub Action to do stuff like this: https://github.com/mui/mui-public/issues/642#issuecomment-3365501433

<img width="525" height="130" alt="SCR-20260320-civo" src="https://github.com/user-attachments/assets/8d2c56c3-0f6b-438e-9939-6411c62ec485" />

However, I have noticed from [a warning](https://groups.google.com/a/mui.com/g/team-admin/c/Q3FVdbvsQC0) sent to admin@mui.com

<img width="179" height="453" alt="SCR-20260320-cjmk" src="https://github.com/user-attachments/assets/bbb30afa-4ec5-41b2-9d6d-a66359c2bfce" />

that this action also runs on PR comments. It seems absurd. For example, I have tried to trigger this logic in: https://github.com/mui/mui-private/pull/1526#issuecomment-4094571151 and the result was a failure of execution https://github.com/mui/mui-private/actions/runs/23323414405.

<img width="386" height="58" alt="SCR-20260320-cjxi" src="https://github.com/user-attachments/assets/94e6d65d-4116-42af-8826-6f211c980d35" />

so instead, let's only run the action on issue comments.

---

*(For the Node.js warning, I have created https://github.com/actions-cool/issues-helper/issues/228)*