### PR TITLE
[code-infra] Rely on github-digest to update GitHub Actions to master

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -45,6 +45,6 @@ jobs:
       - run: pnpm install
       - run: pnpm release:build
       - name: Publish packages to pkg.pr.new
-        uses: mui/mui-public/.github/actions/ci-publish@7a22b0596a1d3e23de0ca7ec25d5603895b66c5e
+        uses: mui/mui-public/.github/actions/ci-publish@7a22b0596a1d3e23de0ca7ec25d5603895b66c5e # master
         with:
           pr-comment: ${{ inputs.pr-comment }}

--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -18,4 +18,4 @@ jobs:
       issues: write
       actions: write
     name: Handle status labels
-    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@7a22b0596a1d3e23de0ca7ec25d5603895b66c5e
+    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@7a22b0596a1d3e23de0ca7ec25d5603895b66c5e # master

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -16,4 +16,4 @@ jobs:
       issues: write
       pull-requests: write
     name: Handle stale issues and PRs
-    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@7a22b0596a1d3e23de0ca7ec25d5603895b66c5e
+    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@7a22b0596a1d3e23de0ca7ec25d5603895b66c5e # master

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -43,19 +43,6 @@
       "datasourceTemplate": "git-refs"
     },
     {
-      "description": "Custom manager for MUI public reusable workflow digests",
-      "customType": "regex",
-      "fileMatch": ["(^|\\/)?\\.github\\/.+\\.ya?ml$"],
-      "matchStrings": [
-        // For GitHub Actions reusable workflows and actions
-        "mui\\\/mui-public\\\/\\.github\\\/[\\w\\/.@-]+@(?<currentDigest>[\\w]+)"
-      ],
-      "currentValueTemplate": "master",
-      "depNameTemplate": "code-infra-gh-actions",
-      "packageNameTemplate": "https://github.com/mui/mui-public",
-      "datasourceTemplate": "git-refs"
-    },
-    {
       "description": "Custom manager for Playwright Docker image versions",
       "customType": "regex",
       "fileMatch": ["(^|\\\/)\\.circleci\\\/.+\\.ya?ml$"],


### PR DESCRIPTION
https://github.com/mui/mui-public/pull/1102/changes#r2798995735 fixed issues like https://github.com/mui/base-ui/security/code-scanning/33, great.

But since https://github.com/renovatebot/renovate/pull/40225 was merged, it looks like it's no longer needed. 
The only downside is that we need to go to the other repositories and add the ` # master` comment but that seems clearer (less magic).

---

While I was at it, I enabled all of those: https://www.notion.so/mui-org/Configuration-of-the-repositories-306cbfe7b6608047ba91e4c7a7bff846?source=copy_link#351cbfe7b66080019b65d3139f3d43ca. 
