### PR TITLE
[frontend-public] Use scrollbar-gutter instead of overflow-y: scroll

### DIFF
--- a/apps/code-infra-dashboard/src/index.css
+++ b/apps/code-infra-dashboard/src/index.css
@@ -1,4 +1,4 @@
 body {
   /* avoid layout shift when revealing content */
-  overflow-y: scroll;
+  scrollbar-gutter: stable;
 }


### PR DESCRIPTION
## Summary

- Replace `overflow-y: scroll` with `scrollbar-gutter: stable` on the body element to prevent layout shift without forcing a visible scrollbar on short pages