### PR TITLE
[code-infra] Inherit stdio for interactive npm publish

### DIFF
--- a/packages/code-infra/src/cli/cmdPublishNewPackage.mjs
+++ b/packages/code-infra/src/cli/cmdPublishNewPackage.mjs
@@ -100,6 +100,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
           }
           await $({
             cwd: newPkgDir,
+            stdio: 'inherit',
           })`npm publish --access public --tag=canary ${publishArgs}`;
           console.log(
             `✅ ${args.dryRun ? '[Dry run] ' : ''}Published ${chalk.bold(`${pkg.name}@${packageJson.version}`)} to npm registry.`,


### PR DESCRIPTION
When publishing fails with a challenge for OTP, npm automatically asks for otp in the same cli session.
https://docs.npmjs.com/cli/v11/commands/npm-publish#otp