### PR TITLE
[internal] Add licenses to packages we use in other repo

### DIFF
--- a/packages/bundle-size-checker/package.json
+++ b/packages/bundle-size-checker/package.json
@@ -2,6 +2,7 @@
   "name": "@mui/internal-bundle-size-checker",
   "version": "1.0.7",
   "description": "Bundle size checker for MUI packages.",
+  "license": "MIT",
   "type": "module",
   "main": "./src/index.js",
   "types": "./build/index.d.ts",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.17",
   "author": "MUI Team",
   "description": "Utilities for MUI tests. This is an internal package not meant for general use.",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mui/mui-public.git",


### PR DESCRIPTION
We have two packages without a license that we use in other repositories that are MIT, so I believe we need to set the license.