### PR TITLE
[docs-infra] Fix `currentColor` attribute value

### DIFF
--- a/docs/components/Select/Select.tsx
+++ b/docs/components/Select/Select.tsx
@@ -45,7 +45,7 @@ function ChevronUpDownIcon(props: React.ComponentProps<'svg'>) {
       height="12"
       viewBox="0 0 8 12"
       fill="none"
-      stroke="currentcolor"
+      stroke="currentColor"
       strokeWidth="1.5"
       {...props}
     >
@@ -57,7 +57,7 @@ function ChevronUpDownIcon(props: React.ComponentProps<'svg'>) {
 
 function CheckIcon(props: React.ComponentProps<'svg'>) {
   return (
-    <svg fill="currentcolor" width="10" height="10" viewBox="0 0 10 10" {...props}>
+    <svg fill="currentColor" width="10" height="10" viewBox="0 0 10 10" {...props}>
       <path d="M9.1603 1.12218C9.50684 1.34873 9.60427 1.81354 9.37792 2.16038L5.13603 8.66012C5.01614 8.8438 4.82192 8.96576 4.60451 8.99384C4.3871 9.02194 4.1683 8.95335 4.00574 8.80615L1.24664 6.30769C0.939709 6.02975 0.916013 5.55541 1.19372 5.24822C1.47142 4.94102 1.94536 4.91731 2.2523 5.19524L4.36085 7.10461L8.12299 1.33999C8.34934 0.993152 8.81376 0.895638 9.1603 1.12218Z" />
     </svg>
   );


### PR DESCRIPTION
`currentcolor` is not a valid value.

Source:

<img width="784" height="72" alt="SCR-20260419-bxpg" src="https://github.com/user-attachments/assets/b1fdad27-b70a-4171-8432-32bc2f8e91f3" />

https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/color

---

I see this mistake type all over the place in the codebase, but it can't be solved in this PR.
Can we take care of propagating the changes? Thanks