### PR TITLE
[internal] Add missing author fields

### DIFF
--- a/packages/bundle-size-checker/package.json
+++ b/packages/bundle-size-checker/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mui/internal-bundle-size-checker",
   "version": "1.0.7",
+  "author": "MUI Team",
   "description": "Bundle size checker for MUI packages.",
   "license": "MIT",
   "type": "module",

--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mui/internal-code-infra",
   "version": "0.0.3",
+  "author": "MUI Team",
   "description": "Infra scripts and configs to be used across MUI repos.",
   "license": "MIT",
   "type": "module",

--- a/packages/netlify-cache/package.json
+++ b/packages/netlify-cache/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mui/internal-netlify-cache",
   "version": "0.0.2",
+  "author": "MUI Team",
   "description": "Netlify plugin to cache Next.js output cache for MUI repos.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
The field is arguably not important https://gemini.google.com/share/0ff94fe3cc61, for example https://unpkg.com/react@19.2.5/package.json doesn't have it. However, in absolute terms, it feels clearer, and we have it in most other places already.

We could easily automate this, so we added it as an entry point: #982.