### PR TITLE
[code-infra] Exclude peer deps from being a hard requirement

### DIFF
--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -45,13 +45,13 @@ pnpm code-infra publish-new-package
 
 This command detects the new public packages in the repo and asks for your confirmation before publishing them to the npm registry. Add the `--dryRun` flag to skip the actual publishing.
 
-2. Goto the settings link for each packages, ie, https://www.npmjs.com/package/<pkg-name>/access , and setup `Trusted Publisher`.
+2. Goto the settings link for each packages, ie, `https://www.npmjs.com/package/<pkg-name>/access` , and setup `Trusted Publisher`.
 3. In `Select your publisher` step in the above link, click on the `Github Actions` button to configure Github actions based trusted publishing.
 4. Fill in the details of the repo -
    1. `Organization or user` as `mui`,
    2. `Repository` as per the new package
    3. `Workflow filename*` should be `publish.yml`
-   4. `Environment name` should be `npm-publish`
+   4. `Environment name` should be `npm-publish` or `npm-publish-internal` based on whether the package is user facing package or internal package respectively.
 5. In the `Publishing access` section, toggle the recommended option of `Require two-factor authentication and disallow tokens`.
 6. Finally, save the changes by clicking on `Update Package Settings` button.
 

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -159,7 +159,10 @@ async function prepareChangelogsFromGitCli(packagesToPublish, allPackages, canar
 
   const transitiveDepSets = await Promise.all(
     allPackages.map((pkg) =>
-      getTransitiveDependencies([pkg.name], { includeDev: false, workspacePathByName }),
+      getTransitiveDependencies([pkg.name], {
+        includeDev: false,
+        workspacePathByName,
+      }),
     ),
   );
 

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -315,7 +315,11 @@ async function getLastCanaryTag() {
     // Tag might not exist locally, which is fine
   }
 
-  await $`git fetch origin tag ${CANARY_TAG}`;
+  try {
+    await $`git fetch origin tag ${CANARY_TAG}`;
+  } catch {
+    // Tag might not exist on the remote yet (first canary run), which is fine
+  }
   const { stdout: remoteCanaryTag } = await $`git ls-remote --tags origin ${CANARY_TAG}`;
   return remoteCanaryTag.trim() ? CANARY_TAG : null;
 }

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -320,8 +320,11 @@ async function getLastCanaryTag() {
 
   try {
     await $`git fetch origin tag ${CANARY_TAG}`;
-  } catch {
+  } catch (err) {
     // Tag might not exist on the remote yet (first canary run), which is fine
+    if (!(/** @type {Error} */ (err).message?.includes("couldn't find remote ref"))) {
+      throw err;
+    }
   }
   const { stdout: remoteCanaryTag } = await $`git ls-remote --tags origin ${CANARY_TAG}`;
   return remoteCanaryTag.trim() ? CANARY_TAG : null;

--- a/packages/code-infra/src/cli/cmdPublishNewPackage.mjs
+++ b/packages/code-infra/src/cli/cmdPublishNewPackage.mjs
@@ -62,7 +62,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
             version: '0.0.1',
             repository: {
               type: 'git',
-              url: `git+https://github.com/${repo.owner}/${repo.remoteName}.git`,
+              url: `git+https://github.com/${repo.owner}/${repo.repo}.git`,
               directory: toPosixPath(path.relative(workspaceDir, pkg.path)),
             },
           };

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-import { withTempDir } from './testUtils.mjs';
+import { makeTempDir } from './testUtils.mjs';
 import { createPackageBin, createPackageExports } from './build.mjs';
 
 /**
@@ -16,7 +16,108 @@ async function createFile(filePath, contents = '') {
 
 describe('createPackageExports', () => {
   it('creates exports for a dual bundle module package', async () => {
-    await withTempDir(async (cwd) => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+    /**
+     * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+     */
+    const bundles = [
+      { type: 'esm', dir: '.' },
+      { type: 'cjs', dir: '.' },
+    ];
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/index.ts')),
+      createFile(path.join(cwd, 'src/feature.ts')),
+
+      // Create output files for index
+      createFile(path.join(outputDir, `index.js`)),
+      createFile(path.join(outputDir, `index.cjs`)),
+      createFile(path.join(outputDir, `index.d.ts`)),
+      createFile(path.join(outputDir, `index.d.cts`)),
+
+      // Create output files for feature
+      createFile(path.join(outputDir, `feature.js`)),
+      createFile(path.join(outputDir, `feature.cjs`)),
+      createFile(path.join(outputDir, `feature.d.ts`)),
+      createFile(path.join(outputDir, `feature.d.cts`)),
+    ]);
+
+    const {
+      exports: packageExports,
+      main,
+      types,
+    } = await createPackageExports({
+      exports: {
+        '.': './src/index.ts',
+        './feature': './src/feature.ts',
+      },
+      bundles,
+      outputDir,
+      cwd,
+      addTypes: true,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(main).toBe('./index.cjs');
+    expect(types).toBe('./index.d.cts');
+
+    expect(packageExports['.']).toEqual({
+      import: { types: './index.d.ts', default: './index.js' },
+      require: { types: './index.d.cts', default: './index.cjs' },
+      default: {
+        types: './index.d.ts',
+        default: './index.js',
+      },
+    });
+    expect(packageExports['./feature']).toEqual({
+      import: { types: './feature.d.ts', default: './feature.js' },
+      require: { types: './feature.d.cts', default: './feature.cjs' },
+      default: {
+        types: './feature.d.ts',
+        default: './feature.js',
+      },
+    });
+
+    const {
+      exports: packageExports2,
+      main: main2,
+      types: types2,
+    } = await createPackageExports({
+      exports: {
+        '.': './src/index.ts',
+        './feature': './src/feature.ts',
+      },
+      bundles: [bundles[1]], // only CJS bundle
+      outputDir,
+      cwd,
+      addTypes: true,
+      isFlat: true,
+    });
+
+    expect(main2).toBe('./index.js');
+    expect(types2).toBe('./index.d.ts');
+
+    expect(packageExports2['.']).toEqual({
+      require: { types: './index.d.ts', default: './index.js' },
+      default: {
+        types: './index.d.ts',
+        default: './index.js',
+      },
+    });
+    expect(packageExports2['./feature']).toEqual({
+      require: { types: './feature.d.ts', default: './feature.js' },
+      default: {
+        types: './feature.d.ts',
+        default: './feature.js',
+      },
+    });
+  });
+
+  describe('glob expansion', () => {
+    it('expands glob patterns in export keys and values', async () => {
+      const cwd = await makeTempDir();
       const outputDir = path.join(cwd, 'build');
       /**
        * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
@@ -27,30 +128,23 @@ describe('createPackageExports', () => {
       ];
 
       await Promise.all([
-        createFile(path.join(cwd, 'src/index.ts')),
-        createFile(path.join(cwd, 'src/feature.ts')),
+        createFile(path.join(cwd, 'src/Button.ts')),
+        createFile(path.join(cwd, 'src/TextField.ts')),
 
-        // Create output files for index
-        createFile(path.join(outputDir, `index.js`)),
-        createFile(path.join(outputDir, `index.cjs`)),
-        createFile(path.join(outputDir, `index.d.ts`)),
-        createFile(path.join(outputDir, `index.d.cts`)),
-
-        // Create output files for feature
-        createFile(path.join(outputDir, `feature.js`)),
-        createFile(path.join(outputDir, `feature.cjs`)),
-        createFile(path.join(outputDir, `feature.d.ts`)),
-        createFile(path.join(outputDir, `feature.d.cts`)),
+        // Output files
+        createFile(path.join(outputDir, 'Button.js')),
+        createFile(path.join(outputDir, 'Button.cjs')),
+        createFile(path.join(outputDir, 'Button.d.ts')),
+        createFile(path.join(outputDir, 'Button.d.cts')),
+        createFile(path.join(outputDir, 'TextField.js')),
+        createFile(path.join(outputDir, 'TextField.cjs')),
+        createFile(path.join(outputDir, 'TextField.d.ts')),
+        createFile(path.join(outputDir, 'TextField.d.cts')),
       ]);
 
-      const {
-        exports: packageExports,
-        main,
-        types,
-      } = await createPackageExports({
+      const { exports: packageExports } = await createPackageExports({
         exports: {
-          '.': './src/index.ts',
-          './feature': './src/feature.ts',
+          './*': './src/*.ts',
         },
         bundles,
         outputDir,
@@ -60,569 +154,73 @@ describe('createPackageExports', () => {
         packageType: 'module',
       });
 
-      expect(main).toBe('./index.cjs');
-      expect(types).toBe('./index.d.cts');
-
-      expect(packageExports['.']).toEqual({
-        import: { types: './index.d.ts', default: './index.js' },
-        require: { types: './index.d.cts', default: './index.cjs' },
-        default: {
-          types: './index.d.ts',
-          default: './index.js',
-        },
+      expect(packageExports['./Button']).toEqual({
+        import: { types: './Button.d.ts', default: './Button.js' },
+        require: { types: './Button.d.cts', default: './Button.cjs' },
+        default: { types: './Button.d.ts', default: './Button.js' },
       });
-      expect(packageExports['./feature']).toEqual({
-        import: { types: './feature.d.ts', default: './feature.js' },
-        require: { types: './feature.d.cts', default: './feature.cjs' },
-        default: {
-          types: './feature.d.ts',
-          default: './feature.js',
-        },
+      expect(packageExports['./TextField']).toEqual({
+        import: { types: './TextField.d.ts', default: './TextField.js' },
+        require: { types: './TextField.d.cts', default: './TextField.cjs' },
+        default: { types: './TextField.d.ts', default: './TextField.js' },
       });
-
-      const {
-        exports: packageExports2,
-        main: main2,
-        types: types2,
-      } = await createPackageExports({
-        exports: {
-          '.': './src/index.ts',
-          './feature': './src/feature.ts',
-        },
-        bundles: [bundles[1]], // only CJS bundle
-        outputDir,
-        cwd,
-        addTypes: true,
-        isFlat: true,
-      });
-
-      expect(main2).toBe('./index.js');
-      expect(types2).toBe('./index.d.ts');
-
-      expect(packageExports2['.']).toEqual({
-        require: { types: './index.d.ts', default: './index.js' },
-        default: {
-          types: './index.d.ts',
-          default: './index.js',
-        },
-      });
-      expect(packageExports2['./feature']).toEqual({
-        require: { types: './feature.d.ts', default: './feature.js' },
-        default: {
-          types: './feature.d.ts',
-          default: './feature.js',
-        },
-      });
-    });
-  });
-
-  describe('glob expansion', () => {
-    it('expands glob patterns in export keys and values', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Button.ts')),
-          createFile(path.join(cwd, 'src/TextField.ts')),
-
-          // Output files
-          createFile(path.join(outputDir, 'Button.js')),
-          createFile(path.join(outputDir, 'Button.cjs')),
-          createFile(path.join(outputDir, 'Button.d.ts')),
-          createFile(path.join(outputDir, 'Button.d.cts')),
-          createFile(path.join(outputDir, 'TextField.js')),
-          createFile(path.join(outputDir, 'TextField.cjs')),
-          createFile(path.join(outputDir, 'TextField.d.ts')),
-          createFile(path.join(outputDir, 'TextField.d.cts')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-          },
-          bundles,
-          outputDir,
-          cwd,
-          addTypes: true,
-          isFlat: true,
-          packageType: 'module',
-        });
-
-        expect(packageExports['./Button']).toEqual({
-          import: { types: './Button.d.ts', default: './Button.js' },
-          require: { types: './Button.d.cts', default: './Button.cjs' },
-          default: { types: './Button.d.ts', default: './Button.js' },
-        });
-        expect(packageExports['./TextField']).toEqual({
-          import: { types: './TextField.d.ts', default: './TextField.js' },
-          require: { types: './TextField.d.cts', default: './TextField.cjs' },
-          default: { types: './TextField.d.ts', default: './TextField.js' },
-        });
-        // glob key should not appear in the output
-        expect(packageExports['./*']).toBeUndefined();
-      });
+      // glob key should not appear in the output
+      expect(packageExports['./*']).toBeUndefined();
     });
 
     it('expands glob with commonjs package type', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Button.ts')),
-
-          createFile(path.join(outputDir, 'Button.js')),
-          createFile(path.join(outputDir, 'Button.mjs')),
-          createFile(path.join(outputDir, 'Button.d.ts')),
-          createFile(path.join(outputDir, 'Button.d.mts')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-          },
-          bundles,
-          outputDir,
-          cwd,
-          addTypes: true,
-          isFlat: true,
-          packageType: 'commonjs',
-        });
-
-        expect(packageExports['./Button']).toEqual({
-          import: { types: './Button.d.mts', default: './Button.mjs' },
-          require: { types: './Button.d.ts', default: './Button.js' },
-          default: { types: './Button.d.mts', default: './Button.mjs' },
-        });
-      });
-    });
-
-    it('expands glob with single CJS bundle', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Button.ts')),
-
-          createFile(path.join(outputDir, 'Button.js')),
-          createFile(path.join(outputDir, 'Button.d.ts')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          addTypes: true,
-          isFlat: true,
-          packageType: 'commonjs',
-        });
-
-        expect(packageExports['./Button']).toEqual({
-          require: { types: './Button.d.ts', default: './Button.js' },
-          default: { types: './Button.d.ts', default: './Button.js' },
-        });
-      });
-    });
-
-    it('expands glob patterns with mui-src object values', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Alert.ts')),
-
-          createFile(path.join(outputDir, 'Alert.js')),
-          createFile(path.join(outputDir, 'Alert.cjs')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': { 'mui-src': './src/*.ts' },
-          },
-          bundles,
-          outputDir,
-          cwd,
-          isFlat: true,
-          packageType: 'module',
-        });
-
-        expect(packageExports['./Alert']).toEqual({
-          import: './Alert.js',
-          require: './Alert.cjs',
-          default: './Alert.js',
-        });
-      });
-    });
-
-    it('preserves extra conditions from mui-src object values', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Alert.ts')),
-
-          createFile(path.join(outputDir, 'Alert.js')),
-          createFile(path.join(outputDir, 'Alert.cjs')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': { 'mui-src': './src/*.ts', node: './src/node/*.ts' },
-          },
-          bundles,
-          outputDir,
-          cwd,
-          isFlat: true,
-          packageType: 'module',
-        });
-
-        expect(packageExports['./Alert']).toEqual({
-          import: { node: './src/node/*.ts', default: './Alert.js' },
-          require: { node: './src/node/*.ts', default: './Alert.cjs' },
-          default: './Alert.js',
-        });
-      });
-    });
-
-    it('mixes glob and non-glob exports', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/index.ts')),
-          createFile(path.join(cwd, 'src/Chip.ts')),
-
-          createFile(path.join(outputDir, 'index.js')),
-          createFile(path.join(outputDir, 'index.cjs')),
-          createFile(path.join(outputDir, 'Chip.js')),
-          createFile(path.join(outputDir, 'Chip.cjs')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            '.': './src/index.ts',
-            './*': './src/*.ts',
-          },
-          bundles,
-          outputDir,
-          cwd,
-          isFlat: true,
-          packageType: 'module',
-        });
-
-        // Explicit export still works
-        expect(packageExports['.']).toBeDefined();
-        // Glob-expanded export
-        expect(packageExports['./Chip']).toEqual({
-          import: './Chip.js',
-          require: './Chip.cjs',
-          default: './Chip.js',
-        });
-      });
-    });
-
-    it('expands glob with subdirectory pattern', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/utils/color.ts')),
-          createFile(path.join(cwd, 'src/utils/size.ts')),
-
-          createFile(path.join(outputDir, 'utils/color.js')),
-          createFile(path.join(outputDir, 'utils/color.cjs')),
-          createFile(path.join(outputDir, 'utils/size.js')),
-          createFile(path.join(outputDir, 'utils/size.cjs')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './utils/*': './src/utils/*.ts',
-          },
-          bundles,
-          outputDir,
-          cwd,
-          isFlat: true,
-          packageType: 'module',
-        });
-
-        expect(packageExports['./utils/color']).toEqual({
-          import: './utils/color.js',
-          require: './utils/color.cjs',
-          default: './utils/color.js',
-        });
-        expect(packageExports['./utils/size']).toEqual({
-          import: './utils/size.js',
-          require: './utils/size.cjs',
-          default: './utils/size.js',
-        });
-      });
-    });
-
-    it('produces no entries when glob matches nothing', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        // Create the src directory but no .ts files in it
-        createFile(path.join(cwd, 'src/.gitkeep'));
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: true,
-        });
-
-        // Only the default ./package.json entry should be present
-        expect(Object.keys(packageExports)).toEqual(['./package.json']);
-      });
-    });
-
-    it('expands globs in sorted order', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Zebra.ts')),
-          createFile(path.join(cwd, 'src/Apple.ts')),
-          createFile(path.join(cwd, 'src/Mango.ts')),
-
-          createFile(path.join(outputDir, 'Zebra.js')),
-          createFile(path.join(outputDir, 'Apple.js')),
-          createFile(path.join(outputDir, 'Mango.js')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: true,
-        });
-
-        const exportKeys = Object.keys(packageExports).filter((k) => k !== './package.json');
-        expect(exportKeys).toEqual(['./Apple', './Mango', './Zebra']);
-      });
-    });
-
-    it('removes expanded entries matching a null-valued glob (negation)', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-        /**
-         * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-         */
-        const bundles = [
-          { type: 'esm', dir: '.' },
-          { type: 'cjs', dir: '.' },
-        ];
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Accordion.ts')),
-          createFile(path.join(cwd, 'src/Button.ts')),
-          createFile(path.join(cwd, 'src/ButtonBase.ts')),
-
-          createFile(path.join(outputDir, 'Accordion.js')),
-          createFile(path.join(outputDir, 'Accordion.cjs')),
-          createFile(path.join(outputDir, 'Button.js')),
-          createFile(path.join(outputDir, 'Button.cjs')),
-          createFile(path.join(outputDir, 'ButtonBase.js')),
-          createFile(path.join(outputDir, 'ButtonBase.cjs')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-            './Button*': null,
-          },
-          bundles,
-          outputDir,
-          cwd,
-          isFlat: true,
-          packageType: 'module',
-        });
-
-        expect(packageExports['./Accordion']).toBeDefined();
-        expect(packageExports['./Button']).toBeUndefined();
-        expect(packageExports['./ButtonBase']).toBeUndefined();
-        // The negation glob key itself should not appear
-        expect(packageExports['./Button*']).toBeUndefined();
-      });
-    });
-
-    it('negation with null removes only matching keys', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Alert.ts')),
-          createFile(path.join(cwd, 'src/AlertTitle.ts')),
-          createFile(path.join(cwd, 'src/Button.ts')),
-
-          createFile(path.join(outputDir, 'Alert.js')),
-          createFile(path.join(outputDir, 'AlertTitle.js')),
-          createFile(path.join(outputDir, 'Button.js')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-            './Alert*': null,
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: true,
-        });
-
-        const exportKeys = Object.keys(packageExports).filter((k) => k !== './package.json');
-        expect(exportKeys).toEqual(['./Button']);
-      });
-    });
-
-    it('preserves null glob pattern when no keys match', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Button.ts')),
-          createFile(path.join(outputDir, 'Button.js')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-            './internal/*': null,
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: true,
-        });
-
-        // Button is kept since it doesn't match the negation
-        expect(packageExports['./Button']).toBeDefined();
-        // The negation pattern is preserved as null since nothing matched it
-        expect(packageExports['./internal/*']).toBeNull();
-      });
-    });
-
-    it('does not expand glob patterns when isFlat is false', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/Button.ts')),
-          createFile(path.join(cwd, 'src/TextField.ts')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/*.ts',
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: false,
-        });
-
-        // Glob should NOT be expanded to individual files
-        expect(packageExports['./Button']).toBeUndefined();
-        expect(packageExports['./TextField']).toBeUndefined();
-        // The raw glob pattern is passed through as-is
-        expect(packageExports['./*']).toEqual({
-          require: './*.js',
-          default: './*.js',
-        });
-      });
-    });
-
-    it('passes through glob key when value has no wildcard', async () => {
-      await withTempDir(async (cwd) => {
-        const outputDir = path.join(cwd, 'build');
-
-        await Promise.all([
-          createFile(path.join(cwd, 'src/index.ts')),
-          createFile(path.join(outputDir, 'index.js')),
-        ]);
-
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
-            './*': './src/index.ts',
-          },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: true,
-        });
-
-        // When the value has no *, the glob key is passed through as-is
-        expect(packageExports['./*']).toBeDefined();
-      });
-    });
-  });
-
-  it('uses require/import and default for single bundle package', async () => {
-    await withTempDir(async (cwd) => {
+      const cwd = await makeTempDir();
       const outputDir = path.join(cwd, 'build');
+      /**
+       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+       */
+      const bundles = [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ];
 
       await Promise.all([
-        createFile(path.join(cwd, 'src/index.ts')),
-        createFile(path.join(outputDir, 'index.js')),
-        createFile(path.join(outputDir, 'index.d.ts')),
+        createFile(path.join(cwd, 'src/Button.ts')),
+
+        createFile(path.join(outputDir, 'Button.js')),
+        createFile(path.join(outputDir, 'Button.mjs')),
+        createFile(path.join(outputDir, 'Button.d.ts')),
+        createFile(path.join(outputDir, 'Button.d.mts')),
       ]);
 
       const { exports: packageExports } = await createPackageExports({
         exports: {
-          '.': './src/index.ts',
+          './*': './src/*.ts',
+        },
+        bundles,
+        outputDir,
+        cwd,
+        addTypes: true,
+        isFlat: true,
+        packageType: 'commonjs',
+      });
+
+      expect(packageExports['./Button']).toEqual({
+        import: { types: './Button.d.mts', default: './Button.mjs' },
+        require: { types: './Button.d.ts', default: './Button.js' },
+        default: { types: './Button.d.mts', default: './Button.mjs' },
+      });
+    });
+
+    it('expands glob with single CJS bundle', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Button.ts')),
+
+        createFile(path.join(outputDir, 'Button.js')),
+        createFile(path.join(outputDir, 'Button.d.ts')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
         },
         bundles: [{ type: 'cjs', dir: '.' }],
         outputDir,
@@ -632,24 +230,15 @@ describe('createPackageExports', () => {
         packageType: 'commonjs',
       });
 
-      // Single CJS bundle should have both require and default pointing to the same files
-      expect(packageExports['.']).toEqual({
-        require: {
-          types: './index.d.ts',
-          default: './index.js',
-        },
-        default: {
-          types: './index.d.ts',
-          default: './index.js',
-        },
+      expect(packageExports['./Button']).toEqual({
+        require: { types: './Button.d.ts', default: './Button.js' },
+        default: { types: './Button.d.ts', default: './Button.js' },
       });
     });
-  });
-});
 
-describe('createPackageBin', () => {
-  it('prefers the ESM bundle when available', async () => {
-    await withTempDir(async (cwd) => {
+    it('expands glob patterns with mui-src object values', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
       /**
        * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
        */
@@ -658,36 +247,430 @@ describe('createPackageBin', () => {
         { type: 'cjs', dir: '.' },
       ];
 
-      await Promise.all([createFile(path.join(cwd, 'src/cli.ts'))]);
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Alert.ts')),
 
-      let bin = await createPackageBin({
-        bin: './src/cli.ts',
+        createFile(path.join(outputDir, 'Alert.js')),
+        createFile(path.join(outputDir, 'Alert.cjs')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': { 'mui-src': './src/*.ts' },
+        },
         bundles,
+        outputDir,
         cwd,
         isFlat: true,
         packageType: 'module',
       });
 
-      expect(bin).toBe('./cli.js');
-
-      bin = await createPackageBin({
-        bin: './src/cli.ts',
-        bundles: [bundles[1]], // only CJS bundle
-        cwd,
-        isFlat: true,
+      expect(packageExports['./Alert']).toEqual({
+        import: './Alert.js',
+        require: './Alert.cjs',
+        default: './Alert.js',
       });
-
-      expect(bin).toBe('./cli.js');
-
-      bin = await createPackageBin({
-        bin: './src/cli.ts',
-        bundles, // only CJS bundle
-        cwd,
-        isFlat: true,
-        packageType: 'commonjs',
-      });
-
-      expect(bin).toBe('./cli.mjs');
     });
+
+    it('preserves extra conditions from mui-src object values', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+      /**
+       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+       */
+      const bundles = [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ];
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Alert.ts')),
+
+        createFile(path.join(outputDir, 'Alert.js')),
+        createFile(path.join(outputDir, 'Alert.cjs')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': { 'mui-src': './src/*.ts', node: './src/node/*.ts' },
+        },
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      });
+
+      expect(packageExports['./Alert']).toEqual({
+        import: { node: './src/node/*.ts', default: './Alert.js' },
+        require: { node: './src/node/*.ts', default: './Alert.cjs' },
+        default: './Alert.js',
+      });
+    });
+
+    it('mixes glob and non-glob exports', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+      /**
+       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+       */
+      const bundles = [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ];
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/index.ts')),
+        createFile(path.join(cwd, 'src/Chip.ts')),
+
+        createFile(path.join(outputDir, 'index.js')),
+        createFile(path.join(outputDir, 'index.cjs')),
+        createFile(path.join(outputDir, 'Chip.js')),
+        createFile(path.join(outputDir, 'Chip.cjs')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          '.': './src/index.ts',
+          './*': './src/*.ts',
+        },
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      });
+
+      // Explicit export still works
+      expect(packageExports['.']).toBeDefined();
+      // Glob-expanded export
+      expect(packageExports['./Chip']).toEqual({
+        import: './Chip.js',
+        require: './Chip.cjs',
+        default: './Chip.js',
+      });
+    });
+
+    it('expands glob with subdirectory pattern', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+      /**
+       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+       */
+      const bundles = [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ];
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/utils/color.ts')),
+        createFile(path.join(cwd, 'src/utils/size.ts')),
+
+        createFile(path.join(outputDir, 'utils/color.js')),
+        createFile(path.join(outputDir, 'utils/color.cjs')),
+        createFile(path.join(outputDir, 'utils/size.js')),
+        createFile(path.join(outputDir, 'utils/size.cjs')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './utils/*': './src/utils/*.ts',
+        },
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      });
+
+      expect(packageExports['./utils/color']).toEqual({
+        import: './utils/color.js',
+        require: './utils/color.cjs',
+        default: './utils/color.js',
+      });
+      expect(packageExports['./utils/size']).toEqual({
+        import: './utils/size.js',
+        require: './utils/size.cjs',
+        default: './utils/size.js',
+      });
+    });
+
+    it('produces no entries when glob matches nothing', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      // Create the src directory but no .ts files in it
+      createFile(path.join(cwd, 'src/.gitkeep'));
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
+        },
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      });
+
+      // Only the default ./package.json entry should be present
+      expect(Object.keys(packageExports)).toEqual(['./package.json']);
+    });
+
+    it('expands globs in sorted order', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Zebra.ts')),
+        createFile(path.join(cwd, 'src/Apple.ts')),
+        createFile(path.join(cwd, 'src/Mango.ts')),
+
+        createFile(path.join(outputDir, 'Zebra.js')),
+        createFile(path.join(outputDir, 'Apple.js')),
+        createFile(path.join(outputDir, 'Mango.js')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
+        },
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      });
+
+      const exportKeys = Object.keys(packageExports).filter((k) => k !== './package.json');
+      expect(exportKeys).toEqual(['./Apple', './Mango', './Zebra']);
+    });
+
+    it('removes expanded entries matching a null-valued glob (negation)', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+      /**
+       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+       */
+      const bundles = [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ];
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Accordion.ts')),
+        createFile(path.join(cwd, 'src/Button.ts')),
+        createFile(path.join(cwd, 'src/ButtonBase.ts')),
+
+        createFile(path.join(outputDir, 'Accordion.js')),
+        createFile(path.join(outputDir, 'Accordion.cjs')),
+        createFile(path.join(outputDir, 'Button.js')),
+        createFile(path.join(outputDir, 'Button.cjs')),
+        createFile(path.join(outputDir, 'ButtonBase.js')),
+        createFile(path.join(outputDir, 'ButtonBase.cjs')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
+          './Button*': null,
+        },
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      });
+
+      expect(packageExports['./Accordion']).toBeDefined();
+      expect(packageExports['./Button']).toBeUndefined();
+      expect(packageExports['./ButtonBase']).toBeUndefined();
+      // The negation glob key itself should not appear
+      expect(packageExports['./Button*']).toBeUndefined();
+    });
+
+    it('negation with null removes only matching keys', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Alert.ts')),
+        createFile(path.join(cwd, 'src/AlertTitle.ts')),
+        createFile(path.join(cwd, 'src/Button.ts')),
+
+        createFile(path.join(outputDir, 'Alert.js')),
+        createFile(path.join(outputDir, 'AlertTitle.js')),
+        createFile(path.join(outputDir, 'Button.js')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
+          './Alert*': null,
+        },
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      });
+
+      const exportKeys = Object.keys(packageExports).filter((k) => k !== './package.json');
+      expect(exportKeys).toEqual(['./Button']);
+    });
+
+    it('preserves null glob pattern when no keys match', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Button.ts')),
+        createFile(path.join(outputDir, 'Button.js')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
+          './internal/*': null,
+        },
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      });
+
+      // Button is kept since it doesn't match the negation
+      expect(packageExports['./Button']).toBeDefined();
+      // The negation pattern is preserved as null since nothing matched it
+      expect(packageExports['./internal/*']).toBeNull();
+    });
+
+    it('does not expand glob patterns when isFlat is false', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Button.ts')),
+        createFile(path.join(cwd, 'src/TextField.ts')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/*.ts',
+        },
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: false,
+      });
+
+      // Glob should NOT be expanded to individual files
+      expect(packageExports['./Button']).toBeUndefined();
+      expect(packageExports['./TextField']).toBeUndefined();
+      // The raw glob pattern is passed through as-is
+      expect(packageExports['./*']).toEqual({
+        require: './*.js',
+        default: './*.js',
+      });
+    });
+
+    it('passes through glob key when value has no wildcard', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/index.ts')),
+        createFile(path.join(outputDir, 'index.js')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': './src/index.ts',
+        },
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      });
+
+      // When the value has no *, the glob key is passed through as-is
+      expect(packageExports['./*']).toBeDefined();
+    });
+  });
+
+  it('uses require/import and default for single bundle package', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/index.ts')),
+      createFile(path.join(outputDir, 'index.js')),
+      createFile(path.join(outputDir, 'index.d.ts')),
+    ]);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        '.': './src/index.ts',
+      },
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      addTypes: true,
+      isFlat: true,
+      packageType: 'commonjs',
+    });
+
+    // Single CJS bundle should have both require and default pointing to the same files
+    expect(packageExports['.']).toEqual({
+      require: {
+        types: './index.d.ts',
+        default: './index.js',
+      },
+      default: {
+        types: './index.d.ts',
+        default: './index.js',
+      },
+    });
+  });
+});
+
+describe('createPackageBin', () => {
+  it('prefers the ESM bundle when available', async () => {
+    const cwd = await makeTempDir();
+    /**
+     * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+     */
+    const bundles = [
+      { type: 'esm', dir: '.' },
+      { type: 'cjs', dir: '.' },
+    ];
+
+    await Promise.all([createFile(path.join(cwd, 'src/cli.ts'))]);
+
+    let bin = await createPackageBin({
+      bin: './src/cli.ts',
+      bundles,
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(bin).toBe('./cli.js');
+
+    bin = await createPackageBin({
+      bin: './src/cli.ts',
+      bundles: [bundles[1]], // only CJS bundle
+      cwd,
+      isFlat: true,
+    });
+
+    expect(bin).toBe('./cli.js');
+
+    bin = await createPackageBin({
+      bin: './src/cli.ts',
+      bundles, // only CJS bundle
+      cwd,
+      isFlat: true,
+      packageType: 'commonjs',
+    });
+
+    expect(bin).toBe('./cli.mjs');
   });
 });

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -1,8 +1,8 @@
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { withTempDir } from './testUtils.mjs';
 import { createPackageBin, createPackageExports } from './build.mjs';
 
 /**
@@ -12,18 +12,6 @@ import { createPackageBin, createPackageExports } from './build.mjs';
 async function createFile(filePath, contents = '') {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, contents, 'utf8');
-}
-
-/**
- * @param {(cwd: string) => Promise<void>} fn
- */
-async function withTempDir(fn) {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'code-infra-build-test-'));
-  try {
-    return await fn(tmpDir);
-  } finally {
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  }
 }
 
 describe('createPackageExports', () => {

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -185,23 +185,24 @@ export async function publishPackages(packages, options = {}) {
  * @typedef {Object} GetTransitiveDependenciesOptions
  * @property {Map<string, string>} [workspacePathByName] - Map of workspace package name to directory path
  * @property {boolean} [includeDev=true] - Whether to include devDependencies in the traversal
- * @property {boolean} [includePeer=true] - Whether to include peerDependencies in the traversal
  */
 
 /**
  * Get all transitive workspace dependencies for a set of packages.
  *
- * Traverses `dependencies`, and optionally `peerDependencies` and `devDependencies`,
- * following only packages that exist in `workspacePathByName`. Results are cached
- * per package so each package is read from disk at most once regardless of how many
- * roots depend on it.
+ * Only follows deps whose version spec starts with `workspace:` (e.g. `workspace:*`
+ * or `workspace:^`), meaning they are sourced directly from the monorepo. Pinned
+ * external versions (e.g. `^1.0.0`) are ignored even when the package name exists
+ * in the workspace. Traverses `dependencies` and optionally `devDependencies`.
+ * Results are cached per package so each package is read from disk at most once
+ * regardless of how many roots depend on it.
  *
  * @param {string[]} packageNames - Package names to start the traversal from
  * @param {GetTransitiveDependenciesOptions} [options]
  * @returns {Promise<Set<string>>} All reachable workspace package names, including the input packages themselves
  */
 export async function getTransitiveDependencies(packageNames, options = {}) {
-  const { includeDev = true, includePeer = true, workspacePathByName = new Map() } = options;
+  const { includeDev = true, workspacePathByName = new Map() } = options;
 
   /** @type {Map<string, Promise<Set<string>>>} */
   const cache = new Map();
@@ -223,12 +224,18 @@ export async function getTransitiveDependencies(packageNames, options = {}) {
       }
 
       const pkgJson = await readPackageJson(packagePath);
-      const allDeps = new Set([
-        ...Object.keys(pkgJson.dependencies ?? {}),
-        ...(includeDev ? Object.keys(pkgJson.devDependencies ?? {}) : []),
-        ...(includePeer ? Object.keys(pkgJson.peerDependencies ?? {}) : []),
-      ]);
-      const workspaceDeps = [...allDeps].filter((dep) => workspacePathByName.has(dep));
+      const allDepEntries = [
+        ...Object.entries(pkgJson.dependencies ?? {}),
+        ...(includeDev ? Object.entries(pkgJson.devDependencies ?? {}) : []),
+      ];
+      const workspaceDeps = allDepEntries
+        .filter(
+          ([dep, spec]) =>
+            workspacePathByName.has(dep) &&
+            typeof spec === 'string' &&
+            spec.startsWith('workspace:'),
+        )
+        .map(([dep]) => dep);
 
       const recursiveResults = await Promise.all(workspaceDeps.map(collectDeps));
       return new Set([...workspaceDeps, ...recursiveResults.flatMap((s) => [...s])]);
@@ -246,41 +253,6 @@ export async function getTransitiveDependencies(packageNames, options = {}) {
 
   const results = await Promise.all(packageNames.map(collectDeps));
   return new Set([...packageNames, ...results.flatMap((s) => [...s])]);
-}
-
-/**
- * Collect all workspace dependency names that are hard requirements for publishing.
- * A dependency is a hard requirement only when it appears in `dependencies` (not
- * `peerDependencies` or `devDependencies`) with a `workspace:` version specifier
- * (e.g. `workspace:*` or `workspace:^`). Peer dependencies are never bundled and
- * are satisfied by the consumer at install time. Dev dependencies are not installed
- * on consumer devices. Both are excluded regardless of their version specifier.
- *
- * @param {string} packageName
- * @param {Map<string, string>} workspacePathByName
- * @returns {Promise<Set<string>>}
- */
-async function collectWorkspaceProtocolDeps(packageName, workspacePathByName) {
-  const packagePath = workspacePathByName.get(packageName);
-  if (!packagePath) {
-    throw new Error(`Workspace "${packageName}" not found`);
-  }
-  const pkgJson = await readPackageJson(packagePath);
-
-  // Only inspect dependencies — never peerDependencies or devDependencies.
-  // Peers are never bundled and devDeps are not installed on consumer devices.
-  const hardDepFields = /** @type {Record<string, string>} */ (
-    /** @type {unknown} */ ({ ...pkgJson.dependencies })
-  );
-
-  return new Set(
-    Object.entries(hardDepFields)
-      .filter(
-        ([dep, spec]) =>
-          workspacePathByName.has(dep) && typeof spec === 'string' && spec.startsWith('workspace:'),
-      )
-      .map(([dep]) => dep),
-  );
 }
 
 /**
@@ -308,25 +280,10 @@ export async function checkPublishDependencies(
 ) {
   const publishedNames = new Set(packages.map((pkg) => pkg.name));
 
-  // BFS over workspace:protocol deps only
-  /** @type {Set<string>} */
-  const visited = new Set(packages.map((pkg) => pkg.name));
-  const queue = [...visited];
-
-  while (queue.length > 0) {
-    const name = /** @type {string} */ (queue.shift());
-    // eslint-disable-next-line no-await-in-loop
-    const directDeps = await collectWorkspaceProtocolDeps(name, workspacePathByName);
-    for (const dep of directDeps) {
-      if (!visited.has(dep)) {
-        visited.add(dep);
-        queue.push(dep);
-      }
-    }
-  }
-
-  // visited now contains the roots + all transitive workspace:protocol deps
-  const transitiveDeps = visited;
+  const transitiveDeps = await getTransitiveDependencies(
+    packages.map((pkg) => pkg.name),
+    { includeDev: false, workspacePathByName },
+  );
 
   /** @type {Set<string>} */
   const privateButRequired = new Set();

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -185,12 +185,13 @@ export async function publishPackages(packages, options = {}) {
  * @typedef {Object} GetTransitiveDependenciesOptions
  * @property {Map<string, string>} [workspacePathByName] - Map of workspace package name to directory path
  * @property {boolean} [includeDev=true] - Whether to include devDependencies in the traversal
+ * @property {boolean} [includePeer=true] - Whether to include peerDependencies in the traversal
  */
 
 /**
  * Get all transitive workspace dependencies for a set of packages.
  *
- * Traverses `dependencies`, `peerDependencies`, and optionally `devDependencies`,
+ * Traverses `dependencies`, and optionally `peerDependencies` and `devDependencies`,
  * following only packages that exist in `workspacePathByName`. Results are cached
  * per package so each package is read from disk at most once regardless of how many
  * roots depend on it.
@@ -200,7 +201,7 @@ export async function publishPackages(packages, options = {}) {
  * @returns {Promise<Set<string>>} All reachable workspace package names, including the input packages themselves
  */
 export async function getTransitiveDependencies(packageNames, options = {}) {
-  const { includeDev = true, workspacePathByName = new Map() } = options;
+  const { includeDev = true, includePeer = true, workspacePathByName = new Map() } = options;
 
   /** @type {Map<string, Promise<Set<string>>>} */
   const cache = new Map();
@@ -225,7 +226,7 @@ export async function getTransitiveDependencies(packageNames, options = {}) {
       const allDeps = new Set([
         ...Object.keys(pkgJson.dependencies ?? {}),
         ...(includeDev ? Object.keys(pkgJson.devDependencies ?? {}) : []),
-        ...Object.keys(pkgJson.peerDependencies ?? {}),
+        ...(includePeer ? Object.keys(pkgJson.peerDependencies ?? {}) : []),
       ]);
       const workspaceDeps = [...allDeps].filter((dep) => workspacePathByName.has(dep));
 
@@ -269,7 +270,7 @@ export async function validatePublishDependencies(packages) {
   const publishedNames = new Set(packages.map((pkg) => pkg.name));
   const transitiveDeps = await getTransitiveDependencies(
     packages.map((pkg) => pkg.name),
-    { includeDev: false, workspacePathByName },
+    { includeDev: false, includePeer: false, workspacePathByName },
   );
 
   /** @type {Set<string>} */

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -249,29 +249,84 @@ export async function getTransitiveDependencies(packageNames, options = {}) {
 }
 
 /**
- * Validate that a set of packages covers all of their transitive workspace dependencies,
- * and that none of those dependencies are private (which would make them unpublishable).
+ * Collect all workspace dependency names that are hard requirements for publishing.
+ * A dependency is a hard requirement only when it appears in `dependencies` (not
+ * `peerDependencies` or `devDependencies`) with a `workspace:` version specifier
+ * (e.g. `workspace:*` or `workspace:^`). Peer dependencies are never bundled and
+ * are satisfied by the consumer at install time. Dev dependencies are not installed
+ * on consumer devices. Both are excluded regardless of their version specifier.
+ *
+ * @param {string} packageName
+ * @param {Map<string, string>} workspacePathByName
+ * @returns {Promise<Set<string>>}
+ */
+async function collectWorkspaceProtocolDeps(packageName, workspacePathByName) {
+  const packagePath = workspacePathByName.get(packageName);
+  if (!packagePath) {
+    throw new Error(`Workspace "${packageName}" not found`);
+  }
+  const pkgJson = await readPackageJson(packagePath);
+
+  // Only inspect dependencies — never peerDependencies or devDependencies.
+  // Peers are never bundled and devDeps are not installed on consumer devices.
+  const hardDepFields = /** @type {Record<string, string>} */ (
+    /** @type {unknown} */ ({ ...pkgJson.dependencies })
+  );
+
+  return new Set(
+    Object.entries(hardDepFields)
+      .filter(
+        ([dep, spec]) =>
+          workspacePathByName.has(dep) && typeof spec === 'string' && spec.startsWith('workspace:'),
+      )
+      .map(([dep]) => dep),
+  );
+}
+
+/**
+ * Pure validation logic: given a publish set and workspace maps, checks that all
+ * transitive hard workspace dependencies are covered and none are private.
+ *
+ * A hard dependency is one listed in `dependencies` (not `peerDependencies` or
+ * `devDependencies`) using a `workspace:` version specifier (e.g. `workspace:*` or
+ * `workspace:^`). Peer dependencies are never bundled and dev dependencies are not installed
+ * on consumer devices - both are excluded regardless of version specifier. Pinned-version
+ * references in `dependencies` are also excluded - they resolve from the registry and do
+ * not need to be co-published.
  *
  * @param {PublicPackage[]} packages - The packages intended for publishing
+ * @param {Map<string, PublicPackage | PrivatePackage>} workspacePackageByName - All workspace packages by name
+ * @param {Map<string, string>} workspacePathByName - Map of workspace package name to directory path
  * @returns {Promise<{issues: string[]}>}
  *   List of human-readable issue strings. Empty when the dependency set is valid.
+ * @internal
  */
-export async function validatePublishDependencies(packages) {
-  const allWorkspacePackages = await getWorkspacePackages();
-
-  /** @type {Map<string, PublicPackage | PrivatePackage>} */
-  const workspacePackageByName = new Map(
-    allWorkspacePackages.flatMap((pkg) => (pkg.name ? [[pkg.name, pkg]] : [])),
-  );
-  const workspacePathByName = new Map(
-    allWorkspacePackages.flatMap((pkg) => (pkg.name ? [[pkg.name, pkg.path]] : [])),
-  );
-
+export async function checkPublishDependencies(
+  packages,
+  workspacePackageByName,
+  workspacePathByName,
+) {
   const publishedNames = new Set(packages.map((pkg) => pkg.name));
-  const transitiveDeps = await getTransitiveDependencies(
-    packages.map((pkg) => pkg.name),
-    { includeDev: false, includePeer: false, workspacePathByName },
-  );
+
+  // BFS over workspace:protocol deps only
+  /** @type {Set<string>} */
+  const visited = new Set(packages.map((pkg) => pkg.name));
+  const queue = [...visited];
+
+  while (queue.length > 0) {
+    const name = /** @type {string} */ (queue.shift());
+    // eslint-disable-next-line no-await-in-loop
+    const directDeps = await collectWorkspaceProtocolDeps(name, workspacePathByName);
+    for (const dep of directDeps) {
+      if (!visited.has(dep)) {
+        visited.add(dep);
+        queue.push(dep);
+      }
+    }
+  }
+
+  // visited now contains the roots + all transitive workspace:protocol deps
+  const transitiveDeps = visited;
 
   /** @type {Set<string>} */
   const privateButRequired = new Set();
@@ -306,6 +361,27 @@ export async function validatePublishDependencies(packages) {
   }
 
   return { issues };
+}
+
+/**
+ * Validate that a set of packages covers all of their transitive hard workspace dependencies,
+ * and that none of those dependencies are private (which would make them unpublishable).
+ *
+ * @param {PublicPackage[]} packages - The packages intended for publishing
+ * @returns {Promise<{issues: string[]}>}
+ *   List of human-readable issue strings. Empty when the dependency set is valid.
+ */
+export async function validatePublishDependencies(packages) {
+  const allWorkspacePackages = await getWorkspacePackages();
+
+  const workspacePackageByName = /** @type {Map<string, PublicPackage | PrivatePackage>} */ (
+    new Map(allWorkspacePackages.flatMap((pkg) => (pkg.name ? [[pkg.name, pkg]] : [])))
+  );
+  const workspacePathByName = new Map(
+    allWorkspacePackages.flatMap((pkg) => (pkg.name ? [[pkg.name, pkg.path]] : [])),
+  );
+
+  return checkPublishDependencies(packages, workspacePackageByName, workspacePathByName);
 }
 
 /**

--- a/packages/code-infra/src/utils/pnpm.test.mjs
+++ b/packages/code-infra/src/utils/pnpm.test.mjs
@@ -1,0 +1,604 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import { withTempDir } from './testUtils.mjs';
+import { checkPublishDependencies } from './pnpm.mjs';
+
+/**
+ * Write a package.json file to a temp subdirectory and return the directory path.
+ * @param {string} root - Root temp directory
+ * @param {string} name - Package subdirectory name
+ * @param {object} pkgJson - package.json contents
+ * @returns {Promise<string>} Path to the package directory
+ */
+async function writePackage(root, name, pkgJson) {
+  const pkgDir = path.join(root, name);
+  await fs.mkdir(pkgDir, { recursive: true });
+  await fs.writeFile(path.join(pkgDir, 'package.json'), JSON.stringify(pkgJson, null, 2));
+  return pkgDir;
+}
+
+/**
+ * @param {string} name
+ * @param {string} pkgPath
+ * @returns {import('./pnpm.mjs').PublicPackage}
+ */
+function publicPkg(name, pkgPath) {
+  return { name, version: '1.0.0', path: pkgPath, isPrivate: false };
+}
+
+/**
+ * @param {string} name
+ * @param {string} pkgPath
+ * @returns {import('./pnpm.mjs').PrivatePackage}
+ */
+function privatePkg(name, pkgPath) {
+  return { name, version: '1.0.0', path: pkgPath, isPrivate: true };
+}
+
+/**
+ * Build the workspace maps expected by checkPublishDependencies.
+ * @param {(import('./pnpm.mjs').PublicPackage | import('./pnpm.mjs').PrivatePackage)[]} allPkgs
+ */
+function workspaceMaps(allPkgs) {
+  /** @type {Map<string, import('./pnpm.mjs').PublicPackage | import('./pnpm.mjs').PrivatePackage>} */
+  const byName = new Map(allPkgs.flatMap((p) => (p.name ? [[p.name, p]] : [])));
+  const pathByName = new Map(allPkgs.flatMap((p) => (p.name ? [[p.name, p.path]] : [])));
+  return { byName, pathByName };
+}
+
+describe('checkPublishDependencies', () => {
+  describe('workspace: protocol in dependencies', () => {
+    it('returns no issues when all workspace: dependencies are included in the publish set', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('reports an issue when a workspace: dependency is missing from the publish set', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toContain('@scope/pkg-b');
+        expect(issues[0]).toContain('Add them to the --filter list');
+      });
+    });
+
+    it('reports an issue when a workspace: dependency is private', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = privatePkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toContain('@scope/pkg-b');
+        expect(issues[0]).toContain('private');
+      });
+    });
+
+    it('resolves transitive workspace: dependencies', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', {
+          name: '@scope/pkg-b',
+          dependencies: { '@scope/pkg-c': 'workspace:*' },
+        });
+        const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const pkgC = publicPkg('@scope/pkg-c', cDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
+
+        // publishing only A and B — C is missing but transitively required
+        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toContain('@scope/pkg-c');
+
+        // publishing all three — no issues
+        const { issues: noIssues } = await checkPublishDependencies(
+          [pkgA, pkgB, pkgC],
+          byName,
+          pathByName,
+        );
+        expect(noIssues).toEqual([]);
+      });
+    });
+  });
+
+  describe('peerDependencies are never hard requirements', () => {
+    it('does not require a peer dependency even when using workspace: protocol', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          peerDependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        // publishing only A — B is a workspace: peer dep but must NOT be required
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('does not require a peer dependency with a pinned version', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          peerDependencies: { '@scope/pkg-b': '^1.0.0' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('does not require a private peer dependency', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          peerDependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = privatePkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+
+  describe('workspace:^ protocol in dependencies', () => {
+    it('requires a workspace:^ dependency that is missing from the publish set', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:^' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toContain('@scope/pkg-b');
+      });
+    });
+
+    it('returns no issues when a workspace:^ dependency is included in the publish set', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:^' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+
+  describe('devDependencies are never hard requirements', () => {
+    it('does not require a workspace: devDependency missing from the publish set', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          devDependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('does not require a workspace:^ devDependency missing from the publish set', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          devDependencies: { '@scope/pkg-b': 'workspace:^' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('does not require a private workspace: devDependency', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          devDependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = privatePkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+
+  describe('pinned versions in dependencies are not hard requirements', () => {
+    it('does not require a workspace package referenced with a pinned version in dependencies', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': '^1.0.0' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+
+  describe('mixed dependency types', () => {
+    it('requires workspace: dependencies but not workspace: peers from the same package', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:*' },
+          peerDependencies: { '@scope/pkg-c': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+        const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const pkgC = publicPkg('@scope/pkg-c', cDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
+
+        // B is required (workspace: dep), C is not (workspace: peer)
+        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+        expect(issues).toEqual([]);
+
+        // Omitting B should flag it
+        const { issues: missingB } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(missingB).toHaveLength(1);
+        expect(missingB[0]).toContain('@scope/pkg-b');
+      });
+    });
+
+    it('does not traverse peer deps when resolving transitive requirements', async () => {
+      await withTempDir(async (root) => {
+        // A depends on B (workspace:), B has C as a peer (workspace:)
+        // C should NOT be required just because B peers it
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { '@scope/pkg-b': 'workspace:*' },
+        });
+        const bDir = await writePackage(root, 'pkg-b', {
+          name: '@scope/pkg-b',
+          peerDependencies: { '@scope/pkg-c': 'workspace:*' },
+        });
+        const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const pkgB = publicPkg('@scope/pkg-b', bDir);
+        const pkgC = publicPkg('@scope/pkg-c', cDir);
+        const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
+
+        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+
+  describe('material-ui packages-internal workspace simulation', () => {
+    /**
+     * Mirrors the real package structure from material-ui packages-internal/* plus the
+     * packages/* that appear as workspace deps.
+     *
+     * Public packages-internal:
+     *   @mui/internal-core-docs   – deps: @mui/internal-markdown (workspace:^)
+     *                             – devDeps: @mui-internal/api-docs-builder (workspace:*),
+     *                                        @mui/icons-material (workspace:*), @mui/material (workspace:*)
+     *                             – peers: @mui/material, @mui/icons-material, @mui/system, … (pinned ranges)
+     *   @mui/internal-docs-utils  – no workspace deps
+     *   @mui/internal-markdown    – no workspace deps
+     *   @mui/internal-scripts     – deps: @mui/internal-docs-utils (workspace:^)
+     *
+     * Private packages-internal:
+     *   @mui-internal/api-docs-builder       – deps: @mui/internal-docs-utils (workspace:^),
+     *                                                @mui/internal-markdown (workspace:^)
+     *   @mui-internal/api-docs-builder-core  – deps: @mui-internal/api-docs-builder (workspace:^),
+     *                                                @mui/internal-markdown (workspace:^)
+     *   @mui/internal-waterfall              – no workspace deps
+     *
+     * Public packages/* (not in the --filter set, resolve from registry):
+     *   @mui/material, @mui/icons-material, @mui/system, @mui/utils, @mui/material-nextjs,
+     *   @mui/stylis-plugin-rtl, @mui/core-downloads-tracker, @mui/types,
+     *   @mui/material-pigment-css, @mui/private-theming, @mui/styled-engine
+     */
+    /** @param {string} root */
+    async function buildMaterialUiWorkspace(root) {
+      // packages-internal — public
+      const coreDocs = await writePackage(root, 'packages-internal/core-docs', {
+        name: '@mui/internal-core-docs',
+        version: '9.0.0-beta.1',
+        dependencies: {
+          '@babel/runtime': '^7.29.2',
+          '@mui/internal-markdown': 'workspace:^',
+          'clipboard-copy': '^4.0.1',
+          clsx: '^2.1.1',
+        },
+        devDependencies: {
+          '@mui-internal/api-docs-builder': 'workspace:*',
+          '@mui/icons-material': 'workspace:*',
+          '@mui/material': 'workspace:*',
+        },
+        peerDependencies: {
+          '@mui/base': '^5.0.0 || ^7.0.0',
+          '@mui/icons-material': '^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0',
+          '@mui/material': '^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0',
+          '@mui/material-nextjs': '^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0',
+          '@mui/stylis-plugin-rtl': '^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0',
+          '@mui/system': '^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0',
+          '@mui/utils': '^5.0.0 || ^6.0.0 || ^7.0.0 || ^9.0.0',
+          react: '^17.0.0 || ^18.0.0 || ^19.0.0',
+        },
+      });
+      const docsUtils = await writePackage(root, 'packages-internal/docs-utils', {
+        name: '@mui/internal-docs-utils',
+        version: '3.0.2',
+        dependencies: { rimraf: '^6.1.3', typescript: '^5.9.3' },
+      });
+      const markdown = await writePackage(root, 'packages-internal/markdown', {
+        name: '@mui/internal-markdown',
+        version: '3.0.6',
+        dependencies: { '@babel/runtime': '^7.29.2', marked: '^17.0.5', prismjs: '^1.30.0' },
+      });
+      const scripts = await writePackage(root, 'packages-internal/scripts', {
+        name: '@mui/internal-scripts',
+        version: '3.0.5',
+        dependencies: {
+          '@mui/internal-docs-utils': 'workspace:^',
+          '@babel/core': '^7.29.0',
+          doctrine: '^3.0.0',
+        },
+      });
+
+      // packages-internal — private
+      const apiDocsBuilder = await writePackage(root, 'packages-internal/api-docs-builder', {
+        name: '@mui-internal/api-docs-builder',
+        version: '1.0.0',
+        private: true,
+        dependencies: {
+          '@mui/internal-docs-utils': 'workspace:^',
+          '@mui/internal-markdown': 'workspace:^',
+          '@babel/core': '^7.29.0',
+        },
+      });
+      const apiDocsBuilderCore = await writePackage(
+        root,
+        'packages-internal/api-docs-builder-core',
+        {
+          name: '@mui-internal/api-docs-builder-core',
+          version: '1.0.0',
+          private: true,
+          dependencies: {
+            '@mui-internal/api-docs-builder': 'workspace:^',
+            '@mui/internal-markdown': 'workspace:^',
+          },
+        },
+      );
+      const waterfall = await writePackage(root, 'packages-internal/waterfall', {
+        name: '@mui/internal-waterfall',
+        version: '1.0.0',
+        private: true,
+      });
+
+      // packages/* — public, resolve from registry (not in the --filter set)
+      const material = await writePackage(root, 'packages/material', {
+        name: '@mui/material',
+        version: '9.0.0-beta.1',
+      });
+      const iconsM = await writePackage(root, 'packages/icons-material', {
+        name: '@mui/icons-material',
+        version: '9.0.0-beta.1',
+      });
+      const muiSystem = await writePackage(root, 'packages/system', {
+        name: '@mui/system',
+        version: '9.0.0-beta.1',
+      });
+      const muiUtils = await writePackage(root, 'packages/utils', {
+        name: '@mui/utils',
+        version: '9.0.0-beta.1',
+      });
+      const materialNextjs = await writePackage(root, 'packages/material-nextjs', {
+        name: '@mui/material-nextjs',
+        version: '9.0.0-beta.0',
+      });
+      const stylisPluginRtl = await writePackage(root, 'packages/stylis-plugin-rtl', {
+        name: '@mui/stylis-plugin-rtl',
+        version: '9.0.0-beta.0',
+      });
+
+      const publicInternalPkgs = [
+        publicPkg('@mui/internal-core-docs', coreDocs),
+        publicPkg('@mui/internal-docs-utils', docsUtils),
+        publicPkg('@mui/internal-markdown', markdown),
+        publicPkg('@mui/internal-scripts', scripts),
+      ];
+      const privateInternalPkgs = [
+        privatePkg('@mui-internal/api-docs-builder', apiDocsBuilder),
+        privatePkg('@mui-internal/api-docs-builder-core', apiDocsBuilderCore),
+        privatePkg('@mui/internal-waterfall', waterfall),
+      ];
+      const publicMainPkgs = [
+        publicPkg('@mui/material', material),
+        publicPkg('@mui/icons-material', iconsM),
+        publicPkg('@mui/system', muiSystem),
+        publicPkg('@mui/utils', muiUtils),
+        publicPkg('@mui/material-nextjs', materialNextjs),
+        publicPkg('@mui/stylis-plugin-rtl', stylisPluginRtl),
+      ];
+
+      const allPkgs = [...publicInternalPkgs, ...privateInternalPkgs, ...publicMainPkgs];
+      return { publicInternalPkgs, privateInternalPkgs, publicMainPkgs, allPkgs };
+    }
+
+    it('passes with no issues when publishing all public packages-internal packages', async () => {
+      await withTempDir(async (root) => {
+        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+        const { byName, pathByName } = workspaceMaps(allPkgs);
+
+        const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('passes when @mui/material and other pinned-range peers of core-docs are not in the publish set', async () => {
+      await withTempDir(async (root) => {
+        const { publicInternalPkgs, privateInternalPkgs } = await buildMaterialUiWorkspace(root);
+        // workspace without the packages/* — simulates --filter "./packages-internal/*"
+        const filteredWorkspace = [...publicInternalPkgs, ...privateInternalPkgs];
+        const { byName, pathByName } = workspaceMaps(filteredWorkspace);
+
+        const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('passes when workspace:* devDependencies of core-docs are not in the publish set', async () => {
+      // core-docs has @mui-internal/api-docs-builder and @mui/icons-material as workspace:*
+      // devDependencies. They must NOT be required — devDeps are not installed on consumer devices.
+      await withTempDir(async (root) => {
+        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+        const { byName, pathByName } = workspaceMaps(allPkgs);
+
+        const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+
+    it('flags @mui/internal-markdown as missing when core-docs is published without it', async () => {
+      await withTempDir(async (root) => {
+        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+        const { byName, pathByName } = workspaceMaps(allPkgs);
+
+        const withoutMarkdown = publicInternalPkgs.filter(
+          (p) => p.name !== '@mui/internal-markdown',
+        );
+        const { issues } = await checkPublishDependencies(withoutMarkdown, byName, pathByName);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toContain('@mui/internal-markdown');
+      });
+    });
+
+    it('flags @mui/internal-docs-utils as missing when scripts is published without it', async () => {
+      await withTempDir(async (root) => {
+        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+        const { byName, pathByName } = workspaceMaps(allPkgs);
+
+        const withoutDocsUtils = publicInternalPkgs.filter(
+          (p) => p.name !== '@mui/internal-docs-utils',
+        );
+        const { issues } = await checkPublishDependencies(withoutDocsUtils, byName, pathByName);
+        expect(issues).toHaveLength(1);
+        expect(issues[0]).toContain('@mui/internal-docs-utils');
+      });
+    });
+
+    it('flags both missing workspace: deps when core-docs and scripts lack their deps', async () => {
+      await withTempDir(async (root) => {
+        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+        const { byName, pathByName } = workspaceMaps(allPkgs);
+
+        const onlyCoreDocs = publicInternalPkgs.filter(
+          (p) => p.name !== '@mui/internal-markdown' && p.name !== '@mui/internal-docs-utils',
+        );
+        const { issues } = await checkPublishDependencies(onlyCoreDocs, byName, pathByName);
+        expect(issues).toHaveLength(1); // single issue listing both missing packages
+        expect(issues[0]).toContain('@mui/internal-markdown');
+        expect(issues[0]).toContain('@mui/internal-docs-utils');
+      });
+    });
+  });
+
+  describe('packages not in the workspace', () => {
+    it('ignores dependencies that are not workspace packages', async () => {
+      await withTempDir(async (root) => {
+        const aDir = await writePackage(root, 'pkg-a', {
+          name: '@scope/pkg-a',
+          dependencies: { react: '^18.0.0', lodash: '^4.0.0' },
+        });
+
+        const pkgA = publicPkg('@scope/pkg-a', aDir);
+        const { byName, pathByName } = workspaceMaps([pkgA]);
+
+        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+        expect(issues).toEqual([]);
+      });
+    });
+  });
+});

--- a/packages/code-infra/src/utils/pnpm.test.mjs
+++ b/packages/code-infra/src/utils/pnpm.test.mjs
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { describe, it, expect } from 'vitest';
 
-import { withTempDir } from './testUtils.mjs';
+import { makeTempDir } from './testUtils.mjs';
 import { checkPublishDependencies } from './pnpm.mjs';
 
 /**
@@ -51,305 +51,290 @@ function workspaceMaps(allPkgs) {
 describe('checkPublishDependencies', () => {
   describe('workspace: protocol in dependencies', () => {
     it('returns no issues when all workspace: dependencies are included in the publish set', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('reports an issue when a workspace: dependency is missing from the publish set', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toHaveLength(1);
-        expect(issues[0]).toContain('@scope/pkg-b');
-        expect(issues[0]).toContain('Add them to the --filter list');
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('@scope/pkg-b');
+      expect(issues[0]).toContain('Add them to the --filter list');
     });
 
     it('reports an issue when a workspace: dependency is private', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = privatePkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toHaveLength(1);
-        expect(issues[0]).toContain('@scope/pkg-b');
-        expect(issues[0]).toContain('private');
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = privatePkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('@scope/pkg-b');
+      expect(issues[0]).toContain('private');
     });
 
     it('resolves transitive workspace: dependencies', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', {
-          name: '@scope/pkg-b',
-          dependencies: { '@scope/pkg-c': 'workspace:*' },
-        });
-        const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const pkgC = publicPkg('@scope/pkg-c', cDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
-
-        // publishing only A and B — C is missing but transitively required
-        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
-        expect(issues).toHaveLength(1);
-        expect(issues[0]).toContain('@scope/pkg-c');
-
-        // publishing all three — no issues
-        const { issues: noIssues } = await checkPublishDependencies(
-          [pkgA, pkgB, pkgC],
-          byName,
-          pathByName,
-        );
-        expect(noIssues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', {
+        name: '@scope/pkg-b',
+        dependencies: { '@scope/pkg-c': 'workspace:*' },
+      });
+      const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const pkgC = publicPkg('@scope/pkg-c', cDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
+
+      // publishing only A and B — C is missing but transitively required
+      const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('@scope/pkg-c');
+
+      // publishing all three — no issues
+      const { issues: noIssues } = await checkPublishDependencies(
+        [pkgA, pkgB, pkgC],
+        byName,
+        pathByName,
+      );
+      expect(noIssues).toEqual([]);
     });
   });
 
   describe('peerDependencies are never hard requirements', () => {
     it('does not require a peer dependency even when using workspace: protocol', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          peerDependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        // publishing only A — B is a workspace: peer dep but must NOT be required
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        peerDependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      // publishing only A — B is a workspace: peer dep but must NOT be required
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('does not require a peer dependency with a pinned version', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          peerDependencies: { '@scope/pkg-b': '^1.0.0' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        peerDependencies: { '@scope/pkg-b': '^1.0.0' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('does not require a private peer dependency', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          peerDependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = privatePkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        peerDependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = privatePkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
   });
 
   describe('workspace:^ protocol in dependencies', () => {
     it('requires a workspace:^ dependency that is missing from the publish set', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:^' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toHaveLength(1);
-        expect(issues[0]).toContain('@scope/pkg-b');
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:^' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('@scope/pkg-b');
     });
 
     it('returns no issues when a workspace:^ dependency is included in the publish set', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:^' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:^' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+      expect(issues).toEqual([]);
     });
   });
 
   describe('devDependencies are never hard requirements', () => {
     it('does not require a workspace: devDependency missing from the publish set', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          devDependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        devDependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('does not require a workspace:^ devDependency missing from the publish set', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          devDependencies: { '@scope/pkg-b': 'workspace:^' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        devDependencies: { '@scope/pkg-b': 'workspace:^' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('does not require a private workspace: devDependency', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          devDependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = privatePkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        devDependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b', private: true });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = privatePkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
   });
 
   describe('pinned versions in dependencies are not hard requirements', () => {
     it('does not require a workspace package referenced with a pinned version in dependencies', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': '^1.0.0' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': '^1.0.0' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
   });
 
   describe('mixed dependency types', () => {
     it('requires workspace: dependencies but not workspace: peers from the same package', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:*' },
-          peerDependencies: { '@scope/pkg-c': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
-        const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const pkgC = publicPkg('@scope/pkg-c', cDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
-
-        // B is required (workspace: dep), C is not (workspace: peer)
-        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
-        expect(issues).toEqual([]);
-
-        // Omitting B should flag it
-        const { issues: missingB } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(missingB).toHaveLength(1);
-        expect(missingB[0]).toContain('@scope/pkg-b');
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:*' },
+        peerDependencies: { '@scope/pkg-c': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', { name: '@scope/pkg-b' });
+      const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const pkgC = publicPkg('@scope/pkg-c', cDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
+
+      // B is required (workspace: dep), C is not (workspace: peer)
+      const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+      expect(issues).toEqual([]);
+
+      // Omitting B should flag it
+      const { issues: missingB } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(missingB).toHaveLength(1);
+      expect(missingB[0]).toContain('@scope/pkg-b');
     });
 
     it('does not traverse peer deps when resolving transitive requirements', async () => {
-      await withTempDir(async (root) => {
-        // A depends on B (workspace:), B has C as a peer (workspace:)
-        // C should NOT be required just because B peers it
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { '@scope/pkg-b': 'workspace:*' },
-        });
-        const bDir = await writePackage(root, 'pkg-b', {
-          name: '@scope/pkg-b',
-          peerDependencies: { '@scope/pkg-c': 'workspace:*' },
-        });
-        const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const pkgB = publicPkg('@scope/pkg-b', bDir);
-        const pkgC = publicPkg('@scope/pkg-c', cDir);
-        const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
-
-        const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      // A depends on B (workspace:), B has C as a peer (workspace:)
+      // C should NOT be required just because B peers it
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { '@scope/pkg-b': 'workspace:*' },
       });
+      const bDir = await writePackage(root, 'pkg-b', {
+        name: '@scope/pkg-b',
+        peerDependencies: { '@scope/pkg-c': 'workspace:*' },
+      });
+      const cDir = await writePackage(root, 'pkg-c', { name: '@scope/pkg-c' });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const pkgB = publicPkg('@scope/pkg-b', bDir);
+      const pkgC = publicPkg('@scope/pkg-c', cDir);
+      const { byName, pathByName } = workspaceMaps([pkgA, pkgB, pkgC]);
+
+      const { issues } = await checkPublishDependencies([pkgA, pkgB], byName, pathByName);
+      expect(issues).toEqual([]);
     });
   });
 
@@ -508,97 +493,88 @@ describe('checkPublishDependencies', () => {
     }
 
     it('passes with no issues when publishing all public packages-internal packages', async () => {
-      await withTempDir(async (root) => {
-        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
-        const { byName, pathByName } = workspaceMaps(allPkgs);
+      const root = await makeTempDir();
+      const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+      const { byName, pathByName } = workspaceMaps(allPkgs);
 
-        const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
-        expect(issues).toEqual([]);
-      });
+      const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('passes when @mui/material and other pinned-range peers of core-docs are not in the publish set', async () => {
-      await withTempDir(async (root) => {
-        const { publicInternalPkgs, privateInternalPkgs } = await buildMaterialUiWorkspace(root);
-        // workspace without the packages/* — simulates --filter "./packages-internal/*"
-        const filteredWorkspace = [...publicInternalPkgs, ...privateInternalPkgs];
-        const { byName, pathByName } = workspaceMaps(filteredWorkspace);
+      const root = await makeTempDir();
+      const { publicInternalPkgs, privateInternalPkgs } = await buildMaterialUiWorkspace(root);
+      // workspace without the packages/* — simulates --filter "./packages-internal/*"
+      const filteredWorkspace = [...publicInternalPkgs, ...privateInternalPkgs];
+      const { byName, pathByName } = workspaceMaps(filteredWorkspace);
 
-        const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
-        expect(issues).toEqual([]);
-      });
+      const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('passes when workspace:* devDependencies of core-docs are not in the publish set', async () => {
       // core-docs has @mui-internal/api-docs-builder and @mui/icons-material as workspace:*
       // devDependencies. They must NOT be required — devDeps are not installed on consumer devices.
-      await withTempDir(async (root) => {
-        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
-        const { byName, pathByName } = workspaceMaps(allPkgs);
+      const root = await makeTempDir();
+      const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+      const { byName, pathByName } = workspaceMaps(allPkgs);
 
-        const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
-        expect(issues).toEqual([]);
-      });
+      const { issues } = await checkPublishDependencies(publicInternalPkgs, byName, pathByName);
+      expect(issues).toEqual([]);
     });
 
     it('flags @mui/internal-markdown as missing when core-docs is published without it', async () => {
-      await withTempDir(async (root) => {
-        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
-        const { byName, pathByName } = workspaceMaps(allPkgs);
+      const root = await makeTempDir();
+      const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+      const { byName, pathByName } = workspaceMaps(allPkgs);
 
-        const withoutMarkdown = publicInternalPkgs.filter(
-          (p) => p.name !== '@mui/internal-markdown',
-        );
-        const { issues } = await checkPublishDependencies(withoutMarkdown, byName, pathByName);
-        expect(issues).toHaveLength(1);
-        expect(issues[0]).toContain('@mui/internal-markdown');
-      });
+      const withoutMarkdown = publicInternalPkgs.filter((p) => p.name !== '@mui/internal-markdown');
+      const { issues } = await checkPublishDependencies(withoutMarkdown, byName, pathByName);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('@mui/internal-markdown');
     });
 
     it('flags @mui/internal-docs-utils as missing when scripts is published without it', async () => {
-      await withTempDir(async (root) => {
-        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
-        const { byName, pathByName } = workspaceMaps(allPkgs);
+      const root = await makeTempDir();
+      const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+      const { byName, pathByName } = workspaceMaps(allPkgs);
 
-        const withoutDocsUtils = publicInternalPkgs.filter(
-          (p) => p.name !== '@mui/internal-docs-utils',
-        );
-        const { issues } = await checkPublishDependencies(withoutDocsUtils, byName, pathByName);
-        expect(issues).toHaveLength(1);
-        expect(issues[0]).toContain('@mui/internal-docs-utils');
-      });
+      const withoutDocsUtils = publicInternalPkgs.filter(
+        (p) => p.name !== '@mui/internal-docs-utils',
+      );
+      const { issues } = await checkPublishDependencies(withoutDocsUtils, byName, pathByName);
+      expect(issues).toHaveLength(1);
+      expect(issues[0]).toContain('@mui/internal-docs-utils');
     });
 
     it('flags both missing workspace: deps when core-docs and scripts lack their deps', async () => {
-      await withTempDir(async (root) => {
-        const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
-        const { byName, pathByName } = workspaceMaps(allPkgs);
+      const root = await makeTempDir();
+      const { publicInternalPkgs, allPkgs } = await buildMaterialUiWorkspace(root);
+      const { byName, pathByName } = workspaceMaps(allPkgs);
 
-        const onlyCoreDocs = publicInternalPkgs.filter(
-          (p) => p.name !== '@mui/internal-markdown' && p.name !== '@mui/internal-docs-utils',
-        );
-        const { issues } = await checkPublishDependencies(onlyCoreDocs, byName, pathByName);
-        expect(issues).toHaveLength(1); // single issue listing both missing packages
-        expect(issues[0]).toContain('@mui/internal-markdown');
-        expect(issues[0]).toContain('@mui/internal-docs-utils');
-      });
+      const onlyCoreDocs = publicInternalPkgs.filter(
+        (p) => p.name !== '@mui/internal-markdown' && p.name !== '@mui/internal-docs-utils',
+      );
+      const { issues } = await checkPublishDependencies(onlyCoreDocs, byName, pathByName);
+      expect(issues).toHaveLength(1); // single issue listing both missing packages
+      expect(issues[0]).toContain('@mui/internal-markdown');
+      expect(issues[0]).toContain('@mui/internal-docs-utils');
     });
   });
 
   describe('packages not in the workspace', () => {
     it('ignores dependencies that are not workspace packages', async () => {
-      await withTempDir(async (root) => {
-        const aDir = await writePackage(root, 'pkg-a', {
-          name: '@scope/pkg-a',
-          dependencies: { react: '^18.0.0', lodash: '^4.0.0' },
-        });
-
-        const pkgA = publicPkg('@scope/pkg-a', aDir);
-        const { byName, pathByName } = workspaceMaps([pkgA]);
-
-        const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
-        expect(issues).toEqual([]);
+      const root = await makeTempDir();
+      const aDir = await writePackage(root, 'pkg-a', {
+        name: '@scope/pkg-a',
+        dependencies: { react: '^18.0.0', lodash: '^4.0.0' },
       });
+
+      const pkgA = publicPkg('@scope/pkg-a', aDir);
+      const { byName, pathByName } = workspaceMaps([pkgA]);
+
+      const { issues } = await checkPublishDependencies([pkgA], byName, pathByName);
+      expect(issues).toEqual([]);
     });
   });
 });

--- a/packages/code-infra/src/utils/testUtils.mjs
+++ b/packages/code-infra/src/utils/testUtils.mjs
@@ -1,20 +1,18 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { onTestFinished } from 'vitest';
 
 /**
- * Creates a temporary directory, runs the given function with its path, then
- * removes the directory unconditionally — even if the function throws.
+ * Creates a temporary directory and registers an `onTestFinished` hook to
+ * remove it automatically when the current test ends — even if the test throws.
  *
- * @template T
- * @param {(dir: string) => Promise<T>} fn
- * @returns {Promise<T>}
+ * @returns {Promise<string>} The path of the created temporary directory.
  */
-export async function withTempDir(fn) {
+export async function makeTempDir() {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'code-infra-test-'));
-  try {
-    return await fn(tmpDir);
-  } finally {
+  onTestFinished(async () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
-  }
+  });
+  return tmpDir;
 }

--- a/packages/code-infra/src/utils/testUtils.mjs
+++ b/packages/code-infra/src/utils/testUtils.mjs
@@ -1,0 +1,20 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Creates a temporary directory, runs the given function with its path, then
+ * removes the directory unconditionally — even if the function throws.
+ *
+ * @template T
+ * @param {(dir: string) => Promise<T>} fn
+ * @returns {Promise<T>}
+ */
+export async function withTempDir(fn) {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'code-infra-test-'));
+  try {
+    return await fn(tmpDir);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}

--- a/packages/code-infra/src/utils/typescript.test.mjs
+++ b/packages/code-infra/src/utils/typescript.test.mjs
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
-import { withTempDir } from './testUtils.mjs';
+import { makeTempDir } from './testUtils.mjs';
 import { copyDeclarations, moveAndTransformDeclarations } from './typescript.mjs';
 
 /**
@@ -20,158 +20,152 @@ async function createFile(filePath, contents = '') {
 
 describe('copyDeclarations', () => {
   it('copies .d.ts files from source to destination', async () => {
-    await withTempDir(async (cwd) => {
-      const sourceDir = path.join(cwd, 'source');
-      const destDir = path.join(cwd, 'dest');
+    const cwd = await makeTempDir();
+    const sourceDir = path.join(cwd, 'source');
+    const destDir = path.join(cwd, 'dest');
 
-      await Promise.all([
-        createFile(path.join(sourceDir, 'index.d.ts'), 'export const foo: string;'),
-        createFile(path.join(sourceDir, 'utils.d.ts'), 'export const bar: number;'),
-        createFile(path.join(sourceDir, 'index.js'), 'export const foo = "test";'),
-      ]);
+    await Promise.all([
+      createFile(path.join(sourceDir, 'index.d.ts'), 'export const foo: string;'),
+      createFile(path.join(sourceDir, 'utils.d.ts'), 'export const bar: number;'),
+      createFile(path.join(sourceDir, 'index.js'), 'export const foo = "test";'),
+    ]);
 
-      await copyDeclarations(sourceDir, destDir);
+    await copyDeclarations(sourceDir, destDir);
 
-      const indexDts = await fs.readFile(path.join(destDir, 'index.d.ts'), 'utf8');
-      const utilsDts = await fs.readFile(path.join(destDir, 'utils.d.ts'), 'utf8');
+    const indexDts = await fs.readFile(path.join(destDir, 'index.d.ts'), 'utf8');
+    const utilsDts = await fs.readFile(path.join(destDir, 'utils.d.ts'), 'utf8');
 
-      expect(indexDts).toBe('export const foo: string;');
-      expect(utilsDts).toBe('export const bar: number;');
+    expect(indexDts).toBe('export const foo: string;');
+    expect(utilsDts).toBe('export const bar: number;');
 
-      const jsExists = await fs.stat(path.join(destDir, 'index.js')).catch(() => null);
-      expect(jsExists).toBeNull();
-    });
+    const jsExists = await fs.stat(path.join(destDir, 'index.js')).catch(() => null);
+    expect(jsExists).toBeNull();
   });
 
   it('copies .d.mts and .d.cts files', async () => {
-    await withTempDir(async (cwd) => {
-      const sourceDir = path.join(cwd, 'source');
-      const destDir = path.join(cwd, 'dest');
+    const cwd = await makeTempDir();
+    const sourceDir = path.join(cwd, 'source');
+    const destDir = path.join(cwd, 'dest');
 
-      await Promise.all([
-        createFile(path.join(sourceDir, 'index.d.mts'), 'export const esm: string;'),
-        createFile(path.join(sourceDir, 'index.d.cts'), 'export const cjs: string;'),
-      ]);
+    await Promise.all([
+      createFile(path.join(sourceDir, 'index.d.mts'), 'export const esm: string;'),
+      createFile(path.join(sourceDir, 'index.d.cts'), 'export const cjs: string;'),
+    ]);
 
-      await copyDeclarations(sourceDir, destDir);
+    await copyDeclarations(sourceDir, destDir);
 
-      const mtsDts = await fs.readFile(path.join(destDir, 'index.d.mts'), 'utf8');
-      const ctsDts = await fs.readFile(path.join(destDir, 'index.d.cts'), 'utf8');
+    const mtsDts = await fs.readFile(path.join(destDir, 'index.d.mts'), 'utf8');
+    const ctsDts = await fs.readFile(path.join(destDir, 'index.d.cts'), 'utf8');
 
-      expect(mtsDts).toBe('export const esm: string;');
-      expect(ctsDts).toBe('export const cjs: string;');
-    });
+    expect(mtsDts).toBe('export const esm: string;');
+    expect(ctsDts).toBe('export const cjs: string;');
   });
 
   it('ignores dotfiles and dot-directories', async () => {
-    await withTempDir(async (cwd) => {
-      const sourceDir = path.join(cwd, 'source');
-      const destDir = path.join(cwd, 'dest');
+    const cwd = await makeTempDir();
+    const sourceDir = path.join(cwd, 'source');
+    const destDir = path.join(cwd, 'dest');
 
-      await Promise.all([
-        createFile(path.join(sourceDir, 'index.d.ts'), 'export const foo: string;'),
-        createFile(path.join(sourceDir, '.hidden.d.ts'), 'export const hidden: string;'),
-        createFile(path.join(sourceDir, '.git', 'config'), 'git config'),
-      ]);
+    await Promise.all([
+      createFile(path.join(sourceDir, 'index.d.ts'), 'export const foo: string;'),
+      createFile(path.join(sourceDir, '.hidden.d.ts'), 'export const hidden: string;'),
+      createFile(path.join(sourceDir, '.git', 'config'), 'git config'),
+    ]);
 
-      await copyDeclarations(sourceDir, destDir);
+    await copyDeclarations(sourceDir, destDir);
 
-      const indexDts = await fs.readFile(path.join(destDir, 'index.d.ts'), 'utf8');
-      expect(indexDts).toBe('export const foo: string;');
+    const indexDts = await fs.readFile(path.join(destDir, 'index.d.ts'), 'utf8');
+    expect(indexDts).toBe('export const foo: string;');
 
-      const hiddenDts = await fs.stat(path.join(destDir, '.hidden.d.ts')).catch(() => null);
-      expect(hiddenDts).toBeNull();
+    const hiddenDts = await fs.stat(path.join(destDir, '.hidden.d.ts')).catch(() => null);
+    expect(hiddenDts).toBeNull();
 
-      const gitDir = await fs.stat(path.join(destDir, '.git')).catch(() => null);
-      expect(gitDir).toBeNull();
-    });
+    const gitDir = await fs.stat(path.join(destDir, '.git')).catch(() => null);
+    expect(gitDir).toBeNull();
   });
 
   it('preserves nested directory structure for .d.ts files', async () => {
-    await withTempDir(async (cwd) => {
-      const sourceDir = path.join(cwd, 'source');
-      const destDir = path.join(cwd, 'dest');
+    const cwd = await makeTempDir();
+    const sourceDir = path.join(cwd, 'source');
+    const destDir = path.join(cwd, 'dest');
 
-      await Promise.all([
-        createFile(path.join(sourceDir, 'types/index.d.ts'), 'export type Foo = string;'),
-        createFile(
-          path.join(sourceDir, 'types/utils/helpers.d.ts'),
-          'export type Helper = () => void;',
-        ),
-      ]);
+    await Promise.all([
+      createFile(path.join(sourceDir, 'types/index.d.ts'), 'export type Foo = string;'),
+      createFile(
+        path.join(sourceDir, 'types/utils/helpers.d.ts'),
+        'export type Helper = () => void;',
+      ),
+    ]);
 
-      await copyDeclarations(sourceDir, destDir);
+    await copyDeclarations(sourceDir, destDir);
 
-      const indexDts = await fs.readFile(path.join(destDir, 'types/index.d.ts'), 'utf8');
-      const helpersDts = await fs.readFile(path.join(destDir, 'types/utils/helpers.d.ts'), 'utf8');
+    const indexDts = await fs.readFile(path.join(destDir, 'types/index.d.ts'), 'utf8');
+    const helpersDts = await fs.readFile(path.join(destDir, 'types/utils/helpers.d.ts'), 'utf8');
 
-      expect(indexDts).toBe('export type Foo = string;');
-      expect(helpersDts).toBe('export type Helper = () => void;');
-    });
+    expect(indexDts).toBe('export type Foo = string;');
+    expect(helpersDts).toBe('export type Helper = () => void;');
   });
 });
 
 describe('moveAndTransformDeclarations', () => {
   it('handles path normalization correctly for Windows-style paths', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      // Create a test .d.ts file
-      await Promise.all([
-        createFile(path.join(inputDir, 'index.d.ts'), 'export const test: string;'),
-      ]);
+    // Create a test .d.ts file
+    await Promise.all([
+      createFile(path.join(inputDir, 'index.d.ts'), 'export const test: string;'),
+    ]);
 
-      /** @type {{type: BundleType; dir: string}[]} */
-      const bundles = [{ type: 'esm', dir: 'esm' }];
+    /** @type {{type: BundleType; dir: string}[]} */
+    const bundles = [{ type: 'esm', dir: 'esm' }];
 
-      // Mock babel transformAsync to avoid actual babel transformations
-      vi.doMock('@babel/core', () => ({
-        transformAsync: vi.fn(async (code) => ({ code })),
-      }));
+    // Mock babel transformAsync to avoid actual babel transformations
+    vi.doMock('@babel/core', () => ({
+      transformAsync: vi.fn(async (code) => ({ code })),
+    }));
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: false,
-        packageType: 'module',
-      });
-
-      // Verify file exists in the correct location
-      const dtsFile = path.join(buildDir, 'esm', 'index.d.ts');
-      const stat = await fs.stat(dtsFile).catch(() => null);
-      expect(stat).not.toBeNull();
-      expect(stat?.isFile()).toBe(true);
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: false,
+      packageType: 'module',
     });
+
+    // Verify file exists in the correct location
+    const dtsFile = path.join(buildDir, 'esm', 'index.d.ts');
+    const stat = await fs.stat(dtsFile).catch(() => null);
+    expect(stat).not.toBeNull();
+    expect(stat?.isFile()).toBe(true);
   });
 
   it('preserves original path file when not flat build', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      // Create a test .d.ts file
-      await Promise.all([
-        createFile(path.join(inputDir, 'index.d.ts'), 'export const test: string;'),
-      ]);
+    // Create a test .d.ts file
+    await Promise.all([
+      createFile(path.join(inputDir, 'index.d.ts'), 'export const test: string;'),
+    ]);
 
-      /** @type {{type: BundleType; dir: string}[]} */
-      const bundles = [{ type: 'esm', dir: 'esm' }];
+    /** @type {{type: BundleType; dir: string}[]} */
+    const bundles = [{ type: 'esm', dir: 'esm' }];
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: false,
-        packageType: 'module',
-      });
-
-      // For single bundle non-flat builds, files are copied to bundle dir
-      const dtsFile = path.join(buildDir, 'esm', 'index.d.ts');
-      const stat = await fs.stat(dtsFile).catch(() => null);
-      expect(stat?.isFile()).toBe(true);
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: false,
+      packageType: 'module',
     });
+
+    // For single bundle non-flat builds, files are copied to bundle dir
+    const dtsFile = path.join(buildDir, 'esm', 'index.d.ts');
+    const stat = await fs.stat(dtsFile).catch(() => null);
+    expect(stat?.isFile()).toBe(true);
   });
 
   it('correctly compares resolved paths on all platforms', async () => {
@@ -188,94 +182,91 @@ describe('moveAndTransformDeclarations', () => {
   });
 
   it('normalizes paths before reading files', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      const content = 'export const normalized: boolean;';
-      await Promise.all([createFile(path.join(inputDir, 'test.d.ts'), content)]);
+    const content = 'export const normalized: boolean;';
+    await Promise.all([createFile(path.join(inputDir, 'test.d.ts'), content)]);
 
-      /** @type {{type: BundleType; dir: string}[]} */
-      const bundles = [{ type: 'esm', dir: 'esm' }];
+    /** @type {{type: BundleType; dir: string}[]} */
+    const bundles = [{ type: 'esm', dir: 'esm' }];
 
-      // Mock babel transformAsync to capture filename
-      const transformMock = vi.fn(async (code) => ({ code }));
-      vi.doMock('@babel/core', () => ({
-        transformAsync: transformMock,
-      }));
+    // Mock babel transformAsync to capture filename
+    const transformMock = vi.fn(async (code) => ({ code }));
+    vi.doMock('@babel/core', () => ({
+      transformAsync: transformMock,
+    }));
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: false,
-        packageType: 'module',
-      });
-
-      // Verify the file was read correctly by checking it exists
-      const dtsFile = path.join(buildDir, 'esm', 'test.d.ts');
-      const stat = await fs.stat(dtsFile).catch(() => null);
-      expect(stat?.isFile()).toBe(true);
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: false,
+      packageType: 'module',
     });
+
+    // Verify the file was read correctly by checking it exists
+    const dtsFile = path.join(buildDir, 'esm', 'test.d.ts');
+    const stat = await fs.stat(dtsFile).catch(() => null);
+    expect(stat?.isFile()).toBe(true);
   });
 
   it('preserves file when output extension matches in flat builds', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      const content = 'export const flat: string;';
-      await Promise.all([createFile(path.join(inputDir, 'index.d.ts'), content)]);
+    const content = 'export const flat: string;';
+    await Promise.all([createFile(path.join(inputDir, 'index.d.ts'), content)]);
 
-      /** @type {{type: BundleType; dir: string}[]} */
-      // ESM + module packageType keeps .d.ts extension in flat builds
-      const bundles = [{ type: 'esm', dir: 'esm' }];
+    /** @type {{type: BundleType; dir: string}[]} */
+    // ESM + module packageType keeps .d.ts extension in flat builds
+    const bundles = [{ type: 'esm', dir: 'esm' }];
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: true,
-        packageType: 'module',
-      });
-
-      // Since extension doesn't change (.d.ts -> .d.ts), file should remain
-      const outputFile = path.join(buildDir, 'esm', 'index.d.ts');
-      const outputStat = await fs.stat(outputFile).catch(() => null);
-      expect(outputStat?.isFile()).toBe(true);
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: true,
+      packageType: 'module',
     });
+
+    // Since extension doesn't change (.d.ts -> .d.ts), file should remain
+    const outputFile = path.join(buildDir, 'esm', 'index.d.ts');
+    const outputStat = await fs.stat(outputFile).catch(() => null);
+    expect(outputStat?.isFile()).toBe(true);
   });
 
   it('removes original when output extension differs in flat builds', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      const content = 'export const transformed: string;';
-      await Promise.all([createFile(path.join(inputDir, 'index.d.ts'), content)]);
-      /** @type {{type: BundleType; dir: string}[]} */
+    const content = 'export const transformed: string;';
+    await Promise.all([createFile(path.join(inputDir, 'index.d.ts'), content)]);
+    /** @type {{type: BundleType; dir: string}[]} */
 
-      // CJS bundle with module packageType creates .d.cts
-      const bundles = [{ type: 'cjs', dir: 'cjs' }];
+    // CJS bundle with module packageType creates .d.cts
+    const bundles = [{ type: 'cjs', dir: 'cjs' }];
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: true,
-        packageType: 'module',
-      });
-
-      // Transformed file with new extension should exist
-      const outputFile = path.join(buildDir, 'cjs', 'index.d.cts');
-      const outputStat = await fs.stat(outputFile).catch(() => null);
-      expect(outputStat?.isFile()).toBe(true);
-
-      // Original .d.ts should be removed
-      const originalFile = path.join(buildDir, 'cjs', 'index.d.ts');
-      const originalStat = await fs.stat(originalFile).catch(() => null);
-      expect(originalStat).toBeNull();
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: true,
+      packageType: 'module',
     });
+
+    // Transformed file with new extension should exist
+    const outputFile = path.join(buildDir, 'cjs', 'index.d.cts');
+    const outputStat = await fs.stat(outputFile).catch(() => null);
+    expect(outputStat?.isFile()).toBe(true);
+
+    // Original .d.ts should be removed
+    const originalFile = path.join(buildDir, 'cjs', 'index.d.ts');
+    const originalStat = await fs.stat(originalFile).catch(() => null);
+    expect(originalStat).toBeNull();
   });
 
   it('handles mixed separator paths in comparisons on Windows', async () => {
@@ -294,75 +285,73 @@ describe('moveAndTransformDeclarations', () => {
   });
 
   it('uses normalized paths for writesToOriginalPath check', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      const content = 'export const component: string;';
-      await Promise.all([createFile(path.join(inputDir, 'component.d.ts'), content)]);
-      /** @type {{type: BundleType; dir: string}[]} */
+    const content = 'export const component: string;';
+    await Promise.all([createFile(path.join(inputDir, 'component.d.ts'), content)]);
+    /** @type {{type: BundleType; dir: string}[]} */
 
-      // ESM + commonjs packageType creates .d.mts
-      const bundles = [{ type: 'esm', dir: 'esm' }];
+    // ESM + commonjs packageType creates .d.mts
+    const bundles = [{ type: 'esm', dir: 'esm' }];
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: true,
-        packageType: 'commonjs',
-      });
-
-      // The .d.mts file should exist
-      const transformedFile = path.join(buildDir, 'esm', 'component.d.mts');
-      const transformedStat = await fs.stat(transformedFile).catch(() => null);
-      expect(transformedStat?.isFile()).toBe(true);
-
-      // Original .d.ts should be removed because extension changed
-      const originalFile = path.join(buildDir, 'esm', 'component.d.ts');
-      const originalStat = await fs.stat(originalFile).catch(() => null);
-      expect(originalStat).toBeNull();
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: true,
+      packageType: 'commonjs',
     });
+
+    // The .d.mts file should exist
+    const transformedFile = path.join(buildDir, 'esm', 'component.d.mts');
+    const transformedStat = await fs.stat(transformedFile).catch(() => null);
+    expect(transformedStat?.isFile()).toBe(true);
+
+    // Original .d.ts should be removed because extension changed
+    const originalFile = path.join(buildDir, 'esm', 'component.d.ts');
+    const originalStat = await fs.stat(originalFile).catch(() => null);
+    expect(originalStat).toBeNull();
   });
 
   it('handles path normalization with multiple bundles in flat mode', async () => {
-    await withTempDir(async (cwd) => {
-      const inputDir = path.join(cwd, 'input');
-      const buildDir = path.join(cwd, 'build');
+    const cwd = await makeTempDir();
+    const inputDir = path.join(cwd, 'input');
+    const buildDir = path.join(cwd, 'build');
 
-      const content = 'export const multi: string;';
-      await Promise.all([createFile(path.join(inputDir, 'index.d.ts'), content)]);
+    const content = 'export const multi: string;';
+    await Promise.all([createFile(path.join(inputDir, 'index.d.ts'), content)]);
 
-      // Multiple bundles: files are copied to buildDir, not directly to bundle dirs
-      /** @type {{type: BundleType; dir: string}[]} */
-      const bundles = [
-        { type: 'esm', dir: 'esm' },
-        { type: 'cjs', dir: 'cjs' },
-      ];
+    // Multiple bundles: files are copied to buildDir, not directly to bundle dirs
+    /** @type {{type: BundleType; dir: string}[]} */
+    const bundles = [
+      { type: 'esm', dir: 'esm' },
+      { type: 'cjs', dir: 'cjs' },
+    ];
 
-      await moveAndTransformDeclarations({
-        inputDir,
-        buildDir,
-        bundles,
-        isFlat: true,
-        packageType: 'module',
-      });
-
-      // Each bundle gets its own transformed copy
-      // ESM with module packageType keeps .d.ts
-      const esmFile = path.join(buildDir, 'esm', 'index.d.ts');
-      const esmStat = await fs.stat(esmFile).catch(() => null);
-      expect(esmStat?.isFile()).toBe(true);
-
-      // CJS with module packageType gets .d.cts
-      const cjsFile = path.join(buildDir, 'cjs', 'index.d.cts');
-      const cjsStat = await fs.stat(cjsFile).catch(() => null);
-      expect(cjsStat?.isFile()).toBe(true);
-
-      // Original in buildDir should be removed in flat mode since writesToOriginalPath is false
-      const originalFile = path.join(buildDir, 'index.d.ts');
-      const originalStat = await fs.stat(originalFile).catch(() => null);
-      expect(originalStat).toBeNull();
+    await moveAndTransformDeclarations({
+      inputDir,
+      buildDir,
+      bundles,
+      isFlat: true,
+      packageType: 'module',
     });
+
+    // Each bundle gets its own transformed copy
+    // ESM with module packageType keeps .d.ts
+    const esmFile = path.join(buildDir, 'esm', 'index.d.ts');
+    const esmStat = await fs.stat(esmFile).catch(() => null);
+    expect(esmStat?.isFile()).toBe(true);
+
+    // CJS with module packageType gets .d.cts
+    const cjsFile = path.join(buildDir, 'cjs', 'index.d.cts');
+    const cjsStat = await fs.stat(cjsFile).catch(() => null);
+    expect(cjsStat?.isFile()).toBe(true);
+
+    // Original in buildDir should be removed in flat mode since writesToOriginalPath is false
+    const originalFile = path.join(buildDir, 'index.d.ts');
+    const originalStat = await fs.stat(originalFile).catch(() => null);
+    expect(originalStat).toBeNull();
   });
 });

--- a/packages/code-infra/src/utils/typescript.test.mjs
+++ b/packages/code-infra/src/utils/typescript.test.mjs
@@ -1,8 +1,8 @@
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
+import { withTempDir } from './testUtils.mjs';
 import { copyDeclarations, moveAndTransformDeclarations } from './typescript.mjs';
 
 /**
@@ -16,18 +16,6 @@ import { copyDeclarations, moveAndTransformDeclarations } from './typescript.mjs
 async function createFile(filePath, contents = '') {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, contents, 'utf8');
-}
-
-/**
- * @param {(cwd: string) => Promise<void>} fn
- */
-async function withTempDir(fn) {
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'code-infra-typescript-test-'));
-  try {
-    return await fn(tmpDir);
-  } finally {
-    await fs.rm(tmpDir, { recursive: true, force: true });
-  }
 }
 
 describe('copyDeclarations', () => {


### PR DESCRIPTION
for package publishing.

Also, updated the validation logic to only look for direct `workspace:*/^` dependencies. So if a package depends on another package which is part of the same workspace but the version is something that can be resolved from the npm registry, then the dependency doesn't need to be published together.
And for peer deps, regardless of version protocol, it doesn't need to be published together.

Added test to simular the current core repo package structure.