### PR TITLE
[frontend-public] Add margin to the bottom of the page

### DIFF
--- a/apps/code-infra-dashboard/src/index.css
+++ b/apps/code-infra-dashboard/src/index.css
@@ -1,4 +1,4 @@
-body {
+html {
   /* avoid layout shift when revealing content */
   scrollbar-gutter: stable;
 }

--- a/apps/code-infra-dashboard/src/views/Landing.tsx
+++ b/apps/code-infra-dashboard/src/views/Landing.tsx
@@ -77,7 +77,7 @@ const tools: Tool[] = [
 
 export default function Landing() {
   return (
-    <Box sx={{ mt: 4 }}>
+    <Box sx={{ mt: 4, mb: 10 }}>
       <Heading level={1}>MUI Repositories Overview</Heading>
       <Grid container spacing={3} sx={{ mt: 2 }}>
         {[...repositories.values()].map((repo) => (


### PR DESCRIPTION
I was annoyed by Next.js overlay, and the URL overlay 

<img width="355" height="180" alt="SCR-20260416-ccmy" src="https://github.com/user-attachments/assets/71bb77b7-8064-4dcd-a58e-6edf5cb71c56" />
