### PR TITLE
[code-infra] Enable pkg.pr.new PR comments in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         uses: ./.github/actions/ci-publish
         with:
-          pr-comment: false
+          pr-comment: true
       - name: Build docs
         run: pnpm docs:build
       - name: Check for broken links


### PR DESCRIPTION
Enable `pr-comment` for the `ci-publish` action so that pkg.pr.new posts preview install URLs on PRs
Goal is to make preview packages more discoverable for AI tooling inspecting the PR