### PR TITLE
[bundle-size-checker] Remove legacy S3 upload and add _metadata to snapshots

### DIFF
--- a/apps/code-infra-dashboard/src/lib/bundleSize/calculateSizeDiff.ts
+++ b/apps/code-infra-dashboard/src/lib/bundleSize/calculateSizeDiff.ts
@@ -38,7 +38,9 @@ export function calculateSizeDiff(
   baseSnapshot: SizeSnapshot,
   targetSnapshot: SizeSnapshot,
 ): ComparisonResult {
-  const bundleKeys = Object.keys({ ...baseSnapshot, ...targetSnapshot });
+  const bundleKeys = Object.keys({ ...baseSnapshot, ...targetSnapshot }).filter(
+    (key) => !key.startsWith('_'),
+  );
   const results: Size[] = [];
 
   let totalParsed = 0;

--- a/apps/code-infra-dashboard/src/lib/bundleSize/fetchSnapshot.ts
+++ b/apps/code-infra-dashboard/src/lib/bundleSize/fetchSnapshot.ts
@@ -2,32 +2,12 @@ export type SizeSnapshotEntry = { parsed: number; gzip: number };
 export type SizeSnapshot = Record<string, SizeSnapshotEntry>;
 
 export async function fetchSnapshot(repo: string, sha: string): Promise<SizeSnapshot> {
-  const urlsToTry = [
-    `https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/${repo}/${sha}/size-snapshot.json`,
-  ];
+  const url = `https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/${repo}/${sha}/size-snapshot.json`;
 
-  if (repo === 'mui/material-ui') {
-    urlsToTry.push(
-      `https://s3.eu-central-1.amazonaws.com/mui-org-ci/artifacts/master/${sha}/size-snapshot.json`,
-    );
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch "${url}", HTTP ${response.status}`);
   }
 
-  let lastError;
-  for (const url of urlsToTry) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const response = await fetch(url);
-      if (!response.ok) {
-        lastError = new Error(`Failed to fetch "${url}", HTTP ${response.status}`);
-        continue;
-      }
-
-      return response.json();
-    } catch (error) {
-      lastError = error;
-      continue;
-    }
-  }
-
-  throw new Error(`Failed to fetch snapshot`, { cause: lastError });
+  return response.json();
 }

--- a/packages/bundle-size-checker/package.json
+++ b/packages/bundle-size-checker/package.json
@@ -32,8 +32,6 @@
     }
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1008.0",
-    "@aws-sdk/credential-providers": "^3.1008.0",
     "@octokit/rest": "^22.0.1",
     "chalk": "^5.6.2",
     "env-ci": "^11.2.0",

--- a/packages/bundle-size-checker/src/ciReport.js
+++ b/packages/bundle-size-checker/src/ciReport.js
@@ -25,7 +25,13 @@ const sizeSnapshotEntrySchema = z.object({
   gzip: z.number(),
 });
 
-const sizeSnapshotSchema = z.record(z.string(), sizeSnapshotEntrySchema);
+const snapshotMetadataSchema = z.object({
+  trackedBundles: z.array(z.string()).optional(),
+});
+
+const sizeSnapshotSchema = z
+  .record(z.string(), sizeSnapshotEntrySchema)
+  .and(z.object({ _metadata: snapshotMetadataSchema }).partial());
 
 export const sizeSnapshotUploadSchema = ciReportUploadSchema(
   'size-snapshot',

--- a/packages/bundle-size-checker/src/cli.js
+++ b/packages/bundle-size-checker/src/cli.js
@@ -152,9 +152,20 @@ async function run(argv) {
   console.log(`Starting bundle size snapshot creation with ${concurrency} workers...`);
 
   const bundleSizes = await getBundleSizes(argv, config);
+  // Get tracked bundles from config
+  const trackedBundles = config.entrypoints
+    .filter((entry) => entry.track === true)
+    .map((entry) => entry.id);
+
   const sortedBundleSizes = Object.fromEntries(
     bundleSizes.sort((a, b) => a[0].localeCompare(b[0])),
   );
+
+  // Add metadata with tracked bundles to the snapshot
+  if (trackedBundles.length > 0) {
+    // eslint-disable-next-line no-underscore-dangle
+    sortedBundleSizes._metadata = /** @type {any} */ ({ trackedBundles });
+  }
 
   // Ensure output directory exists
   await fs.mkdir(path.dirname(snapshotDestPath), { recursive: true });
@@ -169,11 +180,7 @@ async function run(argv) {
   if (config && config.upload) {
     try {
       // eslint-disable-next-line no-console
-      console.log(
-        config.upload.legacyUpload
-          ? 'Uploading bundle size snapshot directly to S3 (legacy)...'
-          : 'Uploading bundle size snapshot via dashboard API...',
-      );
+      console.log(`Uploading bundle size snapshot via dashboard API at ${config.upload.apiUrl}...`);
       const { key } = await uploadSnapshot(snapshotDestPath, config.upload);
       // eslint-disable-next-line no-console
       console.log(`Bundle size snapshot uploaded to S3 with key: ${key}`);
@@ -209,11 +216,6 @@ async function run(argv) {
 
     // eslint-disable-next-line no-console
     console.log('Syncing PR comment via dashboard API...');
-
-    // Get tracked bundles from config
-    const trackedBundles = config.entrypoints
-      .filter((entry) => entry.track === true)
-      .map((entry) => entry.id);
 
     const result = await syncPrComment(ciInfo.slug, {
       bundleSize: {

--- a/packages/bundle-size-checker/src/configLoader.js
+++ b/packages/bundle-size-checker/src/configLoader.js
@@ -80,7 +80,10 @@ export function applyUploadConfigDefaults(uploadConfig, ciInfo) {
     throw new Error('Missing required field: upload.branch. Please specify a branch name.');
   }
 
-  const legacyUpload = uploadConfig.legacyUpload ?? false;
+  const apiUrl =
+    uploadConfig.apiUrl ||
+    process.env.CI_REPORT_API_URL ||
+    'https://code-infra-dashboard.onrender.com';
 
   // Return the normalized config
   /** @type {NormalizedUploadConfig} */
@@ -91,7 +94,7 @@ export function applyUploadConfigDefaults(uploadConfig, ciInfo) {
       uploadConfig.isPullRequest !== undefined
         ? Boolean(uploadConfig.isPullRequest)
         : Boolean(isPr),
-    legacyUpload,
+    apiUrl,
   };
 
   // Add PR number from CI environment if available
@@ -211,6 +214,11 @@ async function normalizeEntries(entries, configPath) {
   ).flat();
 
   for (const entry of result) {
+    if (entry.id.startsWith('_')) {
+      throw new Error(
+        `Entry id "${entry.id}" must not start with "_". Ids starting with "_" are reserved for internal metadata.`,
+      );
+    }
     if (usedIds.has(entry.id)) {
       throw new Error(`Duplicate entry id found: "${entry.id}". Entry ids must be unique.`);
     }

--- a/packages/bundle-size-checker/src/types.d.ts
+++ b/packages/bundle-size-checker/src/types.d.ts
@@ -3,7 +3,7 @@ export interface UploadConfig {
   repo?: string; // The repository name (e.g., "mui/material-ui")
   branch?: string; // Optional branch name (defaults to current Git branch)
   isPullRequest?: boolean; // Whether this is a pull request build (defaults to CI detection)
-  legacyUpload?: boolean; // Upload directly to S3 instead of using the dashboard API
+  apiUrl?: string; // Dashboard API URL (defaults to https://code-infra-dashboard.onrender.com)
 }
 
 // Normalized upload configuration where all properties are defined
@@ -12,7 +12,7 @@ export interface NormalizedUploadConfig {
   branch: string; // Branch name
   isPullRequest: boolean; // Whether this is a pull request build
   prNumber?: string; // PR number (from CI environment)
-  legacyUpload: boolean; // Whether to use direct S3 upload
+  apiUrl: string; // Dashboard API URL
 }
 
 // EntryPoint types

--- a/packages/bundle-size-checker/src/uploadSnapshot.js
+++ b/packages/bundle-size-checker/src/uploadSnapshot.js
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
-import { S3Client, PutObjectCommand, PutObjectTaggingCommand } from '@aws-sdk/client-s3';
 import { execa } from 'execa';
-import { fromEnv } from '@aws-sdk/credential-providers';
 
 /**
  * @typedef {import('./types.js').NormalizedUploadConfig} NormalizedUploadConfig
@@ -17,28 +15,14 @@ async function getCurrentCommitSHA() {
 }
 
 /**
- * Sanitizes a string to be used as an S3 tag value
- * See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
- * @param {string} str
- * @returns {string}
- */
-function sanitizeS3TagString(str) {
-  // Replace disallowed characters with underscore
-  const safe = str.replace(/[^a-zA-Z0-9 +\-=.:/@]+/g, '_');
-  // Truncate to max lengths (256 for value)
-  const maxLen = 256;
-  return safe.length > maxLen ? safe.substring(0, maxLen) : safe;
-}
-
-/**
  * Uploads the snapshot via the dashboard API (server-side proxied to S3).
+ * @param {string} apiUrl - Base URL of the CI report API
  * @param {Buffer} fileContent - The file content to upload
  * @param {NormalizedUploadConfig} uploadConfig - The normalized upload configuration
  * @param {string} sha - The commit SHA
  * @returns {Promise<{key:string}>}
  */
-async function uploadViaApi(fileContent, uploadConfig, sha) {
-  const apiUrl = process.env.CI_REPORT_API_URL || 'https://code-infra-dashboard.onrender.com';
+async function uploadViaApi(apiUrl, fileContent, uploadConfig, sha) {
   /** @type {import('./ciReport.js').SizeSnapshotUpload} */
   const requestBody = {
     version: 1,
@@ -79,53 +63,6 @@ async function uploadViaApi(fileContent, uploadConfig, sha) {
 }
 
 /**
- * Uploads the snapshot directly to S3 using AWS credentials.
- * @param {Buffer} fileContent - The file content to upload
- * @param {NormalizedUploadConfig} uploadConfig - The normalized upload configuration
- * @param {string} sha - The commit SHA
- * @returns {Promise<{key:string}>}
- */
-async function uploadDirectToS3(fileContent, uploadConfig, sha) {
-  const { branch, isPullRequest } = uploadConfig;
-
-  // Create S3 client (uses AWS credentials from environment)
-  const client = new S3Client({
-    region: process.env.AWS_REGION_ARTIFACTS || process.env.AWS_REGION || 'eu-central-1',
-    credentials: fromEnv(),
-  });
-
-  // S3 bucket and key
-  const bucket = 'mui-org-ci';
-  const key = `artifacts/${uploadConfig.repo}/${sha}/size-snapshot.json`;
-
-  // Upload the file first
-  await client.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: fileContent,
-      ContentType: 'application/json',
-    }),
-  );
-
-  // Then add tags to the uploaded object
-  await client.send(
-    new PutObjectTaggingCommand({
-      Bucket: bucket,
-      Key: key,
-      Tagging: {
-        TagSet: [
-          { Key: 'isPullRequest', Value: isPullRequest ? 'yes' : 'no' },
-          { Key: 'branch', Value: sanitizeS3TagString(branch) },
-        ],
-      },
-    }),
-  );
-
-  return { key };
-}
-
-/**
  * Uploads the size snapshot to S3
  * @param {string} snapshotPath - The path to the size snapshot JSON file
  * @param {NormalizedUploadConfig} uploadConfig - The normalized upload configuration
@@ -139,9 +76,5 @@ export async function uploadSnapshot(snapshotPath, uploadConfig, commitSha) {
     fs.promises.readFile(snapshotPath),
   ]);
 
-  if (uploadConfig.legacyUpload) {
-    return uploadDirectToS3(fileContent, uploadConfig, sha);
-  }
-
-  return uploadViaApi(fileContent, uploadConfig, sha);
+  return uploadViaApi(uploadConfig.apiUrl, fileContent, uploadConfig, sha);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,12 +466,6 @@ importers:
 
   packages/bundle-size-checker:
     dependencies:
-      '@aws-sdk/client-s3':
-        specifier: ^3.1008.0
-        version: 3.1009.0
-      '@aws-sdk/credential-providers':
-        specifier: ^3.1008.0
-        version: 3.1009.0
       '@octokit/rest':
         specifier: ^22.0.1
         version: 22.0.1
@@ -1153,10 +1147,6 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-cognito-identity@3.1009.0':
-    resolution: {integrity: sha512-4+lBLB2sIdrnGruxqsfPM2AOSME3DVDRX7R5OXcgd2jfrUSyYdHJN1kT9hO/vwK4uajRZsQNP5hLJMttkjkoAQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/client-s3@3.1009.0':
     resolution: {integrity: sha512-luy8CxallkoiGWTqU86ca/BbvkWJjs0oala7uIIRN1JtQxMb5i4Yl/PBZVcQFhbK9kQi0PK0GfD8gIpLkI91fw==}
     engines: {node: '>=20.0.0'}
@@ -1167,10 +1157,6 @@ packages:
 
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-provider-cognito-identity@3.972.13':
-    resolution: {integrity: sha512-WZnIK8NPX+4OXkpVoNmUS+Ya1osqjszUsDqFEz97+a/LD5K012np9iR/eWEC43btx8zQjyRIK8kyiwbh8SiHzg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.18':
@@ -1203,10 +1189,6 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.20':
     resolution: {integrity: sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/credential-providers@3.1009.0':
-    resolution: {integrity: sha512-URs590x3cCOHvjgDz8J0iqxDQ87NjF550pnWmd1jQm+w5ZHTxuUEYjivBQQkAB603IlEdeadqO1+LSjtMznhwA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.8':
@@ -13088,50 +13070,6 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-cognito-identity@3.1009.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-node': 3.972.21
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
   '@aws-sdk/client-s3@3.1009.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -13212,16 +13150,6 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-cognito-identity@3.972.13':
-    dependencies:
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-env@3.972.18':
     dependencies:
@@ -13322,31 +13250,6 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@aws-sdk/credential-providers@3.1009.0':
-    dependencies:
-      '@aws-sdk/client-cognito-identity': 3.1009.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-cognito-identity': 3.972.13
-      '@aws-sdk/credential-provider-env': 3.972.18
-      '@aws-sdk/credential-provider-http': 3.972.20
-      '@aws-sdk/credential-provider-ini': 3.972.20
-      '@aws-sdk/credential-provider-login': 3.972.20
-      '@aws-sdk/credential-provider-node': 3.972.21
-      '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
-      '@aws-sdk/credential-provider-web-identity': 3.972.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Removes the legacy direct-S3 upload path and the old `master/{sha}` fallback URL from the snapshot fetcher — neither has been in use since uploads moved to the dashboard API. This also drops the `@aws-sdk` dependencies that were only needed for the legacy path.

Adds a `_metadata` key to size snapshots containing `trackedBundles`, so the `report` command can produce full PR comments with tracked bundle highlighting without needing access to the local config. Entry IDs starting with `_` are now reserved and validated against. The `calculateSizeDiff` function filters these keys out so metadata doesn't appear as a bundle entry.