### PR TITLE
[code-infra] Update test to be closer to real life

### DIFF
--- a/packages/code-infra/src/changelog/categorizeCommits.test.ts
+++ b/packages/code-infra/src/changelog/categorizeCommits.test.ts
@@ -84,15 +84,15 @@ describe('categorizeCommits', () => {
         labels: {
           ...baseLabelConfig,
           categoryOverrides: {
-            'all components': 'General changes',
+            'scope: all components': 'General changes',
           },
         },
       };
 
       const commits = [
-        createCommit(1, ['component: Button', 'all components']),
+        createCommit(1, ['component: Button', 'scope: all components']),
         createCommit(2, ['component: Checkbox']),
-        createCommit(3, ['component: Button', 'all components']),
+        createCommit(3, ['component: Button', 'scope: all components']),
       ];
 
       const result = categorizeCommits(commits, configWithOverrides);
@@ -229,13 +229,13 @@ describe('categorizeCommits', () => {
         labels: {
           ...baseLabelConfig,
           categoryOverrides: {
-            'all packages': 'General changes',
+            'scope: all components': 'General changes',
           },
         },
       };
 
       const commits = [
-        createCommit(1, ['scope: data grid', 'all packages']),
+        createCommit(1, ['scope: data grid', 'scope: all components']),
         createCommit(2, ['scope: charts']),
       ];
 

--- a/packages/code-infra/src/changelog/parseCommitLabels.test.ts
+++ b/packages/code-infra/src/changelog/parseCommitLabels.test.ts
@@ -210,11 +210,11 @@ describe('parseCommitLabels', () => {
 
   describe('category overrides', () => {
     it('should detect category override labels', () => {
-      const commit = createCommit({ labels: ['all components'] });
+      const commit = createCommit({ labels: ['scope: all components'] });
       const config: LabelConfig = {
         ...baseLabelConfig,
         categoryOverrides: {
-          'all components': 'General changes',
+          'scope: all components': 'General changes',
         },
       };
 
@@ -224,11 +224,11 @@ describe('parseCommitLabels', () => {
     });
 
     it('should use the last category override when multiple are present', () => {
-      const commit = createCommit({ labels: ['all components', 'docs'] });
+      const commit = createCommit({ labels: ['scope: all components', 'docs'] });
       const config: LabelConfig = {
         ...baseLabelConfig,
         categoryOverrides: {
-          'all components': 'General changes',
+          'scope: all components': 'General changes',
           docs: 'Documentation',
         },
       };
@@ -243,7 +243,7 @@ describe('parseCommitLabels', () => {
       const config: LabelConfig = {
         ...baseLabelConfig,
         categoryOverrides: {
-          'all components': 'General changes',
+          'scope: all components': 'General changes',
         },
       };
 


### PR DESCRIPTION
Test updated to use real production labels: https://github.com/mui/.github/labels?q=all.

---

We could almost make this a default built-in, as there is no reason for different repositories to rename this label. But that's another discussion, off topic.