### PR TITLE
[docs-infra] Poll for types socket file instead of fs.watch

### DIFF
--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
@@ -9,7 +9,6 @@
  */
 
 import { connect, Socket } from 'node:net';
-import { watch } from 'node:fs';
 import { mkdir, stat } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
@@ -128,7 +127,9 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Wait for the IPC endpoint to become available.
- * On Unix: Watches for the socket file to appear.
+ * On Unix: Polls the filesystem for the socket file to appear. We avoid
+ * `fs.watch` here because on macOS it does not reliably fire events when a
+ * unix domain socket file is created.
  * On Windows: Polls by attempting to connect to the named pipe.
  * @param socketDir - Optional custom directory for socket files (Unix only)
  * @param timeoutMs - Timeout in milliseconds (default: 5000)
@@ -138,55 +139,34 @@ export async function waitForSocketFile(
   timeoutMs: number = 5000,
 ): Promise<void> {
   const socketPath = getSocketPath(socketDir);
+  const pollInterval = 50;
+  const startTime = Date.now();
 
   if (isWindows) {
-    // On Windows, named pipes don't create files - poll by trying to connect
-    const startTime = Date.now();
-    const pollInterval = 100; // ms
-
     while (Date.now() - startTime < timeoutMs) {
       // eslint-disable-next-line no-await-in-loop
       if (await tryConnectToPipe(socketPath)) {
         return;
       }
-
-      // Wait before next poll
       // eslint-disable-next-line no-await-in-loop
       await sleep(pollInterval);
     }
-
     throw new Error(`Named pipe did not become available within ${timeoutMs}ms`);
   }
 
-  // Unix: Check if socket file already exists
-  if (await fileExists(socketPath)) {
-    return;
+  // Ensure the directory exists so the first stat doesn't fail spuriously
+  await mkdir(getEffectiveSocketDir(socketDir), { recursive: true });
+
+  while (Date.now() - startTime < timeoutMs) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await fileExists(socketPath)) {
+      return;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(pollInterval);
   }
 
-  // Ensure the directory exists before watching
-  const dir = getEffectiveSocketDir(socketDir);
-  await mkdir(dir, { recursive: true });
-
-  await new Promise<void>((resolve, reject) => {
-    let timer: NodeJS.Timeout;
-
-    // Watch the directory for the socket file to appear
-    const watcher = watch(dir, (eventType, filename) => {
-      if (
-        filename &&
-        (filename.includes('types.sock') || (isWindows && filename.includes('types')))
-      ) {
-        clearTimeout(timer);
-        watcher.close();
-        resolve();
-      }
-    });
-
-    timer = setTimeout(() => {
-      watcher.close();
-      reject(new Error(`Socket file did not appear within ${timeoutMs}ms`));
-    }, timeoutMs);
-  });
+  throw new Error(`Socket file did not appear within ${timeoutMs}ms`);
 }
 
 // Store the release function globally so we can call it when needed


### PR DESCRIPTION
On macOS, `fs.watch` does not reliably fire events when a unix domain socket file is created. The validate command spawns N worker threads that race for a lock — the winner spawns a nested worker that creates `.next/docs-infra/types.sock`, the losers wait for the file to appear via `fs.watch`. The socket landed within a few ms but no `rename` event for `types.sock` was ever delivered, so every worker timed out at 30s. After the first round of timeouts one worker would re-acquire the lock and the already-listening socket was found via the initial `fileExists` check, which is why exactly N failures were seen regardless of file count.

Replace the Unix `fs.watch` branch in `waitForSocketFile` with the same stat-poll loop already used on Windows. No more platform-specific event blind spot and no watcher-setup race.

Verified locally: `pnpm docs:validate` previously failed with 7 × `Socket file did not appear within 30000ms`; it now completes cleanly (types phase 14s vs. previously 43s with 7 failures).