### PR TITLE
[frontend-public] Add a min range for bundle size auto scale view

### DIFF
--- a/apps/code-infra-dashboard/src/components/DailyBundleSizeChart.tsx
+++ b/apps/code-infra-dashboard/src/components/DailyBundleSizeChart.tsx
@@ -55,6 +55,7 @@ interface DailyBundleSizeChartProps {
 }
 
 type SizeType = 'gzip' | 'parsed';
+const MIN_AUTO_Y_AXIS_RANGE = 1024;
 
 interface ChartData {
   dates: Date[];
@@ -131,6 +132,32 @@ export default function DailyBundleSizeChart({ repo }: DailyBundleSizeChartProps
 
   // Filter series based on selected bundles
   const validSeries = chartData.series.filter((series) => selectedBundles.includes(series.label));
+
+  const autoScaleYAxisLimits = React.useMemo(() => {
+    const values = validSeries.flatMap((series) =>
+      series.data.filter((value): value is number => value !== null),
+    );
+
+    if (values.length === 0) {
+      return {};
+    }
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min;
+
+    if (range >= MIN_AUTO_Y_AXIS_RANGE) {
+      return {};
+    }
+
+    const padding = (MIN_AUTO_Y_AXIS_RANGE - range) / 2;
+    const adjustedMin = Math.max(0, min - padding);
+
+    return {
+      min: adjustedMin,
+      max: adjustedMin + MIN_AUTO_Y_AXIS_RANGE,
+    };
+  }, [validSeries]);
 
   return (
     <Paper elevation={2} sx={{ p: 3 }}>
@@ -237,7 +264,7 @@ export default function DailyBundleSizeChart({ repo }: DailyBundleSizeChartProps
               ]}
               yAxis={[
                 {
-                  ...(yAxisStartAtZero && { min: 0 }),
+                  ...(yAxisStartAtZero ? { min: 0 } : autoScaleYAxisLimits),
                   width: 60,
                   valueFormatter: (value: number) => byteSizeFormatter.format(value),
                 },

--- a/apps/code-infra-dashboard/src/components/DailyBundleSizeChart.tsx
+++ b/apps/code-infra-dashboard/src/components/DailyBundleSizeChart.tsx
@@ -133,32 +133,6 @@ export default function DailyBundleSizeChart({ repo }: DailyBundleSizeChartProps
   // Filter series based on selected bundles
   const validSeries = chartData.series.filter((series) => selectedBundles.includes(series.label));
 
-  const autoScaleYAxisLimits = React.useMemo(() => {
-    const values = validSeries.flatMap((series) =>
-      series.data.filter((value): value is number => value !== null),
-    );
-
-    if (values.length === 0) {
-      return {};
-    }
-
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    const range = max - min;
-
-    if (range >= MIN_AUTO_Y_AXIS_RANGE) {
-      return {};
-    }
-
-    const padding = (MIN_AUTO_Y_AXIS_RANGE - range) / 2;
-    const adjustedMin = Math.max(0, min - padding);
-
-    return {
-      min: adjustedMin,
-      max: adjustedMin + MIN_AUTO_Y_AXIS_RANGE,
-    };
-  }, [validSeries]);
-
   return (
     <Paper elevation={2} sx={{ p: 3 }}>
       <Typography variant="h6" component="h2" gutterBottom>
@@ -264,7 +238,17 @@ export default function DailyBundleSizeChart({ repo }: DailyBundleSizeChartProps
               ]}
               yAxis={[
                 {
-                  ...(yAxisStartAtZero ? { min: 0 } : autoScaleYAxisLimits),
+                  domainLimit: (minValue, maxValue) => {
+                    const dataMin = yAxisStartAtZero ? 0 : Number(minValue);
+                    const dataMax = Number(maxValue);
+                    const deficit = Math.max(0, MIN_AUTO_Y_AXIS_RANGE - (dataMax - dataMin));
+                    const padBelow = yAxisStartAtZero ? 0 : deficit / 2;
+                    const padAbove = deficit - padBelow;
+                    return {
+                      min: Math.max(0, Math.floor((dataMin - padBelow) / 1024) * 1024),
+                      max: Math.ceil((dataMax + padAbove) / 1024) * 1024,
+                    };
+                  },
                   width: 60,
                   valueFormatter: (value: number) => byteSizeFormatter.format(value),
                 },


### PR DESCRIPTION
I was looking at the bundle size evolution of this entry point and saw bug jumps, but in reality, those are marginal, so it feels like we should enforce a minimum y-axis value of 1 KB.

For the implementation, the closest that I could find is https://mui.com/x/react-charts/axis/#relative-axis-subdomain, but it doesn't work as I want to retain the "nice" mode.

## Before: https://frontend-public.mui.com/repository/mui/base-ui/bundle-size

<img width="611" height="537" alt="SCR-20260421-cdpv" src="https://github.com/user-attachments/assets/6b355069-8c81-4004-a753-47487740cbb2" />

## After
<img width="618" height="539" alt="SCR-20260421-cdqq" src="https://github.com/user-attachments/assets/974ddcc9-9de8-4f26-a2f9-ad3d77692883" />

Even for the smallest of all the utils, it seems to still work on this PR:

<img width="687" height="531" alt="SCR-20260421-cixd" src="https://github.com/user-attachments/assets/34eaad72-bb08-45f4-bba0-f78a511f4668" />