### PR TITLE
[code-infra] Use Node v24 instead of v22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # TODO: revert to master before merging
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/bump-node-to-v24/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/LukasTy/mui-public/refs/heads/bump-node-to-v24/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # TODO: revert to master before merging
-  code-infra: https://raw.githubusercontent.com/LukasTy/mui-public/refs/heads/bump-node-to-v24/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/bump-node-to-v24/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/master/.circleci/orbs/code-infra.yml
+  # TODO: revert to master before merging
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/bump-node-to-v24/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -198,7 +198,7 @@ executors:
     parameters:
       node-version:
         type: string
-        default: '22.21.1'
+        default: '24.14.0'
     docker:
       - image: cimg/node:<< parameters.node-version >>
     environment:

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
-        node-version: 22.19.0
+        node-version: 24.14.0
         # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22.18.0'
+          node-version: '24.14.0'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
       - name: Cache Next.js build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Bootstrap, Build, and Test the Repository
 
-- **Prerequisites**: Node.js 22.18.0+ required. Install pnpm: `npm install -g pnpm@10.25.0`
+- **Prerequisites**: Node.js 24.14.0+ required. Install pnpm: `npm install -g pnpm@10.25.0`
 - **Install dependencies**: `pnpm install --no-frozen-lockfile` -- takes 15-20 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Build all packages**: `pnpm release:build` -- takes 5-10 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Type checking**: `pnpm typescript` -- takes 10-15 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.

--- a/apps/code-infra-dashboard/package.json
+++ b/apps/code-infra-dashboard/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@types/etag": "1.8.4",
-    "@types/node": "22.19.0",
+    "@types/node": "24.12.0",
     "@types/pako": "2.0.4",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/apps/tools-public/package.json
+++ b/apps/tools-public/package.json
@@ -22,7 +22,7 @@
     "ssh2-promise": "^1.0.3"
   },
   "devDependencies": {
-    "@types/node": "22.19.0",
+    "@types/node": "24.12.0",
     "@types/ssh2": "1.15.5"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "16.1.6",
-    "@types/node": "22.19.0",
+    "@types/node": "24.12.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@wooorm/starry-night": "3.9.0",

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "docs/export/"
 command = "pnpm docs:lib && pnpm docs:build"
 
 [build.environment]
-NODE_VERSION = "22.18"
+NODE_VERSION = "24.14"
 PNPM_FLAGS = "--frozen-lockfile"
 
 [[plugins]]

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@next/eslint-plugin-next": "^16.1.6",
     "@octokit/rest": "^22.0.1",
     "@tsconfig/node24": "^24.0.4",
-    "@types/node": "^22.18.13",
+    "@types/node": "^24.12.0",
     "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.57.0",
@@ -91,6 +91,6 @@
   "packageManager": "pnpm@10.32.1",
   "engines": {
     "pnpm": "10.32.1",
-    "node": ">=22.18.0"
+    "node": ">=24.14.0"
   }
 }

--- a/packages/babel-plugin-resolve-imports/package.json
+++ b/packages/babel-plugin-resolve-imports/package.json
@@ -25,7 +25,7 @@
     "@babel/preset-typescript": "7.28.5",
     "@types/babel__core": "7.20.5",
     "@types/chai": "5.2.3",
-    "@types/node": "22.19.0",
+    "@types/node": "24.12.0",
     "@types/resolve": "1.20.6",
     "babel-plugin-tester": "12.0.0"
   },

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -127,7 +127,7 @@
     "@types/estree": "1.0.8",
     "@types/hast": "3.0.4",
     "@types/mdast": "4.0.4",
-    "@types/node": "22.19.0",
+    "@types/node": "24.12.0",
     "@types/proper-lockfile": "4.1.4",
     "@types/react": "19.2.14",
     "@types/webpack": "5.28.5",
@@ -164,6 +164,6 @@
     "directory": "build"
   },
   "engines": {
-    "node": ">=22.18.0"
+    "node": ">=24.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^24.0.4
         version: 24.0.4
       '@types/node':
-        specifier: ^22.18.13
-        version: 22.19.0
+        specifier: ^24.12.0
+        version: 24.12.0
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
@@ -57,7 +57,7 @@ importers:
         version: 7.0.0-dev.20260317.1
       '@vitest/coverage-v8':
         specifier: ^4.1.0
-        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))
       eslint:
         specifier: ^10.0.3
         version: 10.0.3(jiti@2.6.1)
@@ -66,7 +66,7 @@ importers:
         version: 28.1.0
       lerna:
         specifier: ^9.0.6
-        version: 9.0.7(@types/node@22.19.0)(babel-plugin-macros@3.1.0)
+        version: 9.0.7(@types/node@24.12.0)(babel-plugin-macros@3.1.0)
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -81,7 +81,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
     devDependencies:
       '@babel/plugin-transform-react-constant-elements':
         specifier: 7.27.1
@@ -157,7 +157,7 @@ importers:
         version: 1.8.1
       mysql2:
         specifier: ^3.19.1
-        version: 3.20.0(@types/node@22.19.0)
+        version: 3.20.0(@types/node@24.12.0)
       next:
         specifier: ^16.1.6
         version: 16.1.7(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -184,8 +184,8 @@ importers:
         specifier: 1.8.4
         version: 1.8.4
       '@types/node':
-        specifier: 22.19.0
-        version: 22.19.0
+        specifier: 24.12.0
+        version: 24.12.0
       '@types/pako':
         specifier: 2.0.4
         version: 2.0.4
@@ -242,14 +242,14 @@ importers:
         version: 2.18.1
       mysql2:
         specifier: ^3.19.1
-        version: 3.20.0(@types/node@22.19.0)
+        version: 3.20.0(@types/node@24.12.0)
       ssh2-promise:
         specifier: ^1.0.3
         version: 1.0.3
     devDependencies:
       '@types/node':
-        specifier: 22.19.0
-        version: 22.19.0
+        specifier: 24.12.0
+        version: 24.12.0
       '@types/ssh2':
         specifier: 1.15.5
         version: 1.15.5
@@ -312,8 +312,8 @@ importers:
         specifier: 16.1.6
         version: 16.1.6
       '@types/node':
-        specifier: 22.19.0
-        version: 22.19.0
+        specifier: 24.12.0
+        version: 24.12.0
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -402,8 +402,8 @@ importers:
         specifier: 5.2.3
         version: 5.2.3
       '@types/node':
-        specifier: 22.19.0
-        version: 22.19.0
+        specifier: 24.12.0
+        version: 24.12.0
       '@types/resolve':
         specifier: 1.20.6
         version: 1.20.6
@@ -445,7 +445,7 @@ importers:
         version: 7.0.1(rolldown@1.0.0-rc.9)(rollup@4.52.5)
       vite:
         specifier: ^8.0.0
-        version: 8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+        version: 8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
@@ -503,10 +503,10 @@ importers:
         version: 1.1.0
       '@inquirer/confirm':
         specifier: ^6.0.8
-        version: 6.0.10(@types/node@22.19.0)
+        version: 6.0.10(@types/node@24.12.0)
       '@inquirer/select':
         specifier: ^5.1.0
-        version: 5.1.2(@types/node@22.19.0)
+        version: 5.1.2(@types/node@24.12.0)
       '@mui/internal-babel-plugin-display-name':
         specifier: workspace:*
         version: link:../babel-plugin-display-name
@@ -545,7 +545,7 @@ importers:
         version: 7.0.0-dev.20260317.1
       '@vitest/eslint-plugin':
         specifier: ^1.6.11
-        version: 1.6.12(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 1.6.12(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))
       babel-plugin-optimize-clsx:
         specifier: ^2.6.2
         version: 2.6.2
@@ -843,8 +843,8 @@ importers:
         specifier: 4.0.4
         version: 4.0.4
       '@types/node':
-        specifier: 22.19.0
-        version: 22.19.0
+        specifier: 24.12.0
+        version: 24.12.0
       '@types/proper-lockfile':
         specifier: 4.1.4
         version: 4.1.4
@@ -883,8 +883,8 @@ importers:
   packages/netlify-cache:
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0 || ^24.0.0
-        version: 22.19.0
+        specifier: ^24.0.0
+        version: 24.12.0
 
   packages/test-utils:
     dependencies:
@@ -938,7 +938,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       vitest-fail-on-console:
         specifier: ^0.10.1
-        version: 0.10.1(@vitest/utils@4.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))
+        version: 0.10.1(@vitest/utils@4.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))
     devDependencies:
       '@playwright/test':
         specifier: 1.58.2
@@ -5936,8 +5936,8 @@ packages:
   '@types/node@20.19.25':
     resolution: {integrity: sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==}
 
-  '@types/node@22.19.0':
-    resolution: {integrity: sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==}
+  '@types/node@24.12.0':
+    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -11924,6 +11924,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
   undici-types@7.24.4:
     resolution: {integrity: sha512-cRaY9PagdEZoRmcwzk3tUV3SVGrVQkR6bcSilav/A0vXsfpW4Lvd0BvgRMwTEDTLLGN+QdyBTG+nnvTgJhdt6w==}
 
@@ -14649,162 +14652,162 @@ snapshots:
 
   '@inquirer/ansi@2.0.4': {}
 
-  '@inquirer/checkbox@4.3.0(@types/node@22.19.0)':
+  '@inquirer/checkbox@4.3.0(@types/node@24.12.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.0)':
+  '@inquirer/confirm@5.1.21(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/confirm@6.0.10(@types/node@22.19.0)':
+  '@inquirer/confirm@6.0.10(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 11.1.7(@types/node@22.19.0)
-      '@inquirer/type': 4.0.4(@types/node@22.19.0)
+      '@inquirer/core': 11.1.7(@types/node@24.12.0)
+      '@inquirer/type': 4.0.4(@types/node@24.12.0)
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/core@10.3.2(@types/node@22.19.0)':
+  '@inquirer/core@10.3.2(@types/node@24.12.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/core@11.1.7(@types/node@22.19.0)':
+  '@inquirer/core@11.1.7(@types/node@24.12.0)':
     dependencies:
       '@inquirer/ansi': 2.0.4
       '@inquirer/figures': 2.0.4
-      '@inquirer/type': 4.0.4(@types/node@22.19.0)
+      '@inquirer/type': 4.0.4(@types/node@24.12.0)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/editor@4.2.21(@types/node@22.19.0)':
+  '@inquirer/editor@4.2.21(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/external-editor': 1.0.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/external-editor': 1.0.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/expand@4.0.21(@types/node@22.19.0)':
+  '@inquirer/expand@4.0.21(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/external-editor@1.0.2(@types/node@22.19.0)':
+  '@inquirer/external-editor@1.0.2(@types/node@24.12.0)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@inquirer/figures@1.0.15': {}
 
   '@inquirer/figures@2.0.4': {}
 
-  '@inquirer/input@4.2.5(@types/node@22.19.0)':
+  '@inquirer/input@4.2.5(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/number@3.0.21(@types/node@22.19.0)':
+  '@inquirer/number@3.0.21(@types/node@24.12.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/password@4.0.21(@types/node@22.19.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
-    optionalDependencies:
-      '@types/node': 22.19.0
-
-  '@inquirer/prompts@7.9.0(@types/node@22.19.0)':
-    dependencies:
-      '@inquirer/checkbox': 4.3.0(@types/node@22.19.0)
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.0)
-      '@inquirer/editor': 4.2.21(@types/node@22.19.0)
-      '@inquirer/expand': 4.0.21(@types/node@22.19.0)
-      '@inquirer/input': 4.2.5(@types/node@22.19.0)
-      '@inquirer/number': 3.0.21(@types/node@22.19.0)
-      '@inquirer/password': 4.0.21(@types/node@22.19.0)
-      '@inquirer/rawlist': 4.1.9(@types/node@22.19.0)
-      '@inquirer/search': 3.2.0(@types/node@22.19.0)
-      '@inquirer/select': 4.4.2(@types/node@22.19.0)
-    optionalDependencies:
-      '@types/node': 22.19.0
-
-  '@inquirer/rawlist@4.1.9(@types/node@22.19.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.0
-
-  '@inquirer/search@3.2.0(@types/node@22.19.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
-      yoctocolors-cjs: 2.1.3
-    optionalDependencies:
-      '@types/node': 22.19.0
-
-  '@inquirer/select@4.4.2(@types/node@22.19.0)':
+  '@inquirer/password@4.0.21(@types/node@24.12.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/prompts@7.9.0(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.0(@types/node@24.12.0)
+      '@inquirer/confirm': 5.1.21(@types/node@24.12.0)
+      '@inquirer/editor': 4.2.21(@types/node@24.12.0)
+      '@inquirer/expand': 4.0.21(@types/node@24.12.0)
+      '@inquirer/input': 4.2.5(@types/node@24.12.0)
+      '@inquirer/number': 3.0.21(@types/node@24.12.0)
+      '@inquirer/password': 4.0.21(@types/node@24.12.0)
+      '@inquirer/rawlist': 4.1.9(@types/node@24.12.0)
+      '@inquirer/search': 3.2.0(@types/node@24.12.0)
+      '@inquirer/select': 4.4.2(@types/node@24.12.0)
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/rawlist@4.1.9(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/select@5.1.2(@types/node@22.19.0)':
+  '@inquirer/search@3.2.0(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/select@4.4.2(@types/node@24.12.0)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.12.0
+
+  '@inquirer/select@5.1.2(@types/node@24.12.0)':
     dependencies:
       '@inquirer/ansi': 2.0.4
-      '@inquirer/core': 11.1.7(@types/node@22.19.0)
+      '@inquirer/core': 11.1.7(@types/node@24.12.0)
       '@inquirer/figures': 2.0.4
-      '@inquirer/type': 4.0.4(@types/node@22.19.0)
+      '@inquirer/type': 4.0.4(@types/node@24.12.0)
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/type@3.0.10(@types/node@22.19.0)':
+  '@inquirer/type@3.0.10(@types/node@24.12.0)':
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
-  '@inquirer/type@4.0.4(@types/node@22.19.0)':
+  '@inquirer/type@4.0.4(@types/node@24.12.0)':
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -18037,7 +18040,7 @@ snapshots:
       serialize-javascript: 6.0.2
       superjson: 2.0.0
       typescript: 5.5.4
-      vite: 5.4.14(@types/node@22.19.0)(lightningcss@1.32.0)(terser@5.44.0)
+      vite: 5.4.14(@types/node@24.12.0)(lightningcss@1.32.0)(terser@5.44.0)
       vm-browserify: 1.1.2
       whatwg-url: 14.0.0
       ws: 8.18.1
@@ -18153,7 +18156,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/braces@3.0.5': {}
 
@@ -18168,17 +18171,17 @@ snapshots:
 
   '@types/clean-css@4.2.11':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       source-map: 0.6.1
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 5.1.0
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/content-type@1.1.9': {}
 
@@ -18186,7 +18189,7 @@ snapshots:
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/d3-array@3.2.2': {}
 
@@ -18249,11 +18252,11 @@ snapshots:
 
   '@types/etag@1.8.4':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -18266,7 +18269,7 @@ snapshots:
 
   '@types/find-package-json@1.2.7':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/format-util@1.0.4': {}
 
@@ -18292,11 +18295,11 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/jsdom@28.0.0':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
       undici-types: 7.24.4
@@ -18333,9 +18336,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/node@22.19.0':
+  '@types/node@24.12.0':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -18362,7 +18365,7 @@ snapshots:
       '@types/eslint': eslint@9.39.4(jiti@2.6.1)
       '@types/express': 5.0.5
       '@types/html-webpack-plugin': 3.2.9
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       '@types/webpack': 4.41.40
       '@types/webpack-dev-server': 3.11.6
     transitivePeerDependencies:
@@ -18395,22 +18398,22 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   '@types/source-list-map@0.1.6': {}
 
@@ -18442,13 +18445,13 @@ snapshots:
 
   '@types/webpack-sources@3.2.3':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       '@types/source-list-map': 0.1.6
       source-map: 0.7.6
 
   '@types/webpack@4.41.40':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       '@types/tapable': 1.0.12
       '@types/uglify-js': 3.17.5
       '@types/webpack-sources': 3.2.3
@@ -18457,7 +18460,7 @@ snapshots:
 
   '@types/webpack@5.28.5(esbuild@0.27.1)(jiti@2.6.1)':
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       tapable: 2.3.0
       webpack: 5.102.1(esbuild@0.27.1)(jiti@2.6.1)
     transitivePeerDependencies:
@@ -18678,11 +18681,11 @@ snapshots:
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.14(@types/node@22.19.0)(lightningcss@1.32.0)(terser@5.44.0)
+      vite: 5.4.14(@types/node@24.12.0)(lightningcss@1.32.0)(terser@5.44.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.0
@@ -18694,16 +18697,16 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.0.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
 
-  '@vitest/eslint-plugin@1.6.12(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))':
+  '@vitest/eslint-plugin@1.6.12(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/utils': 8.57.1(eslint@10.0.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 10.0.3(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -18716,13 +18719,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -21710,17 +21713,17 @@ snapshots:
       url: 0.11.4
     optional: true
 
-  inquirer@12.9.6(@types/node@22.19.0):
+  inquirer@12.9.6(@types/node@24.12.0):
     dependencies:
       '@inquirer/ansi': 1.0.2
-      '@inquirer/core': 10.3.2(@types/node@22.19.0)
-      '@inquirer/prompts': 7.9.0(@types/node@22.19.0)
-      '@inquirer/type': 3.0.10(@types/node@22.19.0)
+      '@inquirer/core': 10.3.2(@types/node@24.12.0)
+      '@inquirer/prompts': 7.9.0(@types/node@24.12.0)
+      '@inquirer/type': 3.0.10(@types/node@24.12.0)
       mute-stream: 2.0.0
       run-async: 4.0.6
       rxjs: 7.8.2
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
 
   internal-slot@1.1.0:
     dependencies:
@@ -22008,7 +22011,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -22180,7 +22183,7 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  lerna@9.0.7(@types/node@22.19.0)(babel-plugin-macros@3.1.0):
+  lerna@9.0.7(@types/node@24.12.0)(babel-plugin-macros@3.1.0):
     dependencies:
       '@npmcli/arborist': 9.1.6
       '@npmcli/package-json': 7.0.2
@@ -22211,7 +22214,7 @@ snapshots:
       import-local: 3.1.0
       ini: 1.3.8
       init-package-json: 8.2.2
-      inquirer: 12.9.6(@types/node@22.19.0)
+      inquirer: 12.9.6(@types/node@24.12.0)
       is-ci: 3.0.1
       jest-diff: 30.2.0
       js-yaml: 4.1.1
@@ -23192,9 +23195,9 @@ snapshots:
       seq-queue: 0.0.5
       sqlstring: 2.3.3
 
-  mysql2@3.20.0(@types/node@22.19.0):
+  mysql2@3.20.0(@types/node@24.12.0):
     dependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       aws-ssl-profiles: 1.1.2
       denque: 2.1.0
       generate-function: 2.3.1
@@ -25613,6 +25616,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.16.0: {}
+
   undici-types@7.24.4: {}
 
   undici@6.23.0: {}
@@ -25819,18 +25824,18 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@5.4.14(@types/node@22.19.0)(lightningcss@1.32.0)(terser@5.44.0):
+  vite@5.4.14(@types/node@24.12.0)(lightningcss@1.32.0)(terser@5.44.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.8
       rollup: 4.52.5
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       fsevents: 2.3.3
       lightningcss: 1.32.0
       terser: 5.44.0
 
-  vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1):
+  vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -25839,7 +25844,7 @@ snapshots:
       rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       esbuild: 0.27.1
       fsevents: 2.3.3
       jiti: 2.6.1
@@ -25847,17 +25852,17 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.1
 
-  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))):
+  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))):
     dependencies:
       '@vitest/utils': 4.1.0
       chalk: 5.6.2
-      vite: 8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
-      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
 
-  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)):
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@24.12.0)(jsdom@28.1.0)(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -25874,11 +25879,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.0(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      vite: 8.0.0(@types/node@24.12.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 22.19.0
+      '@types/node': 24.12.0
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -883,7 +883,7 @@ importers:
   packages/netlify-cache:
     devDependencies:
       '@types/node':
-        specifier: ^24.0.0
+        specifier: ^22.0.0 || ^24.0.0
         version: 24.12.0
 
   packages/test-utils:

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -121,18 +121,18 @@
       "groupName": "node",
       "description": "Restricts Node.js version bumps in Github Actions workflows.",
       "extends": ["group:nodeJs"],
-      "allowedVersions": "<=22.18"
+      "allowedVersions": "<=24.14"
     },
     {
       "groupName": "node",
       "matchDepTypes": ["uses-with"],
       "matchDepNames": ["node"],
-      "allowedVersions": "<=22.18"
+      "allowedVersions": "<=24.14"
     },
     {
       "groupName": "node",
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "<=22.18"
+      "allowedVersions": "<=24.14"
     },
     {
       "matchDepTypes": ["engines"],


### PR DESCRIPTION
Testing it out in: https://github.com/mui/base-ui/pull/4423

---

## CI Performance: Node 22 (#[6168](https://app.circleci.com/pipelines/github/mui/mui-public/6168)) vs Node 24 (#6182)

I chose 6168 pipeline due to it having the new docs infra as well as triggering the `pnpm dedupe`.

The results show no meaningful performance improvement or degradation outside of run-to-run variance.

### Job-Level Comparison

| Job | Node 22 (#6168) | Node 24 (#6182) | Delta |
|-----|:---:|:---:|:---:|
| checkout | 2m 33s | 33s | -2m 00s* |
| test_unit | 59s | 57s | -2s |
| test_static | 1m 25s | 1m 41s | +16s* |
| test_package | 56s | 1m 15s | +19s* |
| test_lint | 1m 49s | 1m 36s | -13s* |
| Validating Docs | 1m 19s | 1m 32s | +13s |
| **Total workflow** | **2m 36s** | **1m 43s** | **-53s** |

*\* Heavily influenced by spin-up time variance (CircleCI infrastructure noise)*

### Step-Level Breakdown (excluding spin-up noise)

| Step | Node 22 | Node 24 | Delta |
|------|:---:|:---:|:---:|
| **Install js deps (checkout)** | 30s | 26s | **-4s** |
| **Install js deps (test_unit)** | 26s | 26s | 0s |
| **Install js deps (test_static)** | 30s | 30s | 0s |
| **Install js deps (test_package)** | 31s | 40s | **+9s** |
| **Install js deps (test_lint)** | 25s | 26s | +1s |
| **Install js deps (Validating Docs)** | 27s | 37s | **+10s** |
| **Install js deps (Val. Docs 2nd)** | 2s | 3s | +1s |
| pnpm dedupe | 23s | 19s | **-4s** |
| pnpm prettier | 15s | 14s | -1s |
| TypeScript | 8s | 9s | +1s |
| ESLint | 43s | 44s | +1s |
| Stylelint | 3s | 4s | +1s |
| Lint Markdown | 1s | 1s | 0s |
| Docs Infra Build | 6s | 6s | 0s |
| Build packages | 9s | 8s | -1s |
| Size snapshot | 8s | 7s | -1s |
| Run tests (vitest) | 26s | 25s | -1s |
| Build docs-infra | 6s | 7s | +1s |
| Validate docs | 35s | 35s | 0s |

### Key Findings

1. **Actual tool execution is neutral.** ESLint (43s vs 44s), TypeScript (8s vs 9s), vitest (26s vs 25s), Validate docs (35s vs 35s), and Build packages (9s vs 8s) are all within ±1s — measurement noise.

2. **pnpm dedupe is 4s faster** on Node 24 (23s → 19s), the only meaningful improvement in actual work.

3. **pnpm install is inconsistent.** Two jobs (test_package, Validating Docs) saw +9-10s install regressions, while others were identical. This is likely **cache variance** rather than a systematic Node 24 issue — the same `pnpm install` command takes 26-40s across different jobs on Node 24, suggesting it depends on when the pnpm store cache was hit.

4. **Spin-up times dominate** the job-level differences. Node 22's checkout job had a 1m 59s spin-up vs 3s on Node 24; test_lint had 24s vs 5s. These are CircleCI Docker image pull/allocation times, not Node performance.

5. **Total excluding spin-up**: 355s (Node 22) vs 369s (Node 24) = **+14s (+4%) slower on Node 24**, almost entirely from install time variance in 2 jobs.

### Verdict

**Node 24 is performance-neutral for actual code execution.** The observed ±1s differences in ESLint, TypeScript, vitest, and builds are within noise. The only real signal is pnpm dedupe being slightly faster (-4s). The +14s aggregate "regression" is driven by pnpm install cache variance in 2 of 6 jobs, not by Node 24 being slower at running JavaScript. A single re-run could flip this result.