### PR TITLE
[code-infra] Add Noise tab to benchmark view

### DIFF
--- a/apps/code-infra-dashboard/src/components/DailyBenchmarkChart.tsx
+++ b/apps/code-infra-dashboard/src/components/DailyBenchmarkChart.tsx
@@ -8,7 +8,6 @@ import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
-import { styled } from '@mui/material/styles';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { useXScale, useDrawingArea } from '@mui/x-charts-pro/hooks';
 import type { BenchmarkReport } from '@/lib/benchmark/types';
@@ -19,19 +18,7 @@ import ErrorDisplay from './ErrorDisplay';
 import { CHART_COLORS } from './chartColors';
 import { BenchmarkComparisonReportView } from './BenchmarkComparisonReportView';
 import NoisiestBenchmarks from './NoisiestBenchmarks';
-
-const ToggleSelectButton = styled(Button)(({ theme }) => ({
-  minWidth: 'auto',
-  padding: 0,
-  fontSize: '0.75rem',
-  textDecoration: 'underline',
-  color: theme.vars.palette.primary.main,
-  textTransform: 'none',
-  '&:disabled': {
-    color: theme.vars.palette.text.secondary,
-    textDecoration: 'none',
-  },
-}));
+import { ToggleSelectButton } from './ToggleSelectButton';
 
 const BASELINE_COLOR = 'var(--mui-palette-info-main)';
 const REPORT_COLOR = 'var(--mui-palette-warning-main)';
@@ -279,10 +266,6 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
     [],
   );
 
-  // `chartData` is ordered oldest → newest. Narrow to a window around the
-  // current selection: both → inclusive range between them, only report →
-  // everything up to the report, only baseline → everything from baseline
-  // onward, neither → all loaded commits.
   const noisiestReports = React.useMemo(() => {
     const baselineIndex = baselineSha
       ? chartData.findIndex((item) => item.commit.sha === baselineSha)
@@ -537,23 +520,21 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
               <Tab value="comparison" label="Comparison" />
               <Tab value="noise" label="Noise" />
             </Tabs>
-            {activeTab === 'comparison' ? (
-              inlinePair ? (
-                <Box>
-                  <Typography variant="subtitle1" gutterBottom>
-                    {inlinePair.baseCommit
-                      ? `Comparing baseline ${inlinePair.baseCommit.sha.substring(0, 7)} → report ${inlinePair.valueCommit.sha.substring(0, 7)}`
-                      : `Report ${inlinePair.valueCommit.sha.substring(0, 7)}`}
-                  </Typography>
-                  <BenchmarkComparisonReportView value={inlinePair.value} base={inlinePair.base} />
-                </Box>
-              ) : (
-                <Typography variant="body2" color="text.secondary">
-                  Select a commit on the chart to see the comparison report.
+            {activeTab === 'noise' && <NoisiestBenchmarks reports={noisiestReports} />}
+            {activeTab === 'comparison' && inlinePair && (
+              <Box>
+                <Typography variant="subtitle1" gutterBottom>
+                  {inlinePair.baseCommit
+                    ? `Comparing baseline ${inlinePair.baseCommit.sha.substring(0, 7)} → report ${inlinePair.valueCommit.sha.substring(0, 7)}`
+                    : `Report ${inlinePair.valueCommit.sha.substring(0, 7)}`}
                 </Typography>
-              )
-            ) : (
-              <NoisiestBenchmarks reports={noisiestReports} />
+                <BenchmarkComparisonReportView value={inlinePair.value} base={inlinePair.base} />
+              </Box>
+            )}
+            {activeTab === 'comparison' && !inlinePair && (
+              <Typography variant="body2" color="text.secondary">
+                Select a commit on the chart to see the comparison report.
+              </Typography>
             )}
           </Box>
         </React.Fragment>

--- a/apps/code-infra-dashboard/src/components/DailyBenchmarkChart.tsx
+++ b/apps/code-infra-dashboard/src/components/DailyBenchmarkChart.tsx
@@ -6,6 +6,8 @@ import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
 import { styled } from '@mui/material/styles';
 import { BarChartPro } from '@mui/x-charts-pro/BarChartPro';
 import { useXScale, useDrawingArea } from '@mui/x-charts-pro/hooks';
@@ -16,6 +18,7 @@ import { useCiReports } from '../hooks/useCiReports';
 import ErrorDisplay from './ErrorDisplay';
 import { CHART_COLORS } from './chartColors';
 import { BenchmarkComparisonReportView } from './BenchmarkComparisonReportView';
+import NoisiestBenchmarks from './NoisiestBenchmarks';
 
 const ToggleSelectButton = styled(Button)(({ theme }) => ({
   minWidth: 'auto',
@@ -118,6 +121,7 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
     baseline: string | null;
   }>({ report: null, baseline: null });
   const { report: reportSha, baseline: baselineSha } = selection;
+  const [activeTab, setActiveTab] = React.useState<'comparison' | 'noise'>('comparison');
 
   const { commits, isLoading, isFetchingNextPage, hasNextPage, error, fetchNextPage } =
     useMasterCommits(repo, { groupByDay: granularity === 'daily' });
@@ -274,6 +278,34 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
     () => setSelection((prev) => ({ ...prev, baseline: null })),
     [],
   );
+
+  // `chartData` is ordered oldest → newest. Narrow to a window around the
+  // current selection: both → inclusive range between them, only report →
+  // everything up to the report, only baseline → everything from baseline
+  // onward, neither → all loaded commits.
+  const noisiestReports = React.useMemo(() => {
+    const baselineIndex = baselineSha
+      ? chartData.findIndex((item) => item.commit.sha === baselineSha)
+      : -1;
+    const reportIndex = reportSha
+      ? chartData.findIndex((item) => item.commit.sha === reportSha)
+      : -1;
+
+    let start = 0;
+    let end = chartData.length;
+    if (baselineIndex >= 0 && reportIndex >= 0) {
+      const [lo, hi] =
+        baselineIndex < reportIndex ? [baselineIndex, reportIndex] : [reportIndex, baselineIndex];
+      start = lo;
+      end = hi + 1;
+    } else if (reportIndex >= 0) {
+      end = reportIndex + 1;
+    } else if (baselineIndex >= 0) {
+      start = baselineIndex;
+    }
+
+    return chartData.slice(start, end).map((item) => item.report);
+  }, [chartData, baselineSha, reportSha]);
 
   const inlinePair = React.useMemo(() => {
     if (!reportData?.report) {
@@ -496,16 +528,34 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
             )}
           </Box>
 
-          {inlinePair && (
-            <Box sx={{ mt: 3 }}>
-              <Typography variant="subtitle1" gutterBottom>
-                {inlinePair.baseCommit
-                  ? `Comparing baseline ${inlinePair.baseCommit.sha.substring(0, 7)} → report ${inlinePair.valueCommit.sha.substring(0, 7)}`
-                  : `Report ${inlinePair.valueCommit.sha.substring(0, 7)}`}
-              </Typography>
-              <BenchmarkComparisonReportView value={inlinePair.value} base={inlinePair.base} />
-            </Box>
-          )}
+          <Box sx={{ mt: 3 }}>
+            <Tabs
+              value={activeTab}
+              onChange={(_event, value: 'comparison' | 'noise') => setActiveTab(value)}
+              sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
+            >
+              <Tab value="comparison" label="Comparison" />
+              <Tab value="noise" label="Noise" />
+            </Tabs>
+            {activeTab === 'comparison' ? (
+              inlinePair ? (
+                <Box>
+                  <Typography variant="subtitle1" gutterBottom>
+                    {inlinePair.baseCommit
+                      ? `Comparing baseline ${inlinePair.baseCommit.sha.substring(0, 7)} → report ${inlinePair.valueCommit.sha.substring(0, 7)}`
+                      : `Report ${inlinePair.valueCommit.sha.substring(0, 7)}`}
+                  </Typography>
+                  <BenchmarkComparisonReportView value={inlinePair.value} base={inlinePair.base} />
+                </Box>
+              ) : (
+                <Typography variant="body2" color="text.secondary">
+                  Select a commit on the chart to see the comparison report.
+                </Typography>
+              )
+            ) : (
+              <NoisiestBenchmarks reports={noisiestReports} />
+            )}
+          </Box>
         </React.Fragment>
       )}
     </Paper>

--- a/apps/code-infra-dashboard/src/components/DailyBenchmarkChart.tsx
+++ b/apps/code-infra-dashboard/src/components/DailyBenchmarkChart.tsx
@@ -14,6 +14,7 @@ import type { BenchmarkReport } from '@/lib/benchmark/types';
 import { formatMs } from '@/utils/formatters';
 import { useMasterCommits, type GitHubCommit } from '../hooks/useMasterCommits';
 import { useCiReports } from '../hooks/useCiReports';
+import { useSearchParamsState } from '../hooks/useSearchParamsState';
 import ErrorDisplay from './ErrorDisplay';
 import { CHART_COLORS } from './chartColors';
 import { BenchmarkComparisonReportView } from './BenchmarkComparisonReportView';
@@ -103,12 +104,17 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
   const [chartMode, setChartMode] = React.useState<ChartMode>('duration');
   const [granularity, setGranularity] = React.useState<Granularity>('perCommit');
   const [showMissing, setShowMissing] = React.useState<boolean>(true);
-  const [selection, setSelection] = React.useState<{
-    report: string | null;
-    baseline: string | null;
-  }>({ report: null, baseline: null });
-  const { report: reportSha, baseline: baselineSha } = selection;
-  const [activeTab, setActiveTab] = React.useState<'comparison' | 'noise'>('comparison');
+  const [params, setParams] = useSearchParamsState(
+    {
+      report: { defaultValue: '' },
+      baseline: { defaultValue: '' },
+      tab: { defaultValue: 'comparison' as 'comparison' | 'noise' },
+    },
+    { replace: true },
+  );
+  const reportSha = params.report || null;
+  const baselineSha = params.baseline || null;
+  const activeTab = params.tab;
 
   const { commits, isLoading, isFetchingNextPage, hasNextPage, error, fetchNextPage } =
     useMasterCommits(repo, { groupByDay: granularity === 'daily' });
@@ -124,10 +130,13 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
     [commits, reports],
   );
 
-  const changeGranularity = React.useCallback((next: Granularity) => {
-    setGranularity(next);
-    setSelection({ report: null, baseline: null });
-  }, []);
+  const changeGranularity = React.useCallback(
+    (next: Granularity) => {
+      setGranularity(next);
+      setParams({ report: '', baseline: '' });
+    },
+    [setParams],
+  );
 
   const allBenchmarks = React.useMemo(() => collectBenchmarkNames(chartData), [chartData]);
 
@@ -228,43 +237,39 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
       // Otherwise: if the click is later than the current report, promote (old report → baseline, click → report).
       // If the click is earlier than the current report (or no report yet), it becomes the baseline,
       // unless there's no report at all — then the click becomes the report.
-      setSelection(({ report, baseline }) => {
+      setParams((prev) => {
+        const report = prev.report || null;
+        const baseline = prev.baseline || null;
         if (clickedSha === report) {
-          return { report: null, baseline };
+          return { report: '' };
         }
         if (clickedSha === baseline) {
-          return { report, baseline: null };
+          return { baseline: '' };
         }
         if (report === null) {
-          return { report: clickedSha, baseline };
+          return { report: clickedSha };
         }
         if (baseline !== null) {
           // Both slots filled: start over with the click as the new report.
-          return { report: clickedSha, baseline: null };
+          return { report: clickedSha, baseline: '' };
         }
         const reportTime = chartData.find((item) => item.commit.sha === report)?.timestamp ?? 0;
         if (clickedTime > reportTime) {
           return { report: clickedSha, baseline: report };
         }
-        return { report, baseline: clickedSha };
+        return { baseline: clickedSha };
       });
     },
-    [visibleChartData, chartData],
+    [visibleChartData, chartData, setParams],
   );
 
   const clearSelection = React.useCallback(
-    () => setSelection({ report: null, baseline: null }),
-    [],
+    () => setParams({ report: '', baseline: '' }),
+    [setParams],
   );
 
-  const clearReport = React.useCallback(
-    () => setSelection((prev) => ({ ...prev, report: null })),
-    [],
-  );
-  const clearBaseline = React.useCallback(
-    () => setSelection((prev) => ({ ...prev, baseline: null })),
-    [],
-  );
+  const clearReport = React.useCallback(() => setParams({ report: '' }), [setParams]);
+  const clearBaseline = React.useCallback(() => setParams({ baseline: '' }), [setParams]);
 
   const noisiestReports = React.useMemo(() => {
     const baselineIndex = baselineSha
@@ -327,8 +332,8 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
               onChange={(_event, newValue) => setUserSelectedBenchmarks(newValue)}
               filterSelectedOptions
               size="small"
-              renderInput={(params) => (
-                <TextField {...params} placeholder="Search and select benchmarks..." />
+              renderInput={(inputParams) => (
+                <TextField {...inputParams} placeholder="Search and select benchmarks..." />
               )}
               sx={{ mb: 1 }}
             />
@@ -514,7 +519,7 @@ export default function DailyBenchmarkChart({ repo }: DailyBenchmarkChartProps) 
           <Box sx={{ mt: 3 }}>
             <Tabs
               value={activeTab}
-              onChange={(_event, value: 'comparison' | 'noise') => setActiveTab(value)}
+              onChange={(_event, value: 'comparison' | 'noise') => setParams({ tab: value })}
               sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}
             >
               <Tab value="comparison" label="Comparison" />

--- a/apps/code-infra-dashboard/src/components/DailyBundleSizeChart.tsx
+++ b/apps/code-infra-dashboard/src/components/DailyBundleSizeChart.tsx
@@ -5,13 +5,13 @@ import Typography from '@mui/material/Typography';
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
-import { styled } from '@mui/material/styles';
 import { LineChart } from '@mui/x-charts-pro/LineChart';
 import { byteSizeFormatter } from './SizeChangeDisplay';
 import { useMasterCommits, type GitHubCommit } from '../hooks/useMasterCommits';
 import { useCiReports } from '../hooks/useCiReports';
 import ErrorDisplay from './ErrorDisplay';
 import { CHART_COLORS } from './chartColors';
+import { ToggleSelectButton } from './ToggleSelectButton';
 
 type SizeSnapshot = Record<string, { parsed: number; gzip: number }>;
 
@@ -20,22 +20,6 @@ interface DailyCommitData {
   commit: GitHubCommit;
   snapshot: SizeSnapshot | null;
 }
-
-/**
- * Styled toggle button for chart controls
- */
-const ToggleSelectButton = styled(Button)(({ theme }) => ({
-  minWidth: 'auto',
-  padding: 0,
-  fontSize: '0.75rem',
-  textDecoration: 'underline',
-  color: theme.vars.palette.primary.main,
-  textTransform: 'none',
-  '&:disabled': {
-    color: theme.vars.palette.text.secondary,
-    textDecoration: 'none',
-  },
-}));
 
 /**
  * Determines if a bundle name represents a top-level package

--- a/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
@@ -10,10 +10,7 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import {
-  computeNoisiestTests,
-  type NoisinessMode,
-} from '@/lib/benchmark/computeNoisiestTests';
+import { computeNoisiestTests, type NoisinessMode } from '@/lib/benchmark/computeNoisiestTests';
 import type { BenchmarkReport } from '@/lib/benchmark/types';
 import { formatMs } from '@/utils/formatters';
 import { ToggleSelectButton } from './ToggleSelectButton';

--- a/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
@@ -84,6 +84,8 @@ export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps)
                   <TableCell align="right">Mean</TableCell>
                   <TableCell align="right">Stdev</TableCell>
                   <TableCell align="right">CV</TableCell>
+                  <TableCell align="right">Max Δ</TableCell>
+                  <TableCell align="right">Max Δ %</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -94,6 +96,10 @@ export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps)
                     <TableCell align="right">{formatMs(row.mean)}</TableCell>
                     <TableCell align="right">{formatMs(row.stdDev)}</TableCell>
                     <TableCell align="right">{cvFormatter.format(row.cv)}</TableCell>
+                    <TableCell align="right">{formatMs(row.maxDiff)}</TableCell>
+                    <TableCell align="right">
+                      {cvFormatter.format(row.maxDiff / row.mean)}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import * as React from 'react';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import { computeNoisiestTests } from '@/lib/benchmark/computeNoisiestTests';
+import { formatMs } from '@/utils/formatters';
+import { useDailyCommits } from '../hooks/useDailyCommits';
+import { useCiReports } from '../hooks/useCiReports';
+
+interface NoisiestBenchmarksProps {
+  repo: string;
+}
+
+const cvFormatter = new Intl.NumberFormat(undefined, {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+export default function NoisiestBenchmarks({ repo }: NoisiestBenchmarksProps) {
+  const { dailyCommits } = useDailyCommits(repo);
+  const { reports } = useCiReports(repo, dailyCommits, 'benchmark.json');
+
+  const rows = React.useMemo(() => {
+    const orderedReports = dailyCommits.map(({ commit }) => reports[commit.sha]?.report ?? null);
+    return computeNoisiestTests(orderedReports);
+  }, [dailyCommits, reports]);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <Paper elevation={2} sx={{ p: 3, mt: 3 }}>
+      <Typography variant="h6" component="h2" gutterBottom>
+        Noisiest tests
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Tests ranked by run-to-run coefficient of variation of duration over the loaded history.
+      </Typography>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Test</TableCell>
+              <TableCell align="right">Runs</TableCell>
+              <TableCell align="right">Mean</TableCell>
+              <TableCell align="right">Stdev</TableCell>
+              <TableCell align="right">CV</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.name}>
+                <TableCell>{row.name}</TableCell>
+                <TableCell align="right">{row.runs}</TableCell>
+                <TableCell align="right">{formatMs(row.mean)}</TableCell>
+                <TableCell align="right">{formatMs(row.stdDev)}</TableCell>
+                <TableCell align="right">{cvFormatter.format(row.cv)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Paper>
+  );
+}

--- a/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
@@ -1,21 +1,39 @@
 'use client';
 
 import * as React from 'react';
-import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
+import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import { computeNoisiestTests } from '@/lib/benchmark/computeNoisiestTests';
+import { styled } from '@mui/material/styles';
+import {
+  computeNoisiestTests,
+  type NoisinessMode,
+} from '@/lib/benchmark/computeNoisiestTests';
+import type { BenchmarkReport } from '@/lib/benchmark/types';
 import { formatMs } from '@/utils/formatters';
-import { useDailyCommits } from '../hooks/useDailyCommits';
-import { useCiReports } from '../hooks/useCiReports';
+
+const ToggleSelectButton = styled(Button)(({ theme }) => ({
+  minWidth: 'auto',
+  padding: 0,
+  fontSize: '0.75rem',
+  textDecoration: 'underline',
+  color: theme.vars.palette.primary.main,
+  textTransform: 'none',
+  '&:disabled': {
+    color: theme.vars.palette.text.secondary,
+    textDecoration: 'none',
+  },
+}));
 
 interface NoisiestBenchmarksProps {
-  repo: string;
+  reports: (BenchmarkReport | null)[];
 }
 
 const cvFormatter = new Intl.NumberFormat(undefined, {
@@ -24,51 +42,93 @@ const cvFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 1,
 });
 
-export default function NoisiestBenchmarks({ repo }: NoisiestBenchmarksProps) {
-  const { dailyCommits } = useDailyCommits(repo);
-  const { reports } = useCiReports(repo, dailyCommits, 'benchmark.json');
+export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps) {
+  const [mode, setMode] = React.useState<NoisinessMode>('totalDuration');
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(10);
+  const rows = React.useMemo(() => computeNoisiestTests(reports, mode), [reports, mode]);
+  const pageRows = React.useMemo(
+    () => rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
+    [rows, page, rowsPerPage],
+  );
 
-  const rows = React.useMemo(() => {
-    const orderedReports = dailyCommits.map(({ commit }) => reports[commit.sha]?.report ?? null);
-    return computeNoisiestTests(orderedReports);
-  }, [dailyCommits, reports]);
-
-  if (rows.length === 0) {
-    return null;
-  }
+  React.useEffect(() => {
+    setPage(0);
+  }, [mode, rows.length]);
 
   return (
-    <Paper elevation={2} sx={{ p: 3, mt: 3 }}>
-      <Typography variant="h6" component="h2" gutterBottom>
-        Noisiest tests
-      </Typography>
+    <Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Tests ranked by run-to-run coefficient of variation of duration over the loaded history.
+        Tests ranked by run-to-run coefficient of variation within the selected range.
       </Typography>
-      <TableContainer>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell>Test</TableCell>
-              <TableCell align="right">Runs</TableCell>
-              <TableCell align="right">Mean</TableCell>
-              <TableCell align="right">Stdev</TableCell>
-              <TableCell align="right">CV</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map((row) => (
-              <TableRow key={row.name}>
-                <TableCell>{row.name}</TableCell>
-                <TableCell align="right">{row.runs}</TableCell>
-                <TableCell align="right">{formatMs(row.mean)}</TableCell>
-                <TableCell align="right">{formatMs(row.stdDev)}</TableCell>
-                <TableCell align="right">{cvFormatter.format(row.cv)}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Paper>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, mb: 2 }}>
+        <Typography variant="caption" color="text.secondary">
+          Granularity:
+        </Typography>
+        <ToggleSelectButton
+          variant="text"
+          size="small"
+          onClick={() => setMode('totalDuration')}
+          disabled={mode === 'totalDuration'}
+        >
+          total duration
+        </ToggleSelectButton>
+        <Typography variant="caption" color="text.secondary">
+          |
+        </Typography>
+        <ToggleSelectButton
+          variant="text"
+          size="small"
+          onClick={() => setMode('perRender')}
+          disabled={mode === 'perRender'}
+        >
+          per render
+        </ToggleSelectButton>
+      </Box>
+      {rows.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          Not enough data to compute noisiness.
+        </Typography>
+      ) : (
+        <React.Fragment>
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Test</TableCell>
+                  <TableCell align="right">Runs</TableCell>
+                  <TableCell align="right">Mean</TableCell>
+                  <TableCell align="right">Stdev</TableCell>
+                  <TableCell align="right">CV</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {pageRows.map((row) => (
+                  <TableRow key={row.name}>
+                    <TableCell>{row.name}</TableCell>
+                    <TableCell align="right">{row.runs}</TableCell>
+                    <TableCell align="right">{formatMs(row.mean)}</TableCell>
+                    <TableCell align="right">{formatMs(row.stdDev)}</TableCell>
+                    <TableCell align="right">{cvFormatter.format(row.cv)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            component="div"
+            count={rows.length}
+            page={page}
+            onPageChange={(_event, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={(event) => {
+              setRowsPerPage(parseInt(event.target.value, 10));
+              setPage(0);
+            }}
+            rowsPerPageOptions={[10, 25, 50, 100]}
+          />
+        </React.Fragment>
+      )}
+    </Box>
   );
 }

--- a/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/components/NoisiestBenchmarks.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -11,26 +10,13 @@ import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import { styled } from '@mui/material/styles';
 import {
   computeNoisiestTests,
   type NoisinessMode,
 } from '@/lib/benchmark/computeNoisiestTests';
 import type { BenchmarkReport } from '@/lib/benchmark/types';
 import { formatMs } from '@/utils/formatters';
-
-const ToggleSelectButton = styled(Button)(({ theme }) => ({
-  minWidth: 'auto',
-  padding: 0,
-  fontSize: '0.75rem',
-  textDecoration: 'underline',
-  color: theme.vars.palette.primary.main,
-  textTransform: 'none',
-  '&:disabled': {
-    color: theme.vars.palette.text.secondary,
-    textDecoration: 'none',
-  },
-}));
+import { ToggleSelectButton } from './ToggleSelectButton';
 
 interface NoisiestBenchmarksProps {
   reports: (BenchmarkReport | null)[];
@@ -47,14 +33,15 @@ export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps)
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(10);
   const rows = React.useMemo(() => computeNoisiestTests(reports, mode), [reports, mode]);
-  const pageRows = React.useMemo(
-    () => rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage),
-    [rows, page, rowsPerPage],
-  );
 
-  React.useEffect(() => {
+  const lastPage = Math.max(0, Math.ceil(rows.length / rowsPerPage) - 1);
+  const safePage = Math.min(page, lastPage);
+  const pageRows = rows.slice(safePage * rowsPerPage, safePage * rowsPerPage + rowsPerPage);
+
+  const changeMode = (next: NoisinessMode) => {
+    setMode(next);
     setPage(0);
-  }, [mode, rows.length]);
+  };
 
   return (
     <Box>
@@ -68,7 +55,7 @@ export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps)
         <ToggleSelectButton
           variant="text"
           size="small"
-          onClick={() => setMode('totalDuration')}
+          onClick={() => changeMode('totalDuration')}
           disabled={mode === 'totalDuration'}
         >
           total duration
@@ -79,7 +66,7 @@ export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps)
         <ToggleSelectButton
           variant="text"
           size="small"
-          onClick={() => setMode('perRender')}
+          onClick={() => changeMode('perRender')}
           disabled={mode === 'perRender'}
         >
           per render
@@ -118,7 +105,7 @@ export default function NoisiestBenchmarks({ reports }: NoisiestBenchmarksProps)
           <TablePagination
             component="div"
             count={rows.length}
-            page={page}
+            page={safePage}
             onPageChange={(_event, newPage) => setPage(newPage)}
             rowsPerPage={rowsPerPage}
             onRowsPerPageChange={(event) => {

--- a/apps/code-infra-dashboard/src/components/ToggleSelectButton.tsx
+++ b/apps/code-infra-dashboard/src/components/ToggleSelectButton.tsx
@@ -1,0 +1,15 @@
+import Button from '@mui/material/Button';
+import { styled } from '@mui/material/styles';
+
+export const ToggleSelectButton = styled(Button)(({ theme }) => ({
+  minWidth: 'auto',
+  padding: 0,
+  fontSize: '0.75rem',
+  textDecoration: 'underline',
+  color: theme.vars.palette.primary.main,
+  textTransform: 'none',
+  '&:disabled': {
+    color: theme.vars.palette.text.secondary,
+    textDecoration: 'none',
+  },
+}));

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
@@ -127,6 +127,18 @@ describe('computeNoisiestTests', () => {
       expect(rows[0].cv).toBeCloseTo(10 / Math.SQRT2 / 15, 5);
     });
 
+    it('reports the largest absolute deviation from the mean', () => {
+      // Mean is 17; deviations are 7, 8, 2, 1 → maxDiff = 8.
+      const reports = buildTotalDurationReports({
+        Widget: [10, 25, 15, 18],
+      });
+
+      const rows = computeNoisiestTests(reports);
+
+      expect(rows[0].mean).toBeCloseTo(17, 5);
+      expect(rows[0].maxDiff).toBeCloseTo(8, 5);
+    });
+
     it('skips tests whose mean is zero', () => {
       const reports = buildTotalDurationReports({
         Zero: [0, 0, 0, 0],

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { computeNoisiestTests } from './computeNoisiestTests';
+import type { BenchmarkReport, RenderStats } from './types';
+
+function makeRender(
+  id: string,
+  actualDuration: number,
+  phase: RenderStats['phase'] = 'mount',
+): RenderStats {
+  return {
+    id,
+    phase,
+    startTime: 0,
+    actualDuration,
+    stdDev: 0,
+    rawMean: actualDuration,
+    rawStdDev: 0,
+    outliers: 0,
+  };
+}
+
+function makeReport(entries: Record<string, RenderStats[]>): BenchmarkReport {
+  const report: BenchmarkReport = {};
+  for (const [name, renders] of Object.entries(entries)) {
+    report[name] = {
+      iterations: 1,
+      totalDuration: 0,
+      renders,
+      metrics: {},
+    };
+  }
+  return report;
+}
+
+function buildReports(
+  series: Record<string, number[]>,
+  phase: RenderStats['phase'] = 'mount',
+): BenchmarkReport[] {
+  const length = Math.max(...Object.values(series).map((values) => values.length));
+  const reports: BenchmarkReport[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const entries: Record<string, RenderStats[]> = {};
+    for (const [key, values] of Object.entries(series)) {
+      const value = values[index];
+      if (value === undefined) {
+        continue;
+      }
+      const [entryName, renderId] = key.split('|');
+      if (!entries[entryName]) {
+        entries[entryName] = [];
+      }
+      entries[entryName].push(makeRender(renderId, value, phase));
+    }
+    reports.push(makeReport(entries));
+  }
+  return reports;
+}
+
+describe('computeNoisiestTests', () => {
+  it('ranks tests by CV descending', () => {
+    const reports = buildReports({
+      'Widget|root': [10, 10.1, 9.9, 10.05], // very stable, CV ~= 0.008
+      'Widget|child': [10, 15, 5, 12], // moderate
+      'Widget|wild': [5, 25, 2, 40], // noisy
+    });
+
+    const rows = computeNoisiestTests(reports);
+
+    expect(rows.map((row) => row.name)).toEqual([
+      'Widget / wild:mount',
+      'Widget / child:mount',
+      'Widget / root:mount',
+    ]);
+    expect(rows[0].cv).toBeGreaterThan(rows[1].cv);
+    expect(rows[1].cv).toBeGreaterThan(rows[2].cv);
+  });
+
+  it('skips tests with fewer than 3 samples', () => {
+    const reports = buildReports({
+      'Widget|short': [10, 20], // skipped
+      'Widget|long': [10, 12, 11, 13],
+    });
+
+    const rows = computeNoisiestTests(reports);
+
+    expect(rows.map((row) => row.name)).toEqual(['Widget / long:mount']);
+  });
+
+  it('skips tests whose mean is zero', () => {
+    const reports = buildReports({
+      'Widget|zero': [0, 0, 0, 0],
+      'Widget|nonzero': [1, 2, 3, 4],
+    });
+
+    const rows = computeNoisiestTests(reports);
+
+    expect(rows.map((row) => row.name)).toEqual(['Widget / nonzero:mount']);
+  });
+
+  it('respects the topN limit', () => {
+    const series: Record<string, number[]> = {};
+    for (let index = 0; index < 5; index += 1) {
+      series[`Widget|item${index}`] = [1, 1 + index, 1, 1 + index];
+    }
+
+    const rows = computeNoisiestTests(buildReports(series), 2);
+
+    expect(rows).toHaveLength(2);
+  });
+
+  it('skips null reports (gaps in the timeline)', () => {
+    const reports: (BenchmarkReport | null)[] = [
+      makeReport({ Widget: [makeRender('root', 10)] }),
+      null,
+      makeReport({ Widget: [makeRender('root', 12)] }),
+      makeReport({ Widget: [makeRender('root', 11)] }),
+    ];
+
+    const rows = computeNoisiestTests(reports);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].runs).toBe(3);
+    expect(rows[0].mean).toBeCloseTo(11, 5);
+  });
+
+  it('breaks ties deterministically by stdDev then name', () => {
+    // Two series with identical CV: the one with higher stdDev wins, then name.
+    const reports = buildReports({
+      'Widget|beta': [10, 20, 30], // mean 20, stdDev 10, CV 0.5
+      'Widget|alpha': [10, 20, 30], // identical
+      'Widget|small': [1, 2, 3], // mean 2, stdDev 1, CV 0.5
+    });
+
+    const rows = computeNoisiestTests(reports);
+
+    expect(rows.map((row) => row.name)).toEqual([
+      'Widget / alpha:mount',
+      'Widget / beta:mount',
+      'Widget / small:mount',
+    ]);
+  });
+
+  it('separates renders with the same id but different phases', () => {
+    const reports: BenchmarkReport[] = [
+      makeReport({
+        Widget: [makeRender('root', 10, 'mount'), makeRender('root', 20, 'update')],
+      }),
+      makeReport({
+        Widget: [makeRender('root', 12, 'mount'), makeRender('root', 30, 'update')],
+      }),
+      makeReport({
+        Widget: [makeRender('root', 11, 'mount'), makeRender('root', 25, 'update')],
+      }),
+    ];
+
+    const rows = computeNoisiestTests(reports);
+
+    expect(rows.map((row) => row.name).sort()).toEqual([
+      'Widget / root:mount',
+      'Widget / root:update',
+    ]);
+  });
+});

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
@@ -179,6 +179,7 @@ describe('computeNoisiestTests', () => {
 
   describe('perRender mode', () => {
     it('keys samples by test, render id and phase', () => {
+      // eslint-disable-next-line testing-library/render-result-naming-convention -- not an RTL render call
       const reports = buildPerRenderReports({
         'Widget|root': [10, 10.1, 9.9, 10.05],
         'Widget|child': [10, 15, 5, 12],

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.test.ts
@@ -19,7 +19,7 @@ function makeRender(
   };
 }
 
-function makeReport(entries: Record<string, RenderStats[]>): BenchmarkReport {
+function makeReportFromRenders(entries: Record<string, RenderStats[]>): BenchmarkReport {
   const report: BenchmarkReport = {};
   for (const [name, renders] of Object.entries(entries)) {
     report[name] = {
@@ -32,7 +32,36 @@ function makeReport(entries: Record<string, RenderStats[]>): BenchmarkReport {
   return report;
 }
 
-function buildReports(
+function makeReportFromTotals(entries: Record<string, number>): BenchmarkReport {
+  const report: BenchmarkReport = {};
+  for (const [name, totalDuration] of Object.entries(entries)) {
+    report[name] = {
+      iterations: 1,
+      totalDuration,
+      renders: [],
+      metrics: {},
+    };
+  }
+  return report;
+}
+
+function buildTotalDurationReports(series: Record<string, number[]>): BenchmarkReport[] {
+  const length = Math.max(...Object.values(series).map((values) => values.length));
+  const reports: BenchmarkReport[] = [];
+  for (let index = 0; index < length; index += 1) {
+    const entries: Record<string, number> = {};
+    for (const [name, values] of Object.entries(series)) {
+      const value = values[index];
+      if (value !== undefined) {
+        entries[name] = value;
+      }
+    }
+    reports.push(makeReportFromTotals(entries));
+  }
+  return reports;
+}
+
+function buildPerRenderReports(
   series: Record<string, number[]>,
   phase: RenderStats['phase'] = 'mount',
 ): BenchmarkReport[] {
@@ -51,113 +80,177 @@ function buildReports(
       }
       entries[entryName].push(makeRender(renderId, value, phase));
     }
-    reports.push(makeReport(entries));
+    reports.push(makeReportFromRenders(entries));
   }
   return reports;
 }
 
 describe('computeNoisiestTests', () => {
-  it('ranks tests by CV descending', () => {
-    const reports = buildReports({
-      'Widget|root': [10, 10.1, 9.9, 10.05], // very stable, CV ~= 0.008
-      'Widget|child': [10, 15, 5, 12], // moderate
-      'Widget|wild': [5, 25, 2, 40], // noisy
+  describe('totalDuration mode (default)', () => {
+    it('ranks tests by CV of totalDuration, descending', () => {
+      const reports = buildTotalDurationReports({
+        Stable: [10, 10.1, 9.9, 10.05],
+        Moderate: [10, 15, 5, 12],
+        Wild: [5, 25, 2, 40],
+      });
+
+      const rows = computeNoisiestTests(reports);
+
+      expect(rows.map((row) => row.name)).toEqual(['Wild', 'Moderate', 'Stable']);
+      expect(rows[0].cv).toBeGreaterThan(rows[1].cv);
+      expect(rows[1].cv).toBeGreaterThan(rows[2].cv);
     });
 
-    const rows = computeNoisiestTests(reports);
+    it('skips tests with fewer than 2 samples', () => {
+      const reports = buildTotalDurationReports({
+        Single: [10],
+        Pair: [10, 20],
+      });
 
-    expect(rows.map((row) => row.name)).toEqual([
-      'Widget / wild:mount',
-      'Widget / child:mount',
-      'Widget / root:mount',
-    ]);
-    expect(rows[0].cv).toBeGreaterThan(rows[1].cv);
-    expect(rows[1].cv).toBeGreaterThan(rows[2].cv);
-  });
+      const rows = computeNoisiestTests(reports);
 
-  it('skips tests with fewer than 3 samples', () => {
-    const reports = buildReports({
-      'Widget|short': [10, 20], // skipped
-      'Widget|long': [10, 12, 11, 13],
+      expect(rows.map((row) => row.name)).toEqual(['Pair']);
     });
 
-    const rows = computeNoisiestTests(reports);
+    it('computes CV from exactly 2 samples', () => {
+      const reports = buildTotalDurationReports({
+        Widget: [10, 20],
+      });
 
-    expect(rows.map((row) => row.name)).toEqual(['Widget / long:mount']);
-  });
+      const rows = computeNoisiestTests(reports);
 
-  it('skips tests whose mean is zero', () => {
-    const reports = buildReports({
-      'Widget|zero': [0, 0, 0, 0],
-      'Widget|nonzero': [1, 2, 3, 4],
+      expect(rows).toHaveLength(1);
+      expect(rows[0].runs).toBe(2);
+      expect(rows[0].mean).toBeCloseTo(15, 5);
+      // Sample stdDev with n-1 divisor: |20-10|/sqrt(2).
+      expect(rows[0].stdDev).toBeCloseTo(10 / Math.SQRT2, 5);
+      expect(rows[0].cv).toBeCloseTo(10 / Math.SQRT2 / 15, 5);
     });
 
-    const rows = computeNoisiestTests(reports);
+    it('skips tests whose mean is zero', () => {
+      const reports = buildTotalDurationReports({
+        Zero: [0, 0, 0, 0],
+        Nonzero: [1, 2, 3, 4],
+      });
 
-    expect(rows.map((row) => row.name)).toEqual(['Widget / nonzero:mount']);
-  });
+      const rows = computeNoisiestTests(reports);
 
-  it('respects the topN limit', () => {
-    const series: Record<string, number[]> = {};
-    for (let index = 0; index < 5; index += 1) {
-      series[`Widget|item${index}`] = [1, 1 + index, 1, 1 + index];
-    }
-
-    const rows = computeNoisiestTests(buildReports(series), 2);
-
-    expect(rows).toHaveLength(2);
-  });
-
-  it('skips null reports (gaps in the timeline)', () => {
-    const reports: (BenchmarkReport | null)[] = [
-      makeReport({ Widget: [makeRender('root', 10)] }),
-      null,
-      makeReport({ Widget: [makeRender('root', 12)] }),
-      makeReport({ Widget: [makeRender('root', 11)] }),
-    ];
-
-    const rows = computeNoisiestTests(reports);
-
-    expect(rows).toHaveLength(1);
-    expect(rows[0].runs).toBe(3);
-    expect(rows[0].mean).toBeCloseTo(11, 5);
-  });
-
-  it('breaks ties deterministically by stdDev then name', () => {
-    // Two series with identical CV: the one with higher stdDev wins, then name.
-    const reports = buildReports({
-      'Widget|beta': [10, 20, 30], // mean 20, stdDev 10, CV 0.5
-      'Widget|alpha': [10, 20, 30], // identical
-      'Widget|small': [1, 2, 3], // mean 2, stdDev 1, CV 0.5
+      expect(rows.map((row) => row.name)).toEqual(['Nonzero']);
     });
 
-    const rows = computeNoisiestTests(reports);
+    it('respects the topN limit', () => {
+      const series: Record<string, number[]> = {};
+      for (let index = 0; index < 5; index += 1) {
+        series[`Test${index}`] = [1, 1 + index, 1, 1 + index];
+      }
 
-    expect(rows.map((row) => row.name)).toEqual([
-      'Widget / alpha:mount',
-      'Widget / beta:mount',
-      'Widget / small:mount',
-    ]);
+      const rows = computeNoisiestTests(buildTotalDurationReports(series), 'totalDuration', 2);
+
+      expect(rows).toHaveLength(2);
+    });
+
+    it('skips null reports (gaps in the timeline)', () => {
+      const reports: (BenchmarkReport | null)[] = [
+        makeReportFromTotals({ Widget: 10 }),
+        null,
+        makeReportFromTotals({ Widget: 12 }),
+        makeReportFromTotals({ Widget: 11 }),
+      ];
+
+      const rows = computeNoisiestTests(reports);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].runs).toBe(3);
+      expect(rows[0].mean).toBeCloseTo(11, 5);
+    });
+
+    it('breaks ties deterministically by stdDev then name', () => {
+      const reports = buildTotalDurationReports({
+        Beta: [10, 20, 30], // mean 20, stdDev 10, CV 0.5
+        Alpha: [10, 20, 30], // identical
+        Small: [1, 2, 3], // mean 2, stdDev 1, CV 0.5
+      });
+
+      const rows = computeNoisiestTests(reports);
+
+      expect(rows.map((row) => row.name)).toEqual(['Alpha', 'Beta', 'Small']);
+    });
   });
 
-  it('separates renders with the same id but different phases', () => {
-    const reports: BenchmarkReport[] = [
-      makeReport({
-        Widget: [makeRender('root', 10, 'mount'), makeRender('root', 20, 'update')],
-      }),
-      makeReport({
-        Widget: [makeRender('root', 12, 'mount'), makeRender('root', 30, 'update')],
-      }),
-      makeReport({
-        Widget: [makeRender('root', 11, 'mount'), makeRender('root', 25, 'update')],
-      }),
-    ];
+  describe('perRender mode', () => {
+    it('keys samples by test, render id and phase', () => {
+      const reports = buildPerRenderReports({
+        'Widget|root': [10, 10.1, 9.9, 10.05],
+        'Widget|child': [10, 15, 5, 12],
+        'Widget|wild': [5, 25, 2, 40],
+      });
 
-    const rows = computeNoisiestTests(reports);
+      const rows = computeNoisiestTests(reports, 'perRender');
 
-    expect(rows.map((row) => row.name).sort()).toEqual([
-      'Widget / root:mount',
-      'Widget / root:update',
-    ]);
+      expect(rows.map((row) => row.name)).toEqual([
+        'Widget / wild:mount',
+        'Widget / child:mount',
+        'Widget / root:mount',
+      ]);
+    });
+
+    it('distinguishes repeated (id, phase) pairs within a test by occurrence order', () => {
+      const reports: BenchmarkReport[] = [
+        makeReportFromRenders({
+          Widget: [
+            makeRender('root', 10, 'mount'),
+            makeRender('root', 20, 'update'),
+            makeRender('root', 30, 'update'),
+          ],
+        }),
+        makeReportFromRenders({
+          Widget: [
+            makeRender('root', 11, 'mount'),
+            makeRender('root', 22, 'update'),
+            makeRender('root', 35, 'update'),
+          ],
+        }),
+        makeReportFromRenders({
+          Widget: [
+            makeRender('root', 12, 'mount'),
+            makeRender('root', 21, 'update'),
+            makeRender('root', 33, 'update'),
+          ],
+        }),
+      ];
+
+      const rows = computeNoisiestTests(reports, 'perRender');
+
+      expect(rows.map((row) => row.name).sort()).toEqual([
+        'Widget / root:mount',
+        'Widget / root:update',
+        'Widget / root:update#2',
+      ]);
+      const firstUpdate = rows.find((row) => row.name === 'Widget / root:update');
+      const secondUpdate = rows.find((row) => row.name === 'Widget / root:update#2');
+      expect(firstUpdate?.mean).toBeCloseTo(21, 5);
+      expect(secondUpdate?.mean).toBeCloseTo((30 + 35 + 33) / 3, 5);
+    });
+
+    it('separates renders with the same id but different phases', () => {
+      const reports: BenchmarkReport[] = [
+        makeReportFromRenders({
+          Widget: [makeRender('root', 10, 'mount'), makeRender('root', 20, 'update')],
+        }),
+        makeReportFromRenders({
+          Widget: [makeRender('root', 12, 'mount'), makeRender('root', 30, 'update')],
+        }),
+        makeReportFromRenders({
+          Widget: [makeRender('root', 11, 'mount'), makeRender('root', 25, 'update')],
+        }),
+      ];
+
+      const rows = computeNoisiestTests(reports, 'perRender');
+
+      expect(rows.map((row) => row.name).sort()).toEqual([
+        'Widget / root:mount',
+        'Widget / root:update',
+      ]);
+    });
   });
 });

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.ts
@@ -8,6 +8,7 @@ export interface NoisyTestRow {
   mean: number;
   stdDev: number;
   cv: number;
+  maxDiff: number;
 }
 
 const MIN_SAMPLES = 2;
@@ -82,12 +83,17 @@ export function computeNoisiestTests(
       continue;
     }
     let squaredDiffSum = 0;
+    let maxDiff = 0;
     for (const sample of samples) {
       const diff = sample - mean;
       squaredDiffSum += diff * diff;
+      const absDiff = Math.abs(diff);
+      if (absDiff > maxDiff) {
+        maxDiff = absDiff;
+      }
     }
     const stdDev = Math.sqrt(squaredDiffSum / (count - 1));
-    rows.push({ name, runs: count, mean, stdDev, cv: stdDev / mean });
+    rows.push({ name, runs: count, mean, stdDev, cv: stdDev / mean, maxDiff });
   }
 
   rows.sort((rowA, rowB) => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.ts
@@ -1,5 +1,7 @@
 import type { BenchmarkReport } from './types';
 
+export type NoisinessMode = 'totalDuration' | 'perRender';
+
 export interface NoisyTestRow {
   name: string;
   runs: number;
@@ -8,34 +10,62 @@ export interface NoisyTestRow {
   cv: number;
 }
 
-const MIN_SAMPLES = 3;
+const MIN_SAMPLES = 2;
 
-/**
- * Rank tests across the provided reports by run-to-run coefficient of variation
- * (stdDev / mean) of `actualDuration`. Returns the top N, highest CV first.
- */
-export function computeNoisiestTests(
+function collectSamples(
   reports: (BenchmarkReport | null)[],
-  topN = 10,
-): NoisyTestRow[] {
+  mode: NoisinessMode,
+): Map<string, number[]> {
   const samplesByKey = new Map<string, number[]>();
-
   for (const report of reports) {
     if (!report) {
       continue;
     }
     for (const [entryName, entry] of Object.entries(report)) {
-      for (const render of entry.renders) {
-        const key = `${entryName} / ${render.id}:${render.phase}`;
-        let samples = samplesByKey.get(key);
+      if (mode === 'totalDuration') {
+        let samples = samplesByKey.get(entryName);
         if (!samples) {
           samples = [];
-          samplesByKey.set(key, samples);
+          samplesByKey.set(entryName, samples);
         }
-        samples.push(render.actualDuration);
+        samples.push(entry.totalDuration);
+      } else {
+        // The same (id, phase) pair can appear multiple times within a test
+        // run (e.g. an update phase fires twice). Track per-entry occurrence
+        // so run N's k-th update is compared against other runs' k-th update,
+        // not pooled together.
+        const occurrences = new Map<string, number>();
+        for (const render of entry.renders) {
+          const baseKey = `${entryName} / ${render.id}:${render.phase}`;
+          const occurrence = occurrences.get(baseKey) ?? 0;
+          occurrences.set(baseKey, occurrence + 1);
+          const key = occurrence === 0 ? baseKey : `${baseKey}#${occurrence + 1}`;
+          let samples = samplesByKey.get(key);
+          if (!samples) {
+            samples = [];
+            samplesByKey.set(key, samples);
+          }
+          samples.push(render.actualDuration);
+        }
       }
     }
   }
+  return samplesByKey;
+}
+
+/**
+ * Rank tests across the provided reports by run-to-run coefficient of variation
+ * (stdDev / mean). In `totalDuration` mode, samples are per-test `totalDuration`.
+ * In `perRender` mode, samples are per-render `actualDuration`, keyed by
+ * `{testName} / {renderId}:{phase}`. Returns all ranked rows by default,
+ * highest CV first; pass `topN` to cap the result.
+ */
+export function computeNoisiestTests(
+  reports: (BenchmarkReport | null)[],
+  mode: NoisinessMode = 'totalDuration',
+  topN = Infinity,
+): NoisyTestRow[] {
+  const samplesByKey = collectSamples(reports, mode);
 
   const rows: NoisyTestRow[] = [];
   for (const [name, samples] of samplesByKey) {

--- a/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/computeNoisiestTests.ts
@@ -1,0 +1,74 @@
+import type { BenchmarkReport } from './types';
+
+export interface NoisyTestRow {
+  name: string;
+  runs: number;
+  mean: number;
+  stdDev: number;
+  cv: number;
+}
+
+const MIN_SAMPLES = 3;
+
+/**
+ * Rank tests across the provided reports by run-to-run coefficient of variation
+ * (stdDev / mean) of `actualDuration`. Returns the top N, highest CV first.
+ */
+export function computeNoisiestTests(
+  reports: (BenchmarkReport | null)[],
+  topN = 10,
+): NoisyTestRow[] {
+  const samplesByKey = new Map<string, number[]>();
+
+  for (const report of reports) {
+    if (!report) {
+      continue;
+    }
+    for (const [entryName, entry] of Object.entries(report)) {
+      for (const render of entry.renders) {
+        const key = `${entryName} / ${render.id}:${render.phase}`;
+        let samples = samplesByKey.get(key);
+        if (!samples) {
+          samples = [];
+          samplesByKey.set(key, samples);
+        }
+        samples.push(render.actualDuration);
+      }
+    }
+  }
+
+  const rows: NoisyTestRow[] = [];
+  for (const [name, samples] of samplesByKey) {
+    if (samples.length < MIN_SAMPLES) {
+      continue;
+    }
+    const count = samples.length;
+    let sum = 0;
+    for (const sample of samples) {
+      sum += sample;
+    }
+    const mean = sum / count;
+    if (mean === 0) {
+      continue;
+    }
+    let squaredDiffSum = 0;
+    for (const sample of samples) {
+      const diff = sample - mean;
+      squaredDiffSum += diff * diff;
+    }
+    const stdDev = Math.sqrt(squaredDiffSum / (count - 1));
+    rows.push({ name, runs: count, mean, stdDev, cv: stdDev / mean });
+  }
+
+  rows.sort((rowA, rowB) => {
+    if (rowB.cv !== rowA.cv) {
+      return rowB.cv - rowA.cv;
+    }
+    if (rowB.stdDev !== rowA.stdDev) {
+      return rowB.stdDev - rowA.stdDev;
+    }
+    return rowA.name.localeCompare(rowB.name);
+  });
+
+  return rows.slice(0, topN);
+}

--- a/apps/code-infra-dashboard/src/views/RepositoryBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/views/RepositoryBenchmarks.tsx
@@ -6,6 +6,7 @@ import Link from '@mui/material/Link';
 import Alert from '@mui/material/Alert';
 import Heading from '../components/Heading';
 import DailyBenchmarkChart from '../components/DailyBenchmarkChart';
+import NoisiestBenchmarks from '../components/NoisiestBenchmarks';
 import { repositories } from '../constants';
 
 export default function RepositoryBenchmarks() {
@@ -38,7 +39,10 @@ export default function RepositoryBenchmarks() {
           API.
         </Alert>
       ) : (
-        <DailyBenchmarkChart repo={fullRepo} />
+        <React.Fragment>
+          <DailyBenchmarkChart repo={fullRepo} />
+          <NoisiestBenchmarks repo={fullRepo} />
+        </React.Fragment>
       )}
     </React.Fragment>
   );

--- a/apps/code-infra-dashboard/src/views/RepositoryBenchmarks.tsx
+++ b/apps/code-infra-dashboard/src/views/RepositoryBenchmarks.tsx
@@ -6,7 +6,6 @@ import Link from '@mui/material/Link';
 import Alert from '@mui/material/Alert';
 import Heading from '../components/Heading';
 import DailyBenchmarkChart from '../components/DailyBenchmarkChart';
-import NoisiestBenchmarks from '../components/NoisiestBenchmarks';
 import { repositories } from '../constants';
 
 export default function RepositoryBenchmarks() {
@@ -39,10 +38,7 @@ export default function RepositoryBenchmarks() {
           API.
         </Alert>
       ) : (
-        <React.Fragment>
-          <DailyBenchmarkChart repo={fullRepo} />
-          <NoisiestBenchmarks repo={fullRepo} />
-        </React.Fragment>
+        <DailyBenchmarkChart repo={fullRepo} />
       )}
     </React.Fragment>
   );


### PR DESCRIPTION
New **Noise** tab below the benchmark chart that ranks tests by run-to-run coefficient of variation across the current selection window (whole history, up to a selected commit, between baseline + report, etc.). Supports per-test *total duration* (default) and *per-render* granularity, with pagination.

Debugging tool to help identify noisy tests and renders.


Example: https://code-infra-dashboard-pr-1341.onrender.com/repository/mui/base-ui/benchmarks?tab=noise&report=3d0be4e37e70d9967dfdbe7955583bfff0e81025&baseline=924e19d6f1e212af587b99cf392f8e39727004bb