### PR TITLE
[code-infra] Only log warnings/errors when publishing packages

### DIFF
--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -178,7 +178,10 @@ export async function publishPackages(packages, options = {}) {
     args.push('--no-git-checks');
   }
 
-  await $({ stdio: 'inherit' })`pnpm -r publish --access public --tag=${tag} ${args}`;
+  await $({
+    stdio: 'inherit',
+    env: { npm_config_loglevel: 'warn' },
+  })`pnpm -r publish --access public --tag=${tag} ${args}`;
 }
 
 /**


### PR DESCRIPTION
Avoids unnecessary logs in github actions to inspect when required.

<details>
  <summary>Before</summary>

```sh
pnpm code-infra publish-canary --dry-run
🧪 Running in DRY RUN mode - no actual publishing will occur

🔍 Discovering all workspace packages...
🔍 Checking for packages changed since canary tag...
📋 Found 1 packages(s) for canary publishing:
   • @mui/internal-code-infra@0.0.3

🔍 Fetching package version information...

🔥 Publishing canary versions...
🏷️  @mui/internal-babel-plugin-display-name: 1.0.4-canary.16 (reused)
🏷️  @mui/internal-babel-plugin-minify-errors: 2.0.8-canary.25 (reused)
🏷️  @mui/internal-babel-plugin-resolve-imports: 2.0.7-canary.34 (reused)
🏷️  @mui/internal-bundle-size-checker: 1.0.9-canary.71 (reused)
🏷️  @mui/internal-code-infra: 0.0.4-canary.19 (new)
🏷️  @mui/internal-docs-infra: 0.7.1-canary.3 (reused)
🏷️  @mui/internal-netlify-cache: 0.0.3-canary.4 (reused)
🏷️  @mui/internal-test-utils: 2.0.18-canary.19 (reused)
📝 Updated @mui/internal-babel-plugin-display-name package.json to 1.0.4-canary.16
📝 Updated @mui/internal-babel-plugin-resolve-imports package.json to 2.0.7-canary.34
📝 Updated @mui/internal-babel-plugin-minify-errors package.json to 2.0.8-canary.25
📝 Updated @mui/internal-code-infra package.json to 0.0.4-canary.19
📝 Updated @mui/internal-netlify-cache package.json to 0.0.3-canary.4
📝 Updated @mui/internal-bundle-size-checker package.json to 1.0.9-canary.71
📝 Updated @mui/internal-test-utils package.json to 2.0.18-canary.19
📝 Updated @mui/internal-docs-infra package.json to 0.7.1-canary.3
📤 Publishing 1 canary versions...
npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
npm notice
npm notice 📦  @mui/internal-code-infra@0.0.4-canary.19
npm notice Tarball Contents
npm notice 1.1kB LICENSE
npm notice 3.2kB README.md
npm notice 51B bin/code-infra.mjs
npm notice 2.0kB build/babel-config.d.mts
npm notice 1.8kB build/brokenLinksChecker/index.d.mts
npm notice 1.6kB build/bundler/adapters/adapter-rollup.d.mts
npm notice 479B build/bundler/adapters/babel-plugin.d.mts
npm notice 487B build/bundler/adapters/babel-runtime-interop-plugin.d.mts
npm notice 1.4kB build/bundler/adapters/base.d.mts
npm notice 1.7kB build/bundler/adapters/dts-side-effect-fix.d.mts
npm notice 433B build/bundler/adapters/index.d.mts
npm notice 2.2kB build/bundler/builder.d.mts
npm notice 39B build/bundler/index.d.mts
npm notice 5.5kB build/bundler/types.d.mts
npm notice 545B build/bundler/utils/config-finder.d.mts
npm notice 167B build/bundler/utils/env.d.mts
npm notice 2.2kB build/bundler/utils/generate-exports-field.d.mts
npm notice 854B build/bundler/utils/resolve-entrypoints.d.mts
npm notice 1.2kB build/changelog/buildSections.d.mts
npm notice 1.1kB build/changelog/categorizeCommits.d.mts
npm notice 1.4kB build/changelog/fetchChangelogs.d.mts
npm notice 649B build/changelog/filterCommits.d.mts
npm notice 819B build/changelog/generateChangelog.d.mts
npm notice 186B build/changelog/index.d.mts
npm notice 555B build/changelog/loadChangelogConfig.d.mts
npm notice 997B build/changelog/parseCommitLabels.d.mts
npm notice 1.8kB build/changelog/renderChangelog.d.mts
npm notice 829B build/changelog/sortSections.d.mts
npm notice 11.7kB build/changelog/types.d.ts
npm notice 381B build/cli/cmdArgosPush.d.mts
npm notice 569B build/cli/cmdBuild.d.mts
npm notice 732B build/cli/cmdBundler.d.mts
npm notice 265B build/cli/cmdCopyFiles.d.mts
npm notice 325B build/cli/cmdExtractErrorCodes.d.mts
npm notice 703B build/cli/cmdGenerateChangelog.d.mts
npm notice 309B build/cli/cmdGithubAuth.d.mts
npm notice 830B build/cli/cmdListWorkspaces.d.mts
npm notice 236B build/cli/cmdNetlifyIgnore.d.mts
npm notice 459B build/cli/cmdPublish.d.mts
npm notice 558B build/cli/cmdPublishCanary.d.mts
npm notice 316B build/cli/cmdPublishNewPackage.d.mts
npm notice 209B build/cli/cmdSetVersionOverrides.d.mts
npm notice 490B build/cli/cmdVale.d.mts
npm notice 141B build/cli/cmdValidateBuiltTypes.d.mts
npm notice 11B build/cli/index.d.mts
npm notice 742B build/eslint/baseConfig.d.mts
npm notice 133B build/eslint/docsConfig.d.mts
npm notice 470B build/eslint/extensions.d.mts
npm notice 136B build/eslint/index.d.mts
npm notice 133B build/eslint/jsonConfig.d.mts
npm notice 566B build/eslint/mui/config.d.mts
npm notice 129B build/eslint/mui/index.d.mts
npm notice 208B build/eslint/mui/rules/add-undef-to-optional.d.mts
npm notice 872B build/eslint/mui/rules/consistent-production-guard.d.mts
npm notice 127B build/eslint/mui/rules/disallow-active-element-as-key-event-target.d.mts
npm notice 131B build/eslint/mui/rules/disallow-react-api-in-server-components.d.mts
npm notice 131B build/eslint/mui/rules/docgen-ignore-before-comment.d.mts
npm notice 214B build/eslint/mui/rules/flatten-parentheses.d.mts
npm notice 127B build/eslint/mui/rules/mui-name-matches-component-name.d.mts
npm notice 127B build/eslint/mui/rules/no-empty-box.d.mts
npm notice 562B build/eslint/mui/rules/no-restricted-resolved-imports.d.mts
npm notice 127B build/eslint/mui/rules/no-styled-box.d.mts
npm notice 776B build/eslint/mui/rules/nodeEnvUtils.d.mts
npm notice 729B build/eslint/mui/rules/require-dev-wrapper.d.mts
npm notice 135B build/eslint/mui/rules/rules-of-use-theme-variants.d.mts
npm notice 127B build/eslint/mui/rules/straight-quotes.d.mts
npm notice 421B build/eslint/testConfig.d.mts
npm notice 1.2kB build/markdownlint/duplicate-h1.d.mts
npm notice 376B build/markdownlint/git-diff.d.mts
npm notice 1.5kB build/markdownlint/index.d.mts
npm notice 376B build/markdownlint/straight-quotes.d.mts
npm notice 376B build/markdownlint/table-alignment.d.mts
npm notice 376B build/markdownlint/terminal-language.d.mts
npm notice 502B build/prettier.d.mts
npm notice 119B build/stylelint/index.d.mts
npm notice 2.7kB build/utils/babel.d.mts
npm notice 3.9kB build/utils/build.d.mts
npm notice 699B build/utils/credentials.d.mts
npm notice 315B build/utils/extractErrorCodes.d.mts
npm notice 639B build/utils/git.d.mts
npm notice 1.5kB build/utils/github.d.mts
npm notice 169B build/utils/path.d.mts
npm notice 6.6kB build/utils/pnpm.d.mts
npm notice 885B build/utils/template.d.mts
npm notice 300B build/utils/testUtils.d.mts
npm notice 3.0kB build/utils/typescript.d.mts
npm notice 5.6kB package.json
npm notice 6.2kB src/babel-config.mjs
npm notice 622B src/brokenLinksChecker/__fixtures__/static-site/broken-links.html
npm notice 834B src/brokenLinksChecker/__fixtures__/static-site/broken-targets.html
npm notice 602B src/brokenLinksChecker/__fixtures__/static-site/example.md
npm notice 712B src/brokenLinksChecker/__fixtures__/static-site/external-links.html
npm notice 433B src/brokenLinksChecker/__fixtures__/static-site/ignored-page.html
npm notice 1.2kB src/brokenLinksChecker/__fixtures__/static-site/index.html
npm notice 82B src/brokenLinksChecker/__fixtures__/static-site/known-targets.json
npm notice 664B src/brokenLinksChecker/__fixtures__/static-site/nested/page.html
npm notice 672B src/brokenLinksChecker/__fixtures__/static-site/orphaned-page.html
npm notice 637B src/brokenLinksChecker/__fixtures__/static-site/page-with-api-links.html
npm notice 656B src/brokenLinksChecker/__fixtures__/static-site/page-with-custom-targets.html
npm notice 716B src/brokenLinksChecker/__fixtures__/static-site/page-with-ignored-content.html
npm notice 598B src/brokenLinksChecker/__fixtures__/static-site/page-with-known-target-links.html
npm notice 308B src/brokenLinksChecker/__fixtures__/static-site/unclosed-tags.html
npm notice 588B src/brokenLinksChecker/__fixtures__/static-site/valid.html
npm notice 821B src/brokenLinksChecker/__fixtures__/static-site/with-anchors.html
npm notice 27.3kB src/brokenLinksChecker/index.mjs
npm notice 10.4kB src/brokenLinksChecker/index.test.ts
npm notice 162B src/build-env.d.ts
npm notice 10.4kB src/changelog/buildSections.mjs
npm notice 5.2kB src/changelog/categorizeCommits.mjs
npm notice 10.4kB src/changelog/categorizeCommits.test.ts
npm notice 4.4kB src/changelog/fetchChangelogs.mjs
npm notice 1.8kB src/changelog/filterCommits.mjs
npm notice 12.2kB src/changelog/filterCommits.test.ts
npm notice 2.4kB src/changelog/generateChangelog.mjs
npm notice 187B src/changelog/index.mjs
npm notice 3.0kB src/changelog/loadChangelogConfig.mjs
npm notice 2.6kB src/changelog/parseCommitLabels.mjs
npm notice 15.5kB src/changelog/parseCommitLabels.test.ts
npm notice 17.0kB src/changelog/renderChangelog.mjs
npm notice 12.8kB src/changelog/renderChangelog.test.ts
npm notice 1.0kB src/changelog/sortSections.mjs
npm notice 5.4kB src/changelog/sortSections.test.ts
npm notice 11.1kB src/changelog/types.ts
npm notice 3.5kB src/cli/cmdArgosPush.mjs
npm notice 18.1kB src/cli/cmdBuild.mjs
npm notice 6.6kB src/cli/cmdCopyFiles.mjs
npm notice 1.3kB src/cli/cmdExtractErrorCodes.mjs
npm notice 2.4kB src/cli/cmdGenerateChangelog.mjs
npm notice 1.0kB src/cli/cmdGithubAuth.mjs
npm notice 3.3kB src/cli/cmdListWorkspaces.mjs
npm notice 6.1kB src/cli/cmdNetlifyIgnore.mjs
npm notice 16.8kB src/cli/cmdPublish.mjs
npm notice 19.8kB src/cli/cmdPublishCanary.mjs
npm notice 4.1kB src/cli/cmdPublishNewPackage.mjs
npm notice 4.6kB src/cli/cmdSetVersionOverrides.mjs
npm notice 1.6kB src/cli/cmdValidateBuiltTypes.mjs
npm notice 2.1kB src/cli/index.mjs
npm notice 19.4kB src/cli/packageJson.d.ts
npm notice 5.4kB src/eslint/baseConfig.mjs
npm notice 1.1kB src/eslint/docsConfig.mjs
npm notice 412B src/eslint/extensions.mjs
npm notice 229B src/eslint/index.mjs
npm notice 979B src/eslint/jsonConfig.mjs
npm notice 21.0kB src/eslint/mui/config.mjs
npm notice 2.1kB src/eslint/mui/index.mjs
npm notice 4.0kB src/eslint/mui/rules/add-undef-to-optional.mjs
npm notice 8.5kB src/eslint/mui/rules/add-undef-to-optional.test.mjs
npm notice 2.9kB src/eslint/mui/rules/consistent-production-guard.mjs
npm notice 3.2kB src/eslint/mui/rules/consistent-production-guard.test.mjs
npm notice 2.4kB src/eslint/mui/rules/disallow-active-element-as-key-event-target.mjs
npm notice 2.3kB src/eslint/mui/rules/disallow-active-elements-as-key-event-target.test.mjs
npm notice 3.9kB src/eslint/mui/rules/disallow-react-api-in-server-components.mjs
npm notice 8.8kB src/eslint/mui/rules/disallow-react-api-in-server-components.test.mjs
npm notice 968B src/eslint/mui/rules/docgen-ignore-before-comment.mjs
npm notice 1.4kB src/eslint/mui/rules/docgen-ignore-before-comment.test.mjs
npm notice 3.0kB src/eslint/mui/rules/flatten-parentheses.mjs
npm notice 5.7kB src/eslint/mui/rules/flatten-parentheses.test.mjs
npm notice 5.8kB src/eslint/mui/rules/mui-name-matches-component-name.mjs
npm notice 7.4kB src/eslint/mui/rules/mui-name-matches-component-name.test.mjs
npm notice 1.5kB src/eslint/mui/rules/no-empty-box.mjs
npm notice 809B src/eslint/mui/rules/no-empty-box.test.mjs
npm notice 2.9kB src/eslint/mui/rules/no-restricted-resolved-imports.mjs
npm notice 1.6kB src/eslint/mui/rules/no-styled-box.mjs
npm notice 1.2kB src/eslint/mui/rules/no-styled-box.test.mjs
npm notice 1.1kB src/eslint/mui/rules/nodeEnvUtils.mjs
npm notice 4.8kB src/eslint/mui/rules/require-dev-wrapper.mjs
npm notice 5.6kB src/eslint/mui/rules/require-dev-wrapper.test.mjs
npm notice 4.6kB src/eslint/mui/rules/rules-of-use-theme-variants.mjs
npm notice 3.4kB src/eslint/mui/rules/rules-of-use-theme-variants.test.mjs
npm notice 1.1kB src/eslint/mui/rules/straight-quotes.mjs
npm notice 1.2kB src/eslint/mui/rules/straight-quotes.test.mjs
npm notice 4.9kB src/eslint/testConfig.mjs
npm notice 485B src/estree-typescript.d.ts
npm notice 1.9kB src/markdownlint/duplicate-h1.mjs
npm notice 936B src/markdownlint/git-diff.mjs
npm notice 2.5kB src/markdownlint/index.mjs
npm notice 745B src/markdownlint/straight-quotes.mjs
npm notice 1.4kB src/markdownlint/table-alignment.mjs
npm notice 532B src/markdownlint/terminal-language.mjs
npm notice 903B src/prettier.mjs
npm notice 577B src/setupVitest.ts
npm notice 1.4kB src/stylelint/index.mjs
npm notice 4.5kB src/untyped-plugins.d.ts
npm notice 5.1kB src/utils/babel.mjs
npm notice 18.5kB src/utils/build.mjs
npm notice 20.4kB src/utils/build.test.mjs
npm notice 1.8kB src/utils/credentials.mjs
npm notice 6.4kB src/utils/extractErrorCodes.mjs
npm notice 1.9kB src/utils/git.mjs
npm notice 8.4kB src/utils/github.mjs
npm notice 229B src/utils/path.mjs
npm notice 14.1kB src/utils/pnpm.mjs
npm notice 24.9kB src/utils/pnpm.test.mjs
npm notice 982B src/utils/template.mjs
npm notice 4.3kB src/utils/template.test.mjs
npm notice 624B src/utils/testUtils.mjs
npm notice 9.4kB src/utils/typescript.mjs
npm notice 12.8kB src/utils/typescript.test.mjs
npm notice Tarball Details
npm notice name: @mui/internal-code-infra
npm notice version: 0.0.4-canary.19
npm notice filename: mui-internal-code-infra-0.0.4-canary.19.tgz
npm notice package size: 147.2 kB
npm notice unpacked size: 643.9 kB
npm notice shasum: 37d1182acc11ef6c2086edb8792b3a9e758087f7
npm notice integrity: sha512-5w8ZPcK+JWZRf[...]CumaUU5D22VhQ==
npm notice total files: 198
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag canary and public access (dry-run)
+ @mui/internal-code-infra@0.0.4-canary.19
✅ Published @mui/internal-code-infra@0.0.4-canary.19

🔄 Restoring original package.json files...
🏷️  Would update and push canary tag (dry-run)

🎉 All canary versions published successfully!

🏁 Publishing complete!
```
</details>

After

```sh
pnpm code-infra publish-canary --dry-run
🧪 Running in DRY RUN mode - no actual publishing will occur

🔍 Discovering all workspace packages...
🔍 Checking for packages changed since canary tag...
📋 Found 1 packages(s) for canary publishing:
   • @mui/internal-code-infra@0.0.3

🔍 Fetching package version information...

🔥 Publishing canary versions...
🏷️  @mui/internal-babel-plugin-display-name: 1.0.4-canary.16 (reused)
🏷️  @mui/internal-babel-plugin-minify-errors: 2.0.8-canary.25 (reused)
🏷️  @mui/internal-babel-plugin-resolve-imports: 2.0.7-canary.34 (reused)
🏷️  @mui/internal-bundle-size-checker: 1.0.9-canary.71 (reused)
🏷️  @mui/internal-code-infra: 0.0.4-canary.19 (new)
🏷️  @mui/internal-docs-infra: 0.7.1-canary.3 (reused)
🏷️  @mui/internal-netlify-cache: 0.0.3-canary.4 (reused)
🏷️  @mui/internal-test-utils: 2.0.18-canary.19 (reused)
📝 Updated @mui/internal-babel-plugin-minify-errors package.json to 2.0.8-canary.25
📝 Updated @mui/internal-babel-plugin-display-name package.json to 1.0.4-canary.16
📝 Updated @mui/internal-babel-plugin-resolve-imports package.json to 2.0.7-canary.34
📝 Updated @mui/internal-bundle-size-checker package.json to 1.0.9-canary.71
📝 Updated @mui/internal-code-infra package.json to 0.0.4-canary.19
📝 Updated @mui/internal-netlify-cache package.json to 0.0.3-canary.4
📝 Updated @mui/internal-docs-infra package.json to 0.7.1-canary.3
📝 Updated @mui/internal-test-utils package.json to 2.0.18-canary.19
📤 Publishing 1 canary versions...
npm warn Unknown env config "verify-deps-before-run". This will stop working in the next major version of npm.
+ @mui/internal-code-infra@0.0.4-canary.19
✅ Published @mui/internal-code-infra@0.0.4-canary.19

🔄 Restoring original package.json files...
🏷️  Would update and push canary tag (dry-run)

🎉 All canary versions published successfully!

🏁 Publishing complete!
```