### PR TITLE
[code-infra] Fix changelog generation blank space

### DIFF
--- a/packages/code-infra/src/changelog/renderChangelog.mjs
+++ b/packages/code-infra/src/changelog/renderChangelog.mjs
@@ -438,7 +438,7 @@ function renderContributors(contributors, config, lines) {
     const template = getTemplateString(
       config.contributors?.message?.contributors,
       allContributors.length,
-      `${allContributors.length !== 1 ? 'All contributors of this release in alphabetical order' : 'Contributor of this release'} : {{contributors}}`,
+      `${allContributors.length !== 1 ? 'All contributors of this release in alphabetical order' : 'Contributor of this release'}: {{contributors}}`,
     );
     const contributorsMessage = templateString(template, {
       contributors: renderContributorsList(allContributors),


### PR DESCRIPTION
The issue:

<img width="1149" height="400" alt="SCR-20260429-bqdm" src="https://github.com/user-attachments/assets/b2cbb95a-68c7-45ad-bc2c-973f2165d12f" />

https://github.com/mui/base-ui/releases

The issue seems to have started with #1023. The first release of Base UI impacted by those changes was v1.2.0 https://github.com/mui/base-ui/releases/tag/v1.2.0.

I have already fixed the previous releases of Base UI: https://github.com/mui/base-ui/commit/921c8e3daef42d0ba9ef6af3f7aea3ad2c0e09df but we need to fix it for the future releases as well.