### PR TITLE
[code-infra] Replace xmlns no-restricted-syntax entry with autofixable rule

### DIFF
--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -419,6 +419,7 @@ export function createCoreConfig(options = {}) {
         'mui/consistent-production-guard': 'error',
         'mui/add-undef-to-optional': 'off',
         'mui/flatten-parentheses': 'warn',
+        'mui/no-xmlns-on-svg': 'error',
 
         'react-hooks/exhaustive-deps': [
           'error',
@@ -499,15 +500,6 @@ export function createCoreConfig(options = {}) {
           {
             message: 'Do not call `Error(...)` without `new`. Use `new Error(...)` instead.',
             selector: "CallExpression[callee.name='Error']",
-          },
-          {
-            // xmlns="http://www.w3.org/2000/svg" is only needed on standalone .svg files so the
-            // browser treats them as SVG instead of generic XML. Inside HTML the <svg> element is
-            // already recognised by the browser, so the attribute is dead weight.
-            // https://github.com/mui/mui-public/pull/1321
-            message:
-              'Remove xmlns from inline <svg>. The attribute is redundant in HTML and adds unnecessary bytes.',
-            selector: 'JSXOpeningElement[name.name="svg"] > JSXAttribute[name.name="xmlns"]',
           },
           ...restrictedSyntaxRules,
         ],

--- a/packages/code-infra/src/eslint/mui/index.mjs
+++ b/packages/code-infra/src/eslint/mui/index.mjs
@@ -6,6 +6,7 @@ import muiNameMatchesComponentName from './rules/mui-name-matches-component-name
 import noEmptyBox from './rules/no-empty-box.mjs';
 import noRestrictedResolvedImports from './rules/no-restricted-resolved-imports.mjs';
 import noStyledBox from './rules/no-styled-box.mjs';
+import noXmlnsOnSvg from './rules/no-xmlns-on-svg.mjs';
 import requireDevWrapper from './rules/require-dev-wrapper.mjs';
 import rulesOfUseThemeVariants from './rules/rules-of-use-theme-variants.mjs';
 import straightQuotes from './rules/straight-quotes.mjs';
@@ -29,6 +30,7 @@ const muiPlugin = {
     'straight-quotes': straightQuotes,
     'disallow-react-api-in-server-components': disallowReactApiInServerComponents,
     'no-restricted-resolved-imports': noRestrictedResolvedImports,
+    'no-xmlns-on-svg': noXmlnsOnSvg,
     'require-dev-wrapper': requireDevWrapper,
     // Some discrepancies between TypeScript and ESLint types - casting to any
     'add-undef-to-optional': /** @type {any} */ (addUndefToOptional),

--- a/packages/code-infra/src/eslint/mui/rules/no-xmlns-on-svg.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-xmlns-on-svg.mjs
@@ -1,0 +1,40 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+const rule = {
+  meta: {
+    docs: {
+      description: 'Disallow xmlns attribute on inline <svg> elements in JSX.',
+    },
+    messages: {
+      xmlnsOnSvg:
+        'Remove xmlns from inline <svg>. The attribute is redundant in HTML and adds unnecessary bytes.',
+    },
+    type: 'suggestion',
+    fixable: 'code',
+    schema: [],
+  },
+  create(context) {
+    return {
+      // xmlns="http://www.w3.org/2000/svg" is only needed on standalone .svg files so the
+      // browser treats them as SVG instead of generic XML. Inside HTML the <svg> element is
+      // already recognised by the browser, so the attribute is dead weight.
+      // https://github.com/mui/mui-public/pull/1321
+      'JSXOpeningElement[name.name="svg"] > JSXAttribute[name.name="xmlns"]'(
+        /** @type {import('estree-jsx').JSXAttribute} */ node,
+      ) {
+        context.report({
+          node,
+          messageId: 'xmlnsOnSvg',
+          fix(fixer) {
+            const tokenBefore = context.sourceCode.getTokenBefore(node);
+            const start = tokenBefore ? tokenBefore.range[1] : /** @type {[number, number]} */ (node.range)[0];
+            return fixer.removeRange([start, /** @type {[number, number]} */ (node.range)[1]]);
+          },
+        });
+      },
+    };
+  },
+};
+
+export default rule;

--- a/packages/code-infra/src/eslint/mui/rules/no-xmlns-on-svg.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-xmlns-on-svg.mjs
@@ -28,7 +28,9 @@ const rule = {
           messageId: 'xmlnsOnSvg',
           fix(fixer) {
             const tokenBefore = context.sourceCode.getTokenBefore(node);
-            const start = tokenBefore ? tokenBefore.range[1] : /** @type {[number, number]} */ (node.range)[0];
+            const start = tokenBefore
+              ? tokenBefore.range[1]
+              : /** @type {[number, number]} */ (node.range)[0];
             return fixer.removeRange([start, /** @type {[number, number]} */ (node.range)[1]]);
           },
         });

--- a/packages/code-infra/src/eslint/mui/rules/no-xmlns-on-svg.test.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/no-xmlns-on-svg.test.mjs
@@ -1,0 +1,50 @@
+import eslint from 'eslint';
+import parser from '@typescript-eslint/parser';
+import rule from './no-xmlns-on-svg.mjs';
+
+const ruleTester = new eslint.RuleTester({
+  languageOptions: {
+    parser,
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-xmlns-on-svg', rule, {
+  valid: [
+    '<svg width="16" height="16" />',
+    '<svg viewBox="0 0 24 24"><path d="M0 0" /></svg>',
+    // xmlns on non-svg elements is out of scope
+    '<div xmlns="http://www.w3.org/2000/svg" />',
+    // xmlns on a nested element (e.g. foreignObject) is out of scope
+    '<svg><foreignObject xmlns="http://www.w3.org/1999/xhtml" /></svg>',
+  ],
+  invalid: [
+    {
+      code: '<svg xmlns="http://www.w3.org/2000/svg" />',
+      output: '<svg />',
+      errors: [{ messageId: 'xmlnsOnSvg' }],
+    },
+    {
+      code: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" />',
+      output: '<svg width="16" height="16" />',
+      errors: [{ messageId: 'xmlnsOnSvg' }],
+    },
+    {
+      code: '<svg width="16" xmlns="http://www.w3.org/2000/svg" height="16" />',
+      output: '<svg width="16" height="16" />',
+      errors: [{ messageId: 'xmlnsOnSvg' }],
+    },
+    {
+      code: '<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" />',
+      output: '<svg width="16" height="16" />',
+      errors: [{ messageId: 'xmlnsOnSvg' }],
+    },
+    {
+      code: '<svg xmlns="http://www.w3.org/2000/svg"><path d="M0 0" /></svg>',
+      output: '<svg><path d="M0 0" /></svg>',
+      errors: [{ messageId: 'xmlnsOnSvg' }],
+    },
+  ],
+});


### PR DESCRIPTION
Follow-up to #1339. The selector-based `no-restricted-syntax` entry only reports — a proper custom rule lets us attach an autofixer, which makes rolling the change out across consumer codebases more ergonomic. `eslint --fix` now strips the attribute (along with its leading whitespace) instead of requiring manual edits.

In the long run this will also benefit contributors using "format on save" to automatically fix copy+pasted code