### PR TITLE
[frontend-public] Favor https://frontend-public.mui.com/

### DIFF
--- a/.github/workflows/ci-analytics.yml
+++ b/.github/workflows/ci-analytics.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
           mkdir -p ci-data-ws/ci-reports
-          curl -sf "https://code-infra-dashboard.onrender.com/api/ci-analytics/collect?fresh=true" > "ci-data-ws/ci-reports/${TIMESTAMP}.json"
+          curl -sf "https://frontend-public.mui.com/api/ci-analytics/collect?fresh=true" > "ci-data-ws/ci-reports/${TIMESTAMP}.json"
           cp "ci-data-ws/ci-reports/${TIMESTAMP}.json" ci-data-ws/ci-reports/latest.json
 
           # Update index.json with the new timestamp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Always reference these instructions first and fallback to search or bash command
   - **ALWAYS run the bootstrapping steps first**
   - Build: `pnpm -F code-infra-dashboard run build` -- takes 5 seconds
   - Dev server: `pnpm -F code-infra-dashboard run start` -- runs on http://localhost:3000
-  - Production URL: `https://code-infra-dashboard.onrender.com`
+  - Production URL: `https://frontend-public.mui.com`
   - PR preview URLs follow the pattern: `https://code-infra-dashboard-pr-{number}.onrender.com`
 
 ## Validation

--- a/apps/tools-public/toolpad/pages/muicomabout/page.yml
+++ b/apps/tools-public/toolpad/pages/muicomabout/page.yml
@@ -16,5 +16,5 @@ spec:
         mode: markdown
         value:
           "This page has moved to the code-infra-dashboard:
-          [mui.com/about](https://code-infra-dashboard.onrender.com/api/mui-about)"
+          [mui.com/about](https://frontend-public.mui.com/api/mui-about)"
   display: shell

--- a/packages/benchmark/src/syncPrComment.ts
+++ b/packages/benchmark/src/syncPrComment.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_URL = 'https://code-infra-dashboard.onrender.com';
+const DEFAULT_API_URL = 'https://frontend-public.mui.com';
 
 interface SyncPrCommentResult {
   success: boolean;

--- a/packages/benchmark/src/upload.ts
+++ b/packages/benchmark/src/upload.ts
@@ -8,7 +8,7 @@ async function uploadCiReport(
   benchmarkUploadSchema.parse(report);
 
   const apiUrl =
-    options?.apiUrl ?? process.env.CI_REPORT_API_URL ?? 'https://code-infra-dashboard.onrender.com';
+    options?.apiUrl ?? process.env.CI_REPORT_API_URL ?? 'https://frontend-public.mui.com';
 
   const url = new URL('/api/ci-reports/upload', apiUrl);
 

--- a/packages/bundle-size-checker/src/configLoader.js
+++ b/packages/bundle-size-checker/src/configLoader.js
@@ -81,9 +81,7 @@ export function applyUploadConfigDefaults(uploadConfig, ciInfo) {
   }
 
   const apiUrl =
-    uploadConfig.apiUrl ||
-    process.env.CI_REPORT_API_URL ||
-    'https://code-infra-dashboard.onrender.com';
+    uploadConfig.apiUrl || process.env.CI_REPORT_API_URL || 'https://frontend-public.mui.com';
 
   // Return the normalized config
   /** @type {NormalizedUploadConfig} */

--- a/packages/bundle-size-checker/src/syncPrComment.js
+++ b/packages/bundle-size-checker/src/syncPrComment.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const DEFAULT_API_URL = 'https://code-infra-dashboard.onrender.com';
+const DEFAULT_API_URL = 'https://frontend-public.mui.com';
 
 /**
  * @typedef {{ success: boolean, skipped?: boolean }} SyncPrCommentResult

--- a/packages/bundle-size-checker/src/types.d.ts
+++ b/packages/bundle-size-checker/src/types.d.ts
@@ -3,7 +3,7 @@ export interface UploadConfig {
   repo?: string; // The repository name (e.g., "mui/material-ui")
   branch?: string; // Optional branch name (defaults to current Git branch)
   isPullRequest?: boolean; // Whether this is a pull request build (defaults to CI detection)
-  apiUrl?: string; // Dashboard API URL (defaults to https://code-infra-dashboard.onrender.com)
+  apiUrl?: string; // Dashboard API URL (defaults to https://frontend-public.mui.com)
 }
 
 // Normalized upload configuration where all properties are defined


### PR DESCRIPTION
Make this more portable, so we can move the hosting from Render to Railways without breaking 2-year-old PRs or Notion iframes or Notion docs.