### PR TITLE
[dashboard] Add /api/mui-about endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,6 +210,7 @@ Follow additional instructions when working in the `@mui/internal-docs-infra` (`
 - **7.10** Use streaming APIs when working with large files to reduce memory usage.
 - **7.11** Avoid using regex when string methods can achieve the same result more clearly and efficiently.
 - **7.12** When building skeleton/loading UI, use a single presentational component with a `loading` prop that renders skeletons internally, rather than creating separate skeleton components. This keeps the component API simple and ensures the skeleton matches the actual layout.
+- **7.13** Avoid single-letter variable and parameter names. `e` is banned outright by the `id-denylist` ESLint rule; prefer descriptive names in callbacks too.
 
 ### Dependencies, Debugging & Performance
 

--- a/apps/code-infra-dashboard/app/api/mui-about/route.ts
+++ b/apps/code-infra-dashboard/app/api/mui-about/route.ts
@@ -1,0 +1,175 @@
+import { NextResponse } from 'next/server';
+
+const COUNTRY_FIX: Record<string, string> = {
+  'Macedonia, the former Yugoslav Republic of': 'North Macedonia',
+  'United Kingdom': 'UK',
+  'United States': 'US',
+};
+
+const CITY_FIX: Record<string, string> = {
+  'Greater London': 'London',
+  'New York City': 'New York',
+  'Islamabad Capital Territory': 'Islamabad',
+};
+
+interface HibobEmployee {
+  id: string;
+  displayName: string;
+  address: {
+    country: string;
+    city: string;
+    customColumns?: { column_1738498855264?: string };
+  };
+  work: {
+    title: string;
+    tenureDurationYears: string;
+    custom: { field_1680187492413: string };
+  };
+  about?: {
+    custom?: {
+      field_1682954415714?: string;
+      field_1690557141686?: string;
+    };
+    socialData?: { twitter?: string };
+  };
+}
+
+interface HibobReportEmployee {
+  id: string;
+  humanReadable: {
+    work: { title: string };
+    history: { work?: { title?: { previousValue?: string } } };
+  };
+}
+
+interface AboutPerson {
+  name: string;
+  title: string;
+  about: string | null;
+  location: string;
+  locationCountry: string | null;
+  github: string | null;
+  twitter: string | null;
+}
+
+async function hibobFetch(path: string, token: string, init?: RequestInit) {
+  const res = await fetch(`https://api.hibob.com${path}`, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      Authorization: `Basic ${btoa(`SERVICE-5772:${token}`)}`,
+      ...init?.headers,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`HiBob HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`);
+  }
+  return res.json();
+}
+
+function stripHandle(url: string | undefined, prefix: string): string | null {
+  if (!url) {
+    return null;
+  }
+  return url.replace(prefix, '');
+}
+
+export async function GET() {
+  const token = process.env.HIBOB_TOKEN_READ_STANDARD;
+  if (!token) {
+    return NextResponse.json(
+      { error: 'Env variable HIBOB_TOKEN_READ_STANDARD not configured' },
+      { status: 500 },
+    );
+  }
+
+  const [peopleData, workReport, countries] = await Promise.all([
+    hibobFetch('/v1/people/search', token, {
+      method: 'POST',
+      body: JSON.stringify({
+        showInactive: false,
+        humanReadable: 'REPLACE',
+        fields: [
+          'root.id',
+          'root.displayName',
+          'address.country',
+          'address.city',
+          'address.customColumns.column_1738498855264',
+          'work.custom.field_1680187492413',
+          'work.title',
+          'work.tenureDurationYears',
+          'about.custom.field_1682954415714',
+          'about.custom.field_1690557141686',
+          'about.socialData.twitter',
+        ],
+      }),
+    }) as Promise<{ employees: HibobEmployee[] }>,
+    hibobFetch(
+      '/v1/company/reports/31115981/download?format=json&humanReadable=APPEND',
+      token,
+    ) as Promise<{ employees: HibobReportEmployee[] }>,
+    fetch('https://flagcdn.com/en/codes.json').then((res) => {
+      if (!res.ok) {
+        throw new Error(`flagcdn HTTP ${res.status}`);
+      }
+      return res.json() as Promise<Record<string, string>>;
+    }),
+  ]);
+
+  const previousTitleById = new Map<string, string | undefined>(
+    workReport.employees.map((employee) => [
+      employee.id,
+      employee.humanReadable.history.work?.title?.previousValue,
+    ]),
+  );
+
+  const countryToISO: Record<string, string> = Object.fromEntries(
+    Object.entries(countries).map(([iso, name]) => [name, iso]),
+  );
+  countryToISO['Czech Republic'] = 'cz';
+  countryToISO.US = 'us';
+  countryToISO.UK = 'gb';
+
+  const people: AboutPerson[] = peopleData.employees
+    .sort(
+      (a, b) =>
+        parseFloat(b.work.tenureDurationYears) - parseFloat(a.work.tenureDurationYears),
+    )
+    .map((employee) => {
+      const country = COUNTRY_FIX[employee.address.country] ?? employee.address.country;
+      const city = CITY_FIX[employee.address.city] ?? employee.address.city;
+      const customCity = employee.address.customColumns?.column_1738498855264;
+      const teams = employee.work.custom.field_1680187492413.split(',');
+      let team = teams[0];
+      if (teams.includes('Core')) {
+        team = 'Core';
+      }
+      if (teams.includes('X')) {
+        team = 'X';
+      }
+      if (teams.includes('MUI')) {
+        team = 'MUI';
+      }
+      const location = city === country ? city : `${customCity ?? city}, ${country}`;
+
+      let title = employee.work.title;
+      if (title.startsWith('Acting ')) {
+        title = previousTitleById.get(employee.id) ?? title;
+      }
+
+      return {
+        name: employee.displayName,
+        title: team === 'MUI' ? title : `${title} — ${team}`,
+        about: employee.about?.custom?.field_1690557141686 ?? null,
+        location,
+        locationCountry: countryToISO[country] ?? null,
+        github: stripHandle(employee.about?.custom?.field_1682954415714, 'https://github.com/'),
+        twitter: stripHandle(
+          employee.about?.socialData?.twitter,
+          'https://www.twitter.com/',
+        ),
+      };
+    });
+
+  return NextResponse.json({ people });
+}

--- a/apps/code-infra-dashboard/app/api/mui-about/route.ts
+++ b/apps/code-infra-dashboard/app/api/mui-about/route.ts
@@ -131,10 +131,7 @@ export async function GET() {
   countryToISO.UK = 'gb';
 
   const people: AboutPerson[] = peopleData.employees
-    .sort(
-      (a, b) =>
-        parseFloat(b.work.tenureDurationYears) - parseFloat(a.work.tenureDurationYears),
-    )
+    .sort((a, b) => parseFloat(b.work.tenureDurationYears) - parseFloat(a.work.tenureDurationYears))
     .map((employee) => {
       const country = COUNTRY_FIX[employee.address.country] ?? employee.address.country;
       const city = CITY_FIX[employee.address.city] ?? employee.address.city;
@@ -164,10 +161,7 @@ export async function GET() {
         location,
         locationCountry: countryToISO[country] ?? null,
         github: stripHandle(employee.about?.custom?.field_1682954415714, 'https://github.com/'),
-        twitter: stripHandle(
-          employee.about?.socialData?.twitter,
-          'https://www.twitter.com/',
-        ),
+        twitter: stripHandle(employee.about?.socialData?.twitter, 'https://www.twitter.com/'),
       };
     });
 

--- a/apps/tools-public/toolpad/pages/muicomabout/page.yml
+++ b/apps/tools-public/toolpad/pages/muicomabout/page.yml
@@ -4,52 +4,17 @@ apiVersion: v1
 kind: page
 spec:
   title: mui.com/about
-  display: shell
-  queries:
-    - name: queryAbout
-      query:
-        function: queryAbout.ts#queryAbout
-        kind: local
-  content:
-    - component: DataGrid
-      name: dataGrid
-      layout:
-        columnSize: 1
-        height: 632
-      props:
-        rows:
-          $$jsExpression: |-
-            queryAbout.rows.map((row) => ({
-              ...row,
-              twitter: row.twitter ? `https://x.com/${row.twitter}` : null,
-              github: row.github ? `https://github.com/${row.github}` : null,
-            }))
-        columns:
-          - field: name
-            type: string
-            width: 175
-            headerName: Name
-          - field: title
-            type: string
-            width: 396
-            headerName: Title
-          - field: about
-            type: string
-            width: 472
-            headerName: About
-          - field: location
-            type: string
-            width: 296
-          - field: locationCountry
-            type: string
-            width: 124
-          - field: github
-            type: link
-            width: 258
-          - field: twitter
-            type: link
-            width: 277
-        height: 648
   alias:
     - nSwYn51
   displayName: mui.com/about
+  content:
+    - component: Text
+      name: text
+      layout:
+        columnSize: 1
+      props:
+        mode: markdown
+        value:
+          "This page has moved to the code-infra-dashboard:
+          [mui.com/about](https://code-infra-dashboard.onrender.com/api/mui-about)"
+  display: shell


### PR DESCRIPTION
## Summary

- Ports the Toolpad `queryAbout` resource (`apps/tools-public/toolpad/pages/muicomabout`) into a Next.js route handler at `app/api/mui-about/route.ts` so the mui.com/about data can be served from `code-infra-dashboard`. Used in https://github.com/mui/material-ui/blob/c973a09653bcadfd6a2b4841d8b2ae821e4614ee/docs/scripts/syncTeamMembers.ts#L9
- Parallelizes the three upstream fetches (HiBob people search, HiBob report `31115981`, flagcdn country codes) and adds minimal types for the HiBob payloads instead of `any`.
- Requires `HIBOB_TOKEN_READ_STANDARD` env var; returns 500 if missing.
- Adds AGENTS.md rule 7.13 documenting the `id-denylist` ESLint rule (no single-letter identifiers, `e` is banned).

Preview: https://code-infra-dashboard-pr-1306.onrender.com/api/mui-about