### PR TITLE
[code-infra] Add otp support for publishing new packages

### DIFF
--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -56,7 +56,7 @@ If publishing fails with npm asking for `otp`, run the command again with 6 digi
 pnpm code-infra publish-new-package --otp=123456
 ```
 
-3. Goto the settings link for each package, e.g., `https://www.npmjs.com/package/<pkg-name>/access`, and setup `Trusted Publisher`.
+3. Go to the settings link for each package, e.g., `https://www.npmjs.com/package/<pkg-name>/access`, and setup `Trusted Publisher`.
 4. In the `Select your publisher` step in the above link, click on the `GitHub Actions` button to configure GitHub Actions-based trusted publishing.
 5. Fill in the details of the repo -
    1. `Organization or user` as `mui`,

--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -37,22 +37,33 @@ This is stored in the `docs` top-level directory.
 
 Whenever new packages are added to the repo (that will get published to npm) or a private package is turned into a public one, follow the below steps before invoking the publish workflow of the previous section.
 
-1. Goto your repo's code base on your system, open terminal and run:
+1. Go to your repo's code base on your system, then log in to npm using
+
+```bash
+npm login
+```
+
+2. Once logged-in, open terminal and run:
 
 ```bash
 pnpm code-infra publish-new-package
 ```
 
 This command detects the new public packages in the repo and asks for your confirmation before publishing them to the npm registry. Add the `--dryRun` flag to skip the actual publishing.
+If publishing fails with npm asking for `otp`, run the command again with 6 digit auth code from your authenticator app where you've added npm; Google Authenticator, Authy or similar:
 
-2. Goto the settings link for each packages, ie, `https://www.npmjs.com/package/<pkg-name>/access` , and setup `Trusted Publisher`.
-3. In `Select your publisher` step in the above link, click on the `Github Actions` button to configure Github actions based trusted publishing.
-4. Fill in the details of the repo -
+```bash
+pnpm code-infra publish-new-package --otp=123456
+```
+
+3. Goto the settings link for each package, e.g., `https://www.npmjs.com/package/<pkg-name>/access`, and setup `Trusted Publisher`.
+4. In the `Select your publisher` step in the above link, click on the `GitHub Actions` button to configure GitHub Actions-based trusted publishing.
+5. Fill in the details of the repo -
    1. `Organization or user` as `mui`,
    2. `Repository` as per the new package
    3. `Workflow filename*` should be `publish.yml`
    4. `Environment name` should be `npm-publish` or `npm-publish-internal` based on whether the package is user facing package or internal package respectively.
-5. In the `Publishing access` section, toggle the recommended option of `Require two-factor authentication and disallow tokens`.
-6. Finally, save the changes by clicking on `Update Package Settings` button.
+6. In the `Publishing access` section, toggle the recommended option of `Require two-factor authentication and disallow tokens`.
+7. Finally, save the changes by clicking on `Update Package Settings` button.
 
 After following these steps, the `Publish` workflow can be invoked again.

--- a/packages/code-infra/src/cli/cmdPublishNewPackage.mjs
+++ b/packages/code-infra/src/cli/cmdPublishNewPackage.mjs
@@ -16,17 +16,34 @@ import { getWorkspacePackages } from '../utils/pnpm.mjs';
 /**
  * @typedef {Object} Args
  * @property {boolean} [dryRun] If true, will only log the commands without executing them
+ * @property {string} [otp] 6 digit auth code to forward to npm for two-factor authentication
  */
 
 export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
   command: 'publish-new-package [pkg...]',
   describe: 'Publish new empty package(s) to the npm registry.',
   builder: (yargs) =>
-    yargs.option('dryRun', {
-      type: 'boolean',
-      default: false,
-      description: 'If true, will only log the commands without executing them.',
-    }),
+    yargs
+      .option('dryRun', {
+        type: 'boolean',
+        default: false,
+        description: 'If true, will only log the commands without executing them.',
+      })
+      .option('otp', {
+        type: 'string',
+        description: '6 digit auth code to forward to npm for two-factor authentication.',
+        coerce: (value) => {
+          if (value === undefined) {
+            return value;
+          }
+
+          if (!/^\d{6}$/.test(value)) {
+            throw new Error('The --otp option must be a 6 digit number.');
+          }
+
+          return value;
+        },
+      }),
   async handler(args) {
     console.log(`🔍 Detecting new packages to publish in workspace...`);
     const newPackages = await getWorkspacePackages({ nonPublishedOnly: true });
@@ -77,6 +94,9 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
 
           if (args.dryRun) {
             publishArgs.push('--dry-run');
+          }
+          if (args.otp) {
+            publishArgs.push('--otp', args.otp);
           }
           await $({
             cwd: newPkgDir,


### PR DESCRIPTION
- [x] Add `--otp` CLI option with 6-digit TOTP validation
- [x] Forward OTP to `npm publish` command
- [x] Update README with npm login step and OTP retry instructions
- [x] Fix README grammar/branding: "Go to", "log in", "e.g.,", "GitHub Actions"