### PR TITLE
[code-infra] Improve GitHub triage views

### DIFF
--- a/apps/code-infra-dashboard/src/components/GitHubStateChip.tsx
+++ b/apps/code-infra-dashboard/src/components/GitHubStateChip.tsx
@@ -1,0 +1,22 @@
+import Chip from '@mui/material/Chip';
+
+const STATE_COLORS: Record<string, string> = {
+  open: '#238636',
+  closed: '#8957e5',
+  merged: '#a371f7',
+  draft: '#656d76',
+};
+
+interface GitHubStateChipProps {
+  state: string;
+}
+
+export default function GitHubStateChip({ state }: GitHubStateChipProps) {
+  return (
+    <Chip
+      label={state}
+      size="small"
+      sx={{ bgcolor: STATE_COLORS[state] ?? '#656d76', color: '#fff', fontWeight: 500 }}
+    />
+  );
+}

--- a/apps/code-infra-dashboard/src/components/GitHubStateChip.tsx
+++ b/apps/code-infra-dashboard/src/components/GitHubStateChip.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import Chip from '@mui/material/Chip';
 
 const STATE_COLORS: Record<string, string> = {

--- a/apps/code-infra-dashboard/src/components/GitHubStateChip.tsx
+++ b/apps/code-infra-dashboard/src/components/GitHubStateChip.tsx
@@ -2,8 +2,8 @@ import Chip from '@mui/material/Chip';
 
 const STATE_COLORS: Record<string, string> = {
   open: '#238636',
-  closed: '#8957e5',
-  merged: '#a371f7',
+  closed: '#da3633',
+  merged: '#8957e5',
   draft: '#656d76',
 };
 

--- a/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
@@ -17,6 +17,7 @@ interface TriageRowInput {
   number: number;
   title: string;
   html_url: string;
+  created_at?: string;
   repository_url?: string;
   repository?: { name: string };
   state?: string;
@@ -50,6 +51,7 @@ function toTriageRow(item: TriageRowInput): TriageRow {
       }
       return label.name ? [label.name] : [];
     }),
+    createdAt: item.created_at ? new Date(item.created_at) : undefined,
   };
 }
 
@@ -82,6 +84,7 @@ interface GqlPrNode {
   title: string;
   state: string;
   isDraft: boolean;
+  createdAt: string;
   repository: { name: string };
   labels: { nodes: { name: string }[] };
 }
@@ -100,7 +103,7 @@ export async function fetchPrsWithoutLabels(): Promise<TriageRow[]> {
   const allRepoFilter = ALL_REPOS.map((r) => `repo:mui/${r.name}`).join(' ');
 
   const prFields = `pullRequests(first: 100, orderBy: {direction: DESC, field: CREATED_AT}) {
-        nodes { number url title state isDraft repository { name } labels(first: 10) { nodes { name } } }
+        nodes { number url title state isDraft createdAt repository { name } labels(first: 10) { nodes { name } } }
       }`;
 
   const repoQueries = PUBLIC_REPOS.map(
@@ -134,9 +137,13 @@ export async function fetchPrsWithoutLabels(): Promise<TriageRow[]> {
       repository: pr.repository.name,
       state: pr.isDraft ? 'draft' : pr.state.toLowerCase(),
       labels: pr.labels.nodes.map((l) => l.name),
+      createdAt: new Date(pr.createdAt),
     }));
 
-  const mergedPrs = mergedData.data.items.map((item) => ({ ...toTriageRow(item), state: 'merged' }));
+  const mergedPrs = mergedData.data.items.map((item) => ({
+    ...toTriageRow(item),
+    state: 'merged',
+  }));
 
   return [...openPrs, ...mergedPrs];
 }
@@ -214,7 +221,7 @@ export async function fetchPrsWithoutReviewer(): Promise<TriageRow[]> {
       url: pr.url,
       repository: pr.repository.name,
       labels: pr.labels.nodes.map((l) => l.name),
-      daysAgo,
+      createdAt: created,
     });
   }
 

--- a/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
@@ -132,7 +132,7 @@ export async function fetchPrsWithoutLabels(): Promise<TriageRow[]> {
       title: pr.title,
       url: pr.url,
       repository: pr.repository.name,
-      state: pr.state,
+      state: pr.isDraft ? 'draft' : pr.state.toLowerCase(),
       labels: pr.labels.nodes.map((l) => l.name),
     }));
 

--- a/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
@@ -67,7 +67,7 @@ export async function fetchIssuesWithoutLabels(): Promise<TriageRow[]> {
       order: 'desc',
     }),
     getOctokit().rest.search.issuesAndPullRequests({
-      q: 'is:issue no:label org:mui is:open',
+      q: `is:issue no:label is:open ${allRepoFilter}`,
       sort: 'updated',
       order: 'desc',
     }),

--- a/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
@@ -21,6 +21,7 @@ interface TriageRowInput {
   repository_url?: string;
   repository?: { name: string };
   state?: string;
+  pull_request?: { merged_at?: string | null };
   labels: Array<string | { name?: string }>;
 }
 
@@ -44,7 +45,7 @@ function toTriageRow(item: TriageRowInput): TriageRow {
     title: item.title,
     url: item.html_url,
     repository: getRepo(item),
-    state: item.state,
+    state: item.pull_request?.merged_at ? 'merged' : item.state,
     labels: item.labels.flatMap((label) => {
       if (typeof label === 'string') {
         return [label];
@@ -140,10 +141,7 @@ export async function fetchPrsWithoutLabels(): Promise<TriageRow[]> {
       createdAt: new Date(pr.createdAt),
     }));
 
-  const mergedPrs = mergedData.data.items.map((item) => ({
-    ...toTriageRow(item),
-    state: 'merged',
-  }));
+  const mergedPrs = mergedData.data.items.map(toTriageRow);
 
   return [...openPrs, ...mergedPrs];
 }

--- a/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/fetchers.ts
@@ -136,7 +136,7 @@ export async function fetchPrsWithoutLabels(): Promise<TriageRow[]> {
       labels: pr.labels.nodes.map((l) => l.name),
     }));
 
-  const mergedPrs = mergedData.data.items.map(toTriageRow);
+  const mergedPrs = mergedData.data.items.map((item) => ({ ...toTriageRow(item), state: 'merged' }));
 
   return [...openPrs, ...mergedPrs];
 }

--- a/apps/code-infra-dashboard/src/lib/triage/types.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/types.ts
@@ -1,4 +1,4 @@
-import type { GridColDef } from '@mui/x-data-grid-premium';
+import type { GridColDef, GridSortModel } from '@mui/x-data-grid-premium';
 
 export type TriageView =
   | 'issues-without-labels'
@@ -25,5 +25,6 @@ export interface TriageViewConfig {
   description: string;
   notionUrl?: string;
   columns: GridColDef<TriageRow>[];
+  initialSortModel?: GridSortModel;
   fetch: () => Promise<TriageRow[]>;
 }

--- a/apps/code-infra-dashboard/src/lib/triage/types.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/types.ts
@@ -16,7 +16,7 @@ export interface TriageRow {
   repository: string;
   state?: string;
   labels?: string[];
-  daysAgo?: number;
+  createdAt?: Date;
 }
 
 export interface TriageViewConfig {

--- a/apps/code-infra-dashboard/src/lib/triage/views.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/views.ts
@@ -74,6 +74,7 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca#c6b06804e0ac40c3aa2b5b5c16b202bf',
     columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_LABELS, COL_DAYS_AGO],
+    initialSortModel: [{ field: 'daysAgo', sort: 'desc' }],
     fetch: fetchPrsWithoutReviewer,
   },
   {

--- a/apps/code-infra-dashboard/src/lib/triage/views.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/views.ts
@@ -1,4 +1,4 @@
-import type { GridColDef } from '@mui/x-data-grid-premium';
+import type { GridColDef, GridSortModel } from '@mui/x-data-grid-premium';
 import type { TriageRow, TriageViewConfig } from './types';
 import {
   fetchIssuesWithoutLabels,
@@ -41,12 +41,20 @@ const COL_LABELS: GridColDef<TriageRow> = {
   valueFormatter: (value: string[] | undefined) => (value ? value.join(', ') : ''),
 };
 
-const COL_DAYS_AGO: GridColDef<TriageRow> = {
-  field: 'daysAgo',
+const COL_AGE: GridColDef<TriageRow> = {
+  field: 'createdAt',
   headerName: 'Age (days)',
   width: 100,
   type: 'number',
+  valueGetter: (value: Date | undefined) => {
+    if (!value) {
+      return undefined;
+    }
+    return Math.ceil((Date.now() - value.getTime()) / (1000 * 3600 * 24));
+  },
 };
+
+const SORT_BY_AGE: GridSortModel = [{ field: 'createdAt', sort: 'asc' }];
 
 export const TRIAGE_VIEWS: TriageViewConfig[] = [
   {
@@ -55,7 +63,8 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Open + closed issues with no labels across all MUI repos',
     notionUrl:
       'https://www.notion.so/mui-org/KPIs-1ce9658b85ce4628a2a2ed2ae74ff69c?pvs=4#0231c2f8e6924c6d856b9dcda6af99c1',
-    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_STATE],
+    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_STATE, COL_AGE],
+    initialSortModel: SORT_BY_AGE,
     fetch: fetchIssuesWithoutLabels,
   },
   {
@@ -64,7 +73,8 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Open non-draft PRs missing meaningful labels',
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca#d97e5e8b4f394dec95de36668dbf81d2',
-    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE],
+    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_AGE],
+    initialSortModel: SORT_BY_AGE,
     fetch: fetchPrsWithoutLabels,
   },
   {
@@ -73,8 +83,8 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Open non-draft PRs with no reviews and no review requests',
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca#c6b06804e0ac40c3aa2b5b5c16b202bf',
-    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_LABELS, COL_DAYS_AGO],
-    initialSortModel: [{ field: 'daysAgo', sort: 'desc' }],
+    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_LABELS, COL_AGE],
+    initialSortModel: SORT_BY_AGE,
     fetch: fetchPrsWithoutReviewer,
   },
   {
@@ -83,7 +93,8 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Open issues labeled "waiting for maintainer" with no assignee',
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca#8f5ae0daa6ad4543b866f3ad0532c9e4',
-    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE],
+    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_AGE],
+    initialSortModel: SORT_BY_AGE,
     fetch: fetchNeedsTriageNotAssigned,
   },
   {
@@ -92,7 +103,8 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Issues with "waiting for maintainer" but only that one meaningful label',
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-12a84fdf50e44595afc55343dac00fca#d6680f5abf8b4e3ab132cb8e336bb5bc',
-    columns: [COL_NUMBER, COL_STATE, COL_REPOSITORY, COL_TITLE],
+    columns: [COL_NUMBER, COL_STATE, COL_REPOSITORY, COL_TITLE, COL_AGE],
+    initialSortModel: SORT_BY_AGE,
     fetch: fetchIssuesWithoutProductScope,
   },
   {
@@ -101,7 +113,8 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Closed issues with "waiting for maintainer" across repos',
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-12a84fdf50e44595afc55343dac00fca#d6680f5abf8b4e3ab132cb8e336bb5bc',
-    columns: [COL_NUMBER, COL_STATE, COL_REPOSITORY, COL_TITLE],
+    columns: [COL_NUMBER, COL_STATE, COL_REPOSITORY, COL_TITLE, COL_AGE],
+    initialSortModel: SORT_BY_AGE,
     fetch: fetchClosedIssuesNoProductScope,
   },
 ];

--- a/apps/code-infra-dashboard/src/lib/triage/views.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/views.ts
@@ -73,7 +73,7 @@ export const TRIAGE_VIEWS: TriageViewConfig[] = [
     description: 'Open non-draft PRs missing meaningful labels',
     notionUrl:
       'https://www.notion.so/mui-org/GitHub-community-issues-PRs-Tier-1-12a84fdf50e44595afc55343dac00fca#d97e5e8b4f394dec95de36668dbf81d2',
-    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_AGE],
+    columns: [COL_NUMBER, COL_REPOSITORY, COL_TITLE, COL_STATE, COL_AGE],
     initialSortModel: SORT_BY_AGE,
     fetch: fetchPrsWithoutLabels,
   },

--- a/apps/code-infra-dashboard/src/lib/triage/views.ts
+++ b/apps/code-infra-dashboard/src/lib/triage/views.ts
@@ -54,7 +54,7 @@ const COL_AGE: GridColDef<TriageRow> = {
   },
 };
 
-const SORT_BY_AGE: GridSortModel = [{ field: 'createdAt', sort: 'asc' }];
+const SORT_BY_AGE: GridSortModel = [{ field: 'createdAt', sort: 'desc' }];
 
 export const TRIAGE_VIEWS: TriageViewConfig[] = [
   {

--- a/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
+++ b/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
@@ -74,14 +74,9 @@ export default function GitHubTriage() {
     rowGroupingModel,
   });
 
-  const initialState = React.useMemo(
-    () => ({
-      ...groupingState,
-      sorting: {
-        sortModel: activeView.initialSortModel ?? [],
-      },
-    }),
-    [groupingState, activeView.initialSortModel],
+  const sortModel = React.useMemo(
+    () => activeView.initialSortModel ?? [],
+    [activeView.initialSortModel],
   );
 
   return (
@@ -139,7 +134,8 @@ export default function GitHubTriage() {
             maxHeight: '100vh',
           }}
           disableRowSelectionOnClick
-          initialState={initialState}
+          initialState={groupingState}
+          sortModel={sortModel}
           rowGroupingModel={rowGroupingModel}
           defaultGroupingExpansionDepth={-1}
           groupingColDef={{ headerName: 'Repository' }}

--- a/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
+++ b/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -17,13 +16,9 @@ import { useSearchParamsState } from '../hooks/useSearchParamsState';
 import { useTriageData } from '../hooks/useTriageData';
 import { TRIAGE_VIEWS, getTriageView } from '../lib/triage/views';
 import type { TriageRow, TriageView as TriageViewId } from '../lib/triage/types';
+import GitHubStateChip from '../components/GitHubStateChip';
 import Heading from '../components/Heading';
 import ErrorDisplay from '../components/ErrorDisplay';
-
-const STATE_COLORS: Record<string, string> = {
-  open: '#238636',
-  closed: '#8957e5',
-};
 
 const TITLE_COLUMN: GridColDef<TriageRow> = {
   field: 'title',
@@ -41,16 +36,9 @@ const STATE_COLUMN: GridColDef<TriageRow> = {
   field: 'state',
   headerName: 'State',
   width: 90,
-  renderCell: (params) => {
-    const state = params.value as string | undefined;
-    if (!state) {
-      return null;
-    }
-    const color = STATE_COLORS[state] ?? '#656d76';
-    return (
-      <Chip label={state} size="small" sx={{ bgcolor: color, color: '#fff', fontWeight: 500 }} />
-    );
-  },
+  renderCell: (params) => (
+    <GitHubStateChip state={params.value as string} />
+  ),
 };
 
 function getColumns(viewColumns: GridColDef<TriageRow>[]): GridColDef<TriageRow>[] {

--- a/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
+++ b/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
@@ -72,9 +72,14 @@ export default function GitHubTriage() {
     rowGroupingModel,
   });
 
-  const sortModel = React.useMemo(
-    () => activeView.initialSortModel ?? [],
-    [activeView.initialSortModel],
+  const initialState = React.useMemo(
+    () => ({
+      ...groupingState,
+      sorting: {
+        sortModel: activeView.initialSortModel ?? [],
+      },
+    }),
+    [groupingState, activeView.initialSortModel],
   );
 
   return (
@@ -131,9 +136,9 @@ export default function GitHubTriage() {
             // Failsafe in case a query returns an unexpectedly large number of rows
             maxHeight: '100vh',
           }}
+          key={activeView.id}
           disableRowSelectionOnClick
-          initialState={groupingState}
-          sortModel={sortModel}
+          initialState={initialState}
           rowGroupingModel={rowGroupingModel}
           defaultGroupingExpansionDepth={-1}
           groupingColDef={{ headerName: 'Repository' }}

--- a/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
+++ b/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
@@ -36,8 +36,7 @@ const STATE_COLUMN: GridColDef<TriageRow> = {
   field: 'state',
   headerName: 'State',
   width: 90,
-  renderCell: (params) =>
-    params.value ? <GitHubStateChip state={params.value} /> : null,
+  renderCell: (params) => (params.value ? <GitHubStateChip state={params.value} /> : null),
 };
 
 function getColumns(viewColumns: GridColDef<TriageRow>[]): GridColDef<TriageRow>[] {

--- a/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
+++ b/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import MenuItem from '@mui/material/MenuItem';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
@@ -19,6 +20,11 @@ import type { TriageRow, TriageView as TriageViewId } from '../lib/triage/types'
 import Heading from '../components/Heading';
 import ErrorDisplay from '../components/ErrorDisplay';
 
+const STATE_COLORS: Record<string, string> = {
+  open: '#238636',
+  closed: '#8957e5',
+};
+
 const TITLE_COLUMN: GridColDef<TriageRow> = {
   field: 'title',
   headerName: 'Title',
@@ -31,10 +37,29 @@ const TITLE_COLUMN: GridColDef<TriageRow> = {
   ),
 };
 
+const STATE_COLUMN: GridColDef<TriageRow> = {
+  field: 'state',
+  headerName: 'State',
+  width: 90,
+  renderCell: (params) => {
+    const state = params.value as string | undefined;
+    if (!state) {
+      return null;
+    }
+    const color = STATE_COLORS[state] ?? '#656d76';
+    return (
+      <Chip label={state} size="small" sx={{ bgcolor: color, color: '#fff', fontWeight: 500 }} />
+    );
+  },
+};
+
 function getColumns(viewColumns: GridColDef<TriageRow>[]): GridColDef<TriageRow>[] {
   return viewColumns.map((col) => {
     if (col.field === 'title') {
       return { ...col, ...TITLE_COLUMN };
+    }
+    if (col.field === 'state') {
+      return { ...col, ...STATE_COLUMN };
     }
     return col;
   });
@@ -56,10 +81,20 @@ export default function GitHubTriage() {
 
   const apiRef = useGridApiRef();
   const rowGroupingModel = React.useMemo(() => ['repository'], []);
-  const initialState = useKeepGroupedColumnsHidden({
+  const groupingState = useKeepGroupedColumnsHidden({
     apiRef,
     rowGroupingModel,
   });
+
+  const initialState = React.useMemo(
+    () => ({
+      ...groupingState,
+      sorting: {
+        sortModel: activeView.initialSortModel ?? [],
+      },
+    }),
+    [groupingState, activeView.initialSortModel],
+  );
 
   return (
     <Box

--- a/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
+++ b/apps/code-infra-dashboard/src/views/GitHubTriage.tsx
@@ -36,9 +36,8 @@ const STATE_COLUMN: GridColDef<TriageRow> = {
   field: 'state',
   headerName: 'State',
   width: 90,
-  renderCell: (params) => (
-    <GitHubStateChip state={params.value as string} />
-  ),
+  renderCell: (params) =>
+    params.value ? <GitHubStateChip state={params.value} /> : null,
 };
 
 function getColumns(viewColumns: GridColDef<TriageRow>[]): GridColDef<TriageRow>[] {


### PR DESCRIPTION
## Summary
- Show correct state for all issues/PRs (open, closed, merged, draft) as colored chips
- Sort all views by age, oldest first
- Only show results from repos we explicitly track