### PR TITLE
[code-infra] Handle pre-existing git tags in canary publish

### DIFF
--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mui/internal-benchmark",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "MUI Team",
   "description": "Benchmark utilities for MUI projects. Internal package.",
   "repository": {

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -282,6 +282,11 @@ async function createGitHubReleasesForPackages(
         },
       })`git tag -fa ${tagName} -m ${`Canary release ${pkg.name}@${version}`}`;
 
+      // Force-push to handle retries where the tag already exists from a previous
+      // failed publish. The npm registry is the source of truth for published
+      // versions, so it's safe to rewrite a tag even if it points to a different
+      // commit — it just means the prior publish for this version failed partway
+      // through and the GitHub release needs to be recreated.
       // eslint-disable-next-line no-await-in-loop
       await $`git push --force origin ${tagName}`;
       console.log(`✅ Created and pushed git tag: ${tagName}`);

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -494,7 +494,6 @@ async function publishCanaryVersions(
       publishedNames.add(name);
       console.log(`✅ Published ${name}@${canaryVersions.get(name)}`);
     }
-
   } finally {
     // Always restore original package.json files in parallel
     console.log('\n🔄 Restoring original package.json files...');
@@ -524,7 +523,9 @@ async function publishCanaryVersions(
       console.log('\n🎉 All canary versions published successfully!');
     } else {
       const missingNames = missing.map((pkg) => pkg.name).join(', ');
-      console.warn(`\n⚠️  Canary tag not advanced, some packages failed to publish: ${missingNames}`);
+      console.warn(
+        `\n⚠️  Canary tag not advanced, some packages failed to publish: ${missingNames}`,
+      );
     }
   }
 }

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -233,7 +233,7 @@ async function prepareChangelogsForPackages(packagesToPublish, allPackages, cana
  * and if it already exists (422), deletes the existing one and retries.
  *
  * @param {InstanceType<typeof Octokit>} octokit
- * @param {Parameters<Octokit['repos']['createRelease']>[0]} params
+ * @param {NonNullable<Parameters<Octokit['repos']['createRelease']>[0]>} params
  */
 async function upsertGitHubRelease(octokit, params) {
   try {
@@ -242,7 +242,7 @@ async function upsertGitHubRelease(octokit, params) {
     const isAlreadyExists =
       error.status === 422 &&
       error.response?.data?.errors?.some(
-        (/** @type {any} */ e) => e.code === 'already_exists' && e.field === 'tag_name',
+        (/** @type {any} */ err) => err.code === 'already_exists' && err.field === 'tag_name',
       );
     if (!isAlreadyExists) {
       throw error;

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -326,6 +326,7 @@ async function createGitHubReleasesForPackages(
       await $`git push --force origin ${tagName}`;
       console.log(`✅ Created and pushed git tag: ${tagName}`);
 
+      // Create GitHub release
       // eslint-disable-next-line no-await-in-loop
       const res = await upsertGitHubRelease(octokit, {
         owner: repoInfo.owner,

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -487,19 +487,14 @@ async function publishCanaryVersions(
       tag: CANARY_TAG,
     });
 
-    for (const pkg of publishedPackages) {
-      publishedNames.add(pkg.name);
+    // Only use package names from the report summary, not versions.
+    // pnpm-publish-summary.json reports the version from the workspace
+    // package.json, which is wrong for packages with publishConfig.directory.
+    for (const { name } of publishedPackages) {
+      publishedNames.add(name);
+      console.log(`✅ Published ${name}@${canaryVersions.get(name)}`);
     }
 
-    for (const { name, version } of publishedPackages) {
-      console.log(`✅ Published ${name}@${version}`);
-    }
-
-    const expectedNames = new Set(packagesToPublish.map((pkg) => pkg.name));
-    const missing = [...expectedNames].filter((name) => !publishedNames.has(name));
-    if (missing.length > 0) {
-      console.warn(`⚠️  Some packages were not published: ${missing.join(', ')}`);
-    }
   } finally {
     // Always restore original package.json files in parallel
     console.log('\n🔄 Restoring original package.json files...');
@@ -514,16 +509,23 @@ async function publishCanaryVersions(
   }
 
   if (publishedNames.size > 0) {
-    // Create/update the canary tag after successful publish
-    await createCanaryTag(options.dryRun);
-
-    // Create GitHub releases if requested
+    // Create GitHub releases only for actually published packages
     if (options.githubRelease) {
       const actuallyPublished = packagesToPublish.filter((pkg) => publishedNames.has(pkg.name));
       await createGitHubReleasesForPackages(actuallyPublished, canaryVersions, changelogs, options);
     }
 
-    console.log('\n🎉 All canary versions published successfully!');
+    // Only advance the canary tag if all expected packages were published.
+    // Otherwise the tag would skip over unpublished packages and they'd
+    // never be retried on the next run.
+    const missing = packagesToPublish.filter((pkg) => !publishedNames.has(pkg.name));
+    if (missing.length === 0) {
+      await createCanaryTag(options.dryRun);
+      console.log('\n🎉 All canary versions published successfully!');
+    } else {
+      const missingNames = missing.map((pkg) => pkg.name).join(', ');
+      console.warn(`\n⚠️  Canary tag not advanced, some packages failed to publish: ${missingNames}`);
+    }
   }
 }
 

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -260,7 +260,6 @@ async function upsertGitHubRelease(octokit, params) {
     repo: params.repo,
     release_id: existing.data.id,
   });
-  console.log(`🔄 Replaced existing GitHub release for ${params.tag_name}`);
   return octokit.repos.createRelease(params);
 }
 

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -335,7 +335,7 @@ async function createGitHubReleasesForPackages(
         name: releaseName,
         body: changelog.join('\n'),
         draft: false,
-        prerelease: true,
+        prerelease: true, // Mark as prerelease since these are canary versions
       });
 
       console.log(`✅ Created GitHub release: ${releaseName} at ${res.data.html_url}`);

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -229,6 +229,42 @@ async function prepareChangelogsForPackages(packagesToPublish, allPackages, cana
 }
 
 /**
+ * Create or replace a GitHub release. Attempts to create the release first,
+ * and if it already exists (422), deletes the existing one and retries.
+ *
+ * @param {InstanceType<typeof Octokit>} octokit
+ * @param {Parameters<Octokit['repos']['createRelease']>[0]} params
+ */
+async function upsertGitHubRelease(octokit, params) {
+  try {
+    return await octokit.repos.createRelease(params);
+  } catch (/** @type {any} */ error) {
+    const isAlreadyExists =
+      error.status === 422 &&
+      error.response?.data?.errors?.some(
+        (/** @type {any} */ e) => e.code === 'already_exists' && e.field === 'tag_name',
+      );
+    if (!isAlreadyExists) {
+      throw error;
+    }
+  }
+
+  // Release already exists — delete and recreate
+  const existing = await octokit.repos.getReleaseByTag({
+    owner: params.owner,
+    repo: params.repo,
+    tag: params.tag_name,
+  });
+  await octokit.repos.deleteRelease({
+    owner: params.owner,
+    repo: params.repo,
+    release_id: existing.data.id,
+  });
+  console.log(`🔄 Replaced existing GitHub release for ${params.tag_name}`);
+  return octokit.repos.createRelease(params);
+}
+
+/**
  * Create GitHub releases and tags for published packages
  * @param {PublicPackage[]} publishedPackages - Packages that were published
  * @param {Map<string, string>} canaryVersions - Map of package names to their canary versions
@@ -291,30 +327,8 @@ async function createGitHubReleasesForPackages(
       await $`git push --force origin ${tagName}`;
       console.log(`✅ Created and pushed git tag: ${tagName}`);
 
-      // Delete existing GitHub release if it exists
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const existing = await octokit.repos.getReleaseByTag({
-          owner: repoInfo.owner,
-          repo: repoInfo.repo,
-          tag: tagName,
-        });
-        // eslint-disable-next-line no-await-in-loop
-        await octokit.repos.deleteRelease({
-          owner: repoInfo.owner,
-          repo: repoInfo.repo,
-          release_id: existing.data.id,
-        });
-        console.log(`🔄 Deleted existing GitHub release for ${tagName}`);
-      } catch (/** @type {any} */ error) {
-        if (error.status !== 404) {
-          throw error;
-        }
-      }
-
-      // Create GitHub release
       // eslint-disable-next-line no-await-in-loop
-      const res = await octokit.repos.createRelease({
+      const res = await upsertGitHubRelease(octokit, {
         owner: repoInfo.owner,
         repo: repoInfo.repo,
         tag_name: tagName,

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -280,11 +280,32 @@ async function createGitHubReleasesForPackages(
           GIT_COMMITTER_NAME: 'Code infra',
           GIT_COMMITTER_EMAIL: 'code-infra@mui.com',
         },
-      })`git tag -a ${tagName} -m ${`Canary release ${pkg.name}@${version}`}`;
+      })`git tag -fa ${tagName} -m ${`Canary release ${pkg.name}@${version}`}`;
 
       // eslint-disable-next-line no-await-in-loop
-      await $`git push origin ${tagName}`;
+      await $`git push --force origin ${tagName}`;
       console.log(`✅ Created and pushed git tag: ${tagName}`);
+
+      // Delete existing GitHub release if it exists
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const existing = await octokit.repos.getReleaseByTag({
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          tag: tagName,
+        });
+        // eslint-disable-next-line no-await-in-loop
+        await octokit.repos.deleteRelease({
+          owner: repoInfo.owner,
+          repo: repoInfo.repo,
+          release_id: existing.data.id,
+        });
+        console.log(`🔄 Deleted existing GitHub release for ${tagName}`);
+      } catch (/** @type {any} */ error) {
+        if (error.status !== 404) {
+          throw error;
+        }
+      }
 
       // Create GitHub release
       // eslint-disable-next-line no-await-in-loop
@@ -296,7 +317,7 @@ async function createGitHubReleasesForPackages(
         name: releaseName,
         body: changelog.join('\n'),
         draft: false,
-        prerelease: true, // Mark as prerelease since these are canary versions
+        prerelease: true,
       });
 
       console.log(`✅ Created GitHub release: ${releaseName} at ${res.data.html_url}`);

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -477,20 +477,29 @@ async function publishCanaryVersions(
   }
 
   // Third pass: publish only the changed packages using recursive publish
-  let publishSuccess = false;
+  /** @type {Set<string>} */
+  const publishedNames = new Set();
   try {
     console.log(`📤 Publishing ${packagesToPublish.length} canary versions...`);
-    await publishPackages(packagesToPublish, {
+    const publishedPackages = await publishPackages(packagesToPublish, {
       dryRun: options.dryRun,
       noGitChecks: true,
       tag: CANARY_TAG,
     });
 
-    packagesToPublish.forEach((pkg) => {
-      const canaryVersion = canaryVersions.get(pkg.name);
-      console.log(`✅ Published ${pkg.name}@${canaryVersion}`);
-    });
-    publishSuccess = true;
+    for (const pkg of publishedPackages) {
+      publishedNames.add(pkg.name);
+    }
+
+    for (const { name, version } of publishedPackages) {
+      console.log(`✅ Published ${name}@${version}`);
+    }
+
+    const expectedNames = new Set(packagesToPublish.map((pkg) => pkg.name));
+    const missing = [...expectedNames].filter((name) => !publishedNames.has(name));
+    if (missing.length > 0) {
+      console.warn(`⚠️  Some packages were not published: ${missing.join(', ')}`);
+    }
   } finally {
     // Always restore original package.json files in parallel
     console.log('\n🔄 Restoring original package.json files...');
@@ -504,13 +513,14 @@ async function publishCanaryVersions(
     await Promise.all(restorePromises);
   }
 
-  if (publishSuccess) {
+  if (publishedNames.size > 0) {
     // Create/update the canary tag after successful publish
     await createCanaryTag(options.dryRun);
 
     // Create GitHub releases if requested
     if (options.githubRelease) {
-      await createGitHubReleasesForPackages(packagesToPublish, canaryVersions, changelogs, options);
+      const actuallyPublished = packagesToPublish.filter((pkg) => publishedNames.has(pkg.name));
+      await createGitHubReleasesForPackages(actuallyPublished, canaryVersions, changelogs, options);
     }
 
     console.log('\n🎉 All canary versions published successfully!');

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
 import { $ } from 'execa';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -155,10 +156,16 @@ export async function getPackageVersionInfo(packageName, baseVersion) {
 }
 
 /**
+ * @typedef {Object} PublishSummaryEntry
+ * @property {string} name
+ * @property {string} version
+ */
+
+/**
  * Publish packages with the given options
  * @param {PublicPackage[]} packages - Packages to publish
  * @param {PublishOptions} [options={}] - Publishing options
- * @returns {Promise<void>}
+ * @returns {Promise<PublishSummaryEntry[]>}
  */
 export async function publishPackages(packages, options = {}) {
   const args = [];
@@ -178,10 +185,23 @@ export async function publishPackages(packages, options = {}) {
     args.push('--no-git-checks');
   }
 
+  const workspaceDir = await findWorkspaceDir(process.cwd());
+  if (!workspaceDir) {
+    throw new Error('Could not find pnpm workspace root');
+  }
+  const summaryPath = path.join(workspaceDir, 'pnpm-publish-summary.json');
+
+  // Clean up any leftover summary file from a previous run
+  await fs.rm(summaryPath, { force: true });
+
   await $({
     stdio: 'inherit',
     env: { npm_config_loglevel: 'warn' },
-  })`pnpm -r publish --access public --tag=${tag} ${args}`;
+  })`pnpm -r publish --access public --tag=${tag} --report-summary ${args}`;
+
+  const summary = JSON.parse(await fs.readFile(summaryPath, 'utf-8'));
+  await fs.rm(summaryPath, { force: true });
+  return /** @type {PublishSummaryEntry[]} */ (summary.publishedPackages);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes canary publish resilience when individual packages fail to publish (e.g. missing trusted publishing setup on npm).

- Use `--report-summary` in `pnpm -r publish` to detect which packages were actually published
- Only create git tags and GitHub releases for actually published packages
- Only advance the canary tag when **all** expected packages were published, so unpublished packages are retried on the next run
- Handle pre-existing git tags (`git tag -fa` + `--force` push) and GitHub releases (`upsertGitHubRelease`) for retry scenarios
- Bump `@mui/internal-benchmark` to 0.0.2