### PR TITLE
[docs-infra] Fix dataAsString dropping trailing newline at frame boundaries

### DIFF
--- a/docs/app/docs-infra/pipeline/hast-utils/types.md
+++ b/docs/app/docs-infra/pipeline/hast-utils/types.md
@@ -144,6 +144,38 @@ See `decompressHast` for `textContent` semantics.
 type ReturnValue = Promise<string>;
 ```
 
+### getHastTextContent
+
+Extracts all text content from a HAST node recursively.
+
+**Parameters:**
+
+| Parameter | Type                  | Default | Description |
+| :-------- | :-------------------- | :------ | :---------- |
+| node      | `Root \| RootContent` | -       | -           |
+
+**Return Value:**
+
+```tsx
+type ReturnValue = string;
+```
+
+### getShallowTextContent
+
+Gets the direct text content of a HAST element (non-recursive, first level only).
+
+**Parameters:**
+
+| Parameter | Type      | Default | Description |
+| :-------- | :-------- | :------ | :---------- |
+| element   | `Element` | -       | -           |
+
+**Return Value:**
+
+```tsx
+type ReturnValue = string;
+```
+
 ### HastDictionaryMismatchError
 
 Error thrown when the dictionary checksum in a compressed payload does not

--- a/docs/app/docs-infra/pipeline/page.mdx
+++ b/docs/app/docs-infra/pipeline/page.mdx
@@ -313,6 +313,10 @@ The `hastUtils` module provides utilities for converting between HAST (Hypertext
     - Parameters: base64, textContent
   - decompressHastAsync
     - Parameters: base64, textContent
+  - getHastTextContent
+    - Parameters: node
+  - getShallowTextContent
+    - Parameters: element
   - HastDictionaryMismatchError
   - hastOrJsonToJsx
     - Parameters: hastOrJson, components

--- a/packages/docs-infra/src/pipeline/hastUtils/getHastTextContent.ts
+++ b/packages/docs-infra/src/pipeline/hastUtils/getHastTextContent.ts
@@ -1,0 +1,27 @@
+import type { Root as HastRoot, Element, Text, RootContent } from 'hast';
+
+/**
+ * Extracts all text content from a HAST node recursively.
+ */
+export function getHastTextContent(node: HastRoot | Element | Text | RootContent): string {
+  if (node.type === 'text') {
+    return node.value || '';
+  }
+  if ('children' in node && Array.isArray(node.children)) {
+    return node.children.map((child) => getHastTextContent(child as RootContent)).join('');
+  }
+  return '';
+}
+
+/**
+ * Gets the direct text content of a HAST element (non-recursive, first level only).
+ */
+export function getShallowTextContent(element: Element): string {
+  let text = '';
+  for (const child of element.children) {
+    if (child.type === 'text') {
+      text += child.value;
+    }
+  }
+  return text;
+}

--- a/packages/docs-infra/src/pipeline/hastUtils/index.ts
+++ b/packages/docs-infra/src/pipeline/hastUtils/index.ts
@@ -1,3 +1,4 @@
 export * from './hastCompression';
 export * from './hastUtils';
+export { getHastTextContent, getShallowTextContent } from './getHastTextContent';
 export { stripHighlightingSpans } from './stripHighlightingSpans';

--- a/packages/docs-infra/src/pipeline/loadServerTypes/hastTypeUtils.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypes/hastTypeUtils.ts
@@ -6,20 +6,9 @@
  */
 
 import type { Root as HastRoot, Element, Text, RootContent } from 'hast';
-import { compressHast } from '../hastUtils';
+import { compressHast, getHastTextContent, getShallowTextContent } from '../hastUtils';
 
-/**
- * Extracts all text content from a HAST node recursively.
- */
-export function getHastTextContent(node: HastRoot | Element | Text | RootContent): string {
-  if (node.type === 'text') {
-    return node.value || '';
-  }
-  if ('children' in node && Array.isArray(node.children)) {
-    return node.children.map((child) => getHastTextContent(child as RootContent)).join('');
-  }
-  return '';
-}
+export { getHastTextContent, getShallowTextContent };
 
 /**
  * Checks if a HAST element has a specific CSS class.
@@ -34,19 +23,6 @@ export function hasClass(element: Element, className: string): boolean {
     return classes.split(' ').includes(className);
   }
   return false;
-}
-
-/**
- * Gets the direct text content of a HAST element (non-recursive, first level only).
- */
-export function getShallowTextContent(element: Element): string {
-  let text = '';
-  for (const child of element.children) {
-    if (child.type === 'text') {
-      text += child.value;
-    }
-  }
-  return text;
 }
 
 /**

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
@@ -710,6 +710,52 @@ describe('starryNightGutter', () => {
     // Verify frameSize is stored when frames are split
     expect((tree.data as any)?.frameSize).toBe(120);
   });
+
+  // Regression: dataAsString must contain the same text the frame's HAST
+  // would render, including the trailing newline at every frame boundary.
+  // Previously this was computed via sourceLines.slice(start, end).join('\n'),
+  // which dropped one trailing '\n' per frame and caused a layout shift when
+  // the lazy-hydrated `<Pre>` swapped between plain and highlighted renders.
+  it('dataAsString should match the frame HAST text content exactly', () => {
+    // Build source with a blank line at a frame boundary: frame 1 ends on the
+    // 3rd line which is blank, frame 2 begins afterwards.
+    const lines = ['a', 'b', '', 'c', 'd'];
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'text', value: lines.join('\n') }],
+    };
+
+    starryNightGutter(tree, lines, 3);
+
+    expect(tree.children).toHaveLength(2);
+
+    const textFromHast = (frame: any): string => {
+      const out: string[] = [];
+      const walk = (nodes: any[]) => {
+        for (const n of nodes) {
+          if (n.type === 'text') out.push(n.value);
+          else if (n.type === 'element' && n.children) walk(n.children);
+        }
+      };
+      walk(frame.children);
+      return out.join('');
+    };
+
+    for (const frame of tree.children) {
+      expect(frame.type).toBe('element');
+      if (frame.type !== 'element') continue;
+      const expected = textFromHast(frame);
+      expect(frame.properties?.dataAsString).toBe(expected);
+    }
+
+    // And specifically: the frame that ends on a blank line must end with
+    // two trailing newlines (one separator, one for the blank-line span),
+    // matching what the highlighted render produces.
+    const firstFrame = tree.children[0];
+    if (firstFrame.type === 'element') {
+      expect(firstFrame.properties?.dataAsString).toBe('a\nb\n\n');
+    }
+  });
 });
 
 describe('countLines', () => {

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
@@ -729,31 +729,17 @@ describe('starryNightGutter', () => {
 
     expect(tree.children).toHaveLength(2);
 
-    const textFromHast = (frame: any): string => {
-      const out: string[] = [];
-      const walk = (nodes: any[]) => {
-        for (const n of nodes) {
-          if (n.type === 'text') out.push(n.value);
-          else if (n.type === 'element' && n.children) walk(n.children);
-        }
-      };
-      walk(frame.children);
-      return out.join('');
-    };
-
-    for (const frame of tree.children) {
-      expect(frame.type).toBe('element');
-      if (frame.type !== 'element') continue;
-      const expected = textFromHast(frame);
-      expect(frame.properties?.dataAsString).toBe(expected);
-    }
-
-    // And specifically: the frame that ends on a blank line must end with
-    // two trailing newlines (one separator, one for the blank-line span),
-    // matching what the highlighted render produces.
-    const firstFrame = tree.children[0];
+    // Frame 1 ends on a blank line, so its text must end with two trailing
+    // newlines (one separator, one for the blank-line span) — matching what
+    // the highlighted render produces.
+    const [firstFrame, secondFrame] = tree.children;
+    expect(firstFrame.type).toBe('element');
+    expect(secondFrame.type).toBe('element');
     if (firstFrame.type === 'element') {
       expect(firstFrame.properties?.dataAsString).toBe('a\nb\n\n');
+    }
+    if (secondFrame.type === 'element') {
+      expect(secondFrame.properties?.dataAsString).toBe('c\nd');
     }
   });
 });

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
@@ -2,6 +2,7 @@
 
 import type { Element, ElementContent, RootContent, Root } from 'hast';
 import { createFrame } from './createFrame';
+import { getHastTextContent } from '../hastUtils';
 
 /**
  * Counts the number of lines in a HAST tree without mutating it.
@@ -157,18 +158,7 @@ export function starryNightGutter(
           (c) => c.type === 'element' && c.properties?.className === 'line',
         );
         if (hasLine) {
-          const parts: string[] = [];
-          const walk = (nodes: Array<ElementContent>) => {
-            for (const n of nodes) {
-              if (n.type === 'text') {
-                parts.push(n.value);
-              } else if (n.type === 'element' && n.children) {
-                walk(n.children as Array<ElementContent>);
-              }
-            }
-          };
-          walk(frame.children as Array<ElementContent>);
-          frame.properties.dataAsString = parts.join('');
+          frame.properties.dataAsString = getHastTextContent(frame);
         }
       }
     }

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
@@ -137,7 +137,15 @@ export function starryNightGutter(
     replacement.push(createFrame(frameLines));
   }
 
-  // If there are multiple frames and sourceLines provided, add dataAsString to each frame
+  // If there are multiple frames and sourceLines provided, add dataAsString to each frame.
+  // Derive the text from the frame's own HAST children rather than from
+  // sourceLines.join('\n'). The latter produces N-1 separator newlines for N
+  // lines, but the frame's HAST carries N newlines worth of content (non-blank
+  // lines are followed by a separator text node, blank lines carry the newline
+  // inside the `.line` span). Using sourceLines.join('\n') drops exactly one
+  // trailing '\n' per frame relative to the highlighted render, which causes
+  // a layout shift during lazy hydration when a frame toggles between its
+  // plain-text fallback and its highlighted output.
   if (replacement.length > 1 && sourceLines) {
     for (const frame of replacement) {
       if (
@@ -145,17 +153,22 @@ export function starryNightGutter(
         frame.tagName === 'span' &&
         frame.properties?.className === 'frame'
       ) {
-        // Extract line range from child .line elements
-        const lineChildren = frame.children.filter(
-          (c): c is Element =>
-            c.type === 'element' &&
-            c.properties?.className === 'line' &&
-            typeof c.properties.dataLn === 'number',
+        const hasLine = frame.children.some(
+          (c) => c.type === 'element' && c.properties?.className === 'line',
         );
-        if (lineChildren.length > 0) {
-          const startLine = Number(lineChildren[0].properties.dataLn) - 1;
-          const endLine = Number(lineChildren[lineChildren.length - 1].properties.dataLn);
-          frame.properties.dataAsString = sourceLines.slice(startLine, endLine).join('\n');
+        if (hasLine) {
+          const parts: string[] = [];
+          const walk = (nodes: Array<ElementContent>) => {
+            for (const n of nodes) {
+              if (n.type === 'text') {
+                parts.push(n.value);
+              } else if (n.type === 'element' && n.children) {
+                walk(n.children as Array<ElementContent>);
+              }
+            }
+          };
+          walk(frame.children as Array<ElementContent>);
+          frame.properties.dataAsString = parts.join('');
         }
       }
     }

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
@@ -2,7 +2,6 @@
 
 import type { Element, ElementContent, RootContent, Root } from 'hast';
 import { createFrame } from './createFrame';
-import { getHastTextContent } from '../hastUtils';
 
 /**
  * Counts the number of lines in a HAST tree without mutating it.
@@ -139,26 +138,34 @@ export function starryNightGutter(
   }
 
   // If there are multiple frames and sourceLines provided, add dataAsString to each frame.
-  // Derive the text from the frame's own HAST children rather than from
-  // sourceLines.join('\n'). The latter produces N-1 separator newlines for N
-  // lines, but the frame's HAST carries N newlines worth of content (non-blank
-  // lines are followed by a separator text node, blank lines carry the newline
-  // inside the `.line` span). Using sourceLines.join('\n') drops exactly one
-  // trailing '\n' per frame relative to the highlighted render, which causes
-  // a layout shift during lazy hydration when a frame toggles between its
-  // plain-text fallback and its highlighted output.
+  // Every frame except the last covers `frameSize` source lines, each of which
+  // was followed by a newline separator in the original source, so its text
+  // ends with a trailing '\n'. The final frame only carries a trailing newline
+  // if the source itself ends with one. Without this trailing '\n', the
+  // plain-text fallback and the highlighted render disagree by exactly one
+  // newline per non-final frame, which causes a layout shift during lazy
+  // hydration when a frame toggles between the two.
   if (replacement.length > 1 && sourceLines) {
-    for (const frame of replacement) {
+    const lastIndex = replacement.length - 1;
+    for (let frameIndex = 0; frameIndex < replacement.length; frameIndex += 1) {
+      const frame = replacement[frameIndex];
       if (
         frame.type === 'element' &&
         frame.tagName === 'span' &&
         frame.properties?.className === 'frame'
       ) {
-        const hasLine = frame.children.some(
-          (c) => c.type === 'element' && c.properties?.className === 'line',
+        // Extract line range from child .line elements
+        const lineChildren = frame.children.filter(
+          (c): c is Element =>
+            c.type === 'element' &&
+            c.properties?.className === 'line' &&
+            typeof c.properties.dataLn === 'number',
         );
-        if (hasLine) {
-          frame.properties.dataAsString = getHastTextContent(frame);
+        if (lineChildren.length > 0) {
+          const startLine = Number(lineChildren[0].properties.dataLn) - 1;
+          const endLine = Number(lineChildren[lineChildren.length - 1].properties.dataLn);
+          const joined = sourceLines.slice(startLine, endLine).join('\n');
+          frame.properties.dataAsString = frameIndex < lastIndex ? `${joined}\n` : joined;
         }
       }
     }

--- a/packages/docs-infra/src/pipeline/transformHtmlCodeInline/transformHtmlCodeInline.ts
+++ b/packages/docs-infra/src/pipeline/transformHtmlCodeInline/transformHtmlCodeInline.ts
@@ -3,6 +3,7 @@ import type { Root as HastRoot, Element } from 'hast';
 import { visit } from 'unist-util-visit';
 import { grammars, extensionMap } from '../parseSource/grammars';
 import { extendSyntaxTokens } from '../parseSource/extendSyntaxTokens';
+import { getHastTextContent } from '../hastUtils';
 import { removePrefixFromHighlightedNodes } from './removePrefixFromHighlightedNodes';
 
 type StarryNight = Awaited<ReturnType<typeof createStarryNight>>;
@@ -69,21 +70,7 @@ export default function transformHtmlCodeInline(options: TransformHtmlCodeInline
       }
 
       // Extract all text content from children (handles multiple text nodes and newlines)
-      const getTextContent = (children: typeof node.children): string => {
-        return children
-          .map((child) => {
-            if (child.type === 'text') {
-              return child.value;
-            }
-            if (child.type === 'element' && 'children' in child) {
-              return getTextContent(child.children);
-            }
-            return '';
-          })
-          .join('');
-      };
-
-      const source = getTextContent(node.children);
+      const source = node.children.map((child) => getHastTextContent(child)).join('');
       if (!source) {
         return;
       }


### PR DESCRIPTION
`sourceLines.slice(start, end).join('\n')` produces N−1 separator newlines for N lines, but the frame's HAST carries N (non-blank lines have a separator `\n` text node; blank lines carry the `\n` inside the `.line` span). `dataAsString` was one `\n` short of the highlighted render, causing CLS when `<Pre>` swapped between the plain-text fallback and highlighted output — a full line-height shift for frames ending on a blank source line.

Compute `dataAsString` by walking the frame's HAST children instead, guaranteeing parity with the highlighted render. This was causing non-zero CLS on some use-cases.

Regression test added; fails on `master`, passes here.


https://github.com/user-attachments/assets/e7d7749c-75ad-4baa-a786-e6ec58b07254

