### PR TITLE
[code-infra] Cache vale binary in circle ci if present

### DIFF
--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -117,8 +117,18 @@ commands:
     description: 'Runs Vale linter on the codebase'
     steps:
       - run:
+          name: Extract Vale version
+          command: node -p "(require('./package.json').config && require('./package.json').config.valeVersion) || ''" > .vale-version
+      - restore_cache:
+          keys:
+            - mui-vale-{{ checksum ".vale-version" }}
+      - run:
           name: Lint writing style
           command: pnpm valelint
+      - save_cache:
+          paths:
+            - node_modules/.cache/mui-vale
+          key: mui-vale-{{ checksum ".vale-version" }}
 
   upload-coverage:
     description: 'Uploads code coverage to Codecov'

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -82,9 +82,6 @@ commands:
   eslint:
     description: 'Runs ESLint on the codebase'
     steps:
-      - run:
-          name: Build docs-infra for ESLint plugins
-          command: pnpm run docs:lib
       - restore_cache:
           keys:
             - eslint-cache-{{ checksum "pnpm-lock.yaml" }}

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -66,6 +66,15 @@
       "depNameTemplate": "code-infra-playwright",
       "packageNameTemplate": "mcr.microsoft.com/playwright",
       "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Custom manager for Vale version pinned in package.json config.valeVersion",
+      "customType": "regex",
+      "fileMatch": ["(^|/)package\\.json$"],
+      "matchStrings": ["\"valeVersion\"\\s*:\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "vale-cli/vale",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
The assumption here is that the workspace `package.json` will have the vale version -

```
"config": {
  "valeVersion": "3.14.1"
},
```