### PR TITLE
[dashboard] Make deploy preview in PR comment opt-in

### DIFF
--- a/apps/code-infra-dashboard/app/api/ci-reports/sync-pr-comment/route.ts
+++ b/apps/code-infra-dashboard/app/api/ci-reports/sync-pr-comment/route.ts
@@ -134,12 +134,14 @@ export async function POST(request: NextRequest) {
           };
         })
       : null,
-    generateDeployPreviewReport(reportOptions).catch((error): ReportResult => {
-      console.error('Failed to generate deploy preview report:', error);
-      return {
-        content: `## Deploy preview\n\n:warning: Failed to generate deploy preview.`,
-      };
-    }),
+    prCommentConfig?.netlifyDocs
+      ? generateDeployPreviewReport(reportOptions).catch((error): ReportResult => {
+          console.error('Failed to generate deploy preview report:', error);
+          return {
+            content: `## Deploy preview\n\n:warning: Failed to generate deploy preview.`,
+          };
+        })
+      : null,
   ]);
 
   const commentSections: Record<string, string> = {};

--- a/apps/code-infra-dashboard/src/lib/ciReports/deployPreviewReport.ts
+++ b/apps/code-infra-dashboard/src/lib/ciReports/deployPreviewReport.ts
@@ -13,7 +13,7 @@ export async function generateDeployPreviewReport(
 
   const rawConfig = repositories.get(repo)?.prComment?.netlifyDocs;
 
-  if (rawConfig === false) {
+  if (!rawConfig) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Gate the deploy preview section behind `prCommentConfig.netlifyDocs`, matching the opt-in pattern used by bundle size and benchmark sections
- Repos without `netlifyDocs` configured (e.g. base-ui) no longer get a spurious "Deploy preview" section in their PR comments