### PR TITLE
[code-infra] Send CircleCI OIDC token with bundle-size uploads

### DIFF
--- a/packages/bundle-size-checker/src/uploadSnapshot.js
+++ b/packages/bundle-size-checker/src/uploadSnapshot.js
@@ -58,9 +58,14 @@ async function uploadViaApi(apiUrl, fileContent, uploadConfig, sha) {
 
   const url = new URL('/api/ci-reports/upload', apiUrl);
 
+  const oidcToken = process.env.CIRCLE_OIDC_TOKEN_V2;
+  if (!oidcToken) {
+    throw new Error('CIRCLE_OIDC_TOKEN_V2 environment variable is required for uploads');
+  }
+
   const response = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${oidcToken}` },
     body: JSON.stringify(requestBody),
   });
 


### PR DESCRIPTION
Send `CIRCLE_OIDC_TOKEN_V2` as a Bearer token in the Authorization header when uploading bundle size snapshots

Will update server in https://github.com/mui/mui-public/pull/1242 to use it to authenticate once all consumers send the token.