### PR TITLE
[code-infra] Always enforce consistent-type-imports

### DIFF
--- a/apps/code-infra-dashboard/app/api/ci-analytics/collect/route.ts
+++ b/apps/code-infra-dashboard/app/api/ci-analytics/collect/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 import { unstable_cache } from 'next/cache';
 import { collectCiSnapshot } from '../../../../src/lib/collectCiMetrics';
 

--- a/apps/code-infra-dashboard/app/api/ci-reports/sync-pr-comment/route.ts
+++ b/apps/code-infra-dashboard/app/api/ci-reports/sync-pr-comment/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { verifyOidcToken } from '@/lib/ciReports/oidcAuth';
 import { findAssociatedPr } from '@/lib/ciReports/findAssociatedPr';

--- a/apps/code-infra-dashboard/app/api/ci-reports/upload/route.ts
+++ b/apps/code-infra-dashboard/app/api/ci-reports/upload/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { uploadReport } from '@/lib/ciReports/s3';
 import { verifyOidcToken } from '@/lib/ciReports/oidcAuth';

--- a/apps/code-infra-dashboard/app/api/npm-downloads/route.ts
+++ b/apps/code-infra-dashboard/app/api/npm-downloads/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;

--- a/apps/code-infra-dashboard/src/components/Heading.tsx
+++ b/apps/code-infra-dashboard/src/components/Heading.tsx
@@ -4,7 +4,7 @@ import Link from '@mui/material/Link';
 import IconButton from '@mui/material/IconButton';
 import LinkIcon from '@mui/icons-material/Link';
 import Box from '@mui/material/Box';
-import { SxProps } from '@mui/material/styles';
+import { type SxProps } from '@mui/material/styles';
 
 interface HeadingProps {
   id?: string;

--- a/apps/code-infra-dashboard/src/components/LineWithHitArea.tsx
+++ b/apps/code-infra-dashboard/src/components/LineWithHitArea.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AnimatedLineProps } from '@mui/x-charts-pro';
+import { type AnimatedLineProps } from '@mui/x-charts-pro';
 
 /**
  * A line chart path component with an extended invisible hit area for easier hover interaction.

--- a/apps/code-infra-dashboard/src/components/NpmDownloadsChart.tsx
+++ b/apps/code-infra-dashboard/src/components/NpmDownloadsChart.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import Link from 'next/link';
-import { UseQueryResult } from '@tanstack/react-query';
+import { type UseQueryResult } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Card from '@mui/material/Card';
@@ -26,14 +26,22 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import AnchorIcon from '@mui/icons-material/Anchor';
 import CloseIcon from '@mui/icons-material/Close';
-import { AxisValueFormatterContext, HighlightItemIdentifier, ZoomData } from '@mui/x-charts-pro';
+import {
+  type AxisValueFormatterContext,
+  type HighlightItemIdentifier,
+  type ZoomData,
+} from '@mui/x-charts-pro';
 import { LineChartPro } from '@mui/x-charts-pro/LineChartPro';
 import { DateRangePicker } from '@mui/x-date-pickers-pro/DateRangePicker';
-import { DateRange } from '@mui/x-date-pickers-pro/models';
-import { PickersShortcutsItem } from '@mui/x-date-pickers-pro';
-import dayjs, { Dayjs } from 'dayjs';
+import { type DateRange } from '@mui/x-date-pickers-pro/models';
+import { type PickersShortcutsItem } from '@mui/x-date-pickers-pro';
+import dayjs, { type Dayjs } from 'dayjs';
 import { useEventCallback } from '@mui/material/utils';
-import { NpmDownloadsData, processDownloadsData, AggregationPeriod } from '../lib/npmDownloads';
+import {
+  type NpmDownloadsData,
+  processDownloadsData,
+  type AggregationPeriod,
+} from '../lib/npmDownloads';
 import { NpmDownloadsLink } from './NpmDownloadsLink';
 import { HoverStoreProvider, useHoverStore, useHoveredIndex } from './hoverStore';
 import { LineWithHitArea } from './LineWithHitArea';

--- a/apps/code-infra-dashboard/src/components/NpmVersionBreakdown.tsx
+++ b/apps/code-infra-dashboard/src/components/NpmVersionBreakdown.tsx
@@ -18,16 +18,16 @@ import Skeleton from '@mui/material/Skeleton';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import * as semver from 'semver';
 import {
-  AxisValueFormatterContext,
-  PieItemIdentifier,
-  PieSeriesType,
-  PieValueType,
+  type AxisValueFormatterContext,
+  type PieItemIdentifier,
+  type PieSeriesType,
+  type PieValueType,
   LineChart,
   PieChart,
-  HighlightItemIdentifier,
+  type HighlightItemIdentifier,
 } from '@mui/x-charts-pro';
 import { useEventCallback } from '@mui/material/utils';
-import { fetchNpmPackageDetails, PackageDetails } from '../lib/npm';
+import { fetchNpmPackageDetails, type PackageDetails } from '../lib/npm';
 import { HoverStoreProvider, useHoverStore, useHoveredIndex } from './hoverStore';
 import { LineWithHitArea } from './LineWithHitArea';
 

--- a/apps/code-infra-dashboard/src/components/PRList.tsx
+++ b/apps/code-infra-dashboard/src/components/PRList.tsx
@@ -14,7 +14,7 @@ import Chip from '@mui/material/Chip';
 import Skeleton from '@mui/material/Skeleton';
 import GitPullRequestIcon from '@mui/icons-material/Commit';
 import { styled } from '@mui/material/styles';
-import { GitHubPRInfo } from '../hooks/useGitHubPR';
+import { type GitHubPRInfo } from '../hooks/useGitHubPR';
 import { useGitHubPRs } from '../hooks/useGitHubPRs';
 import ErrorDisplay from './ErrorDisplay';
 

--- a/apps/code-infra-dashboard/src/hooks/useGitHubPRs.ts
+++ b/apps/code-infra-dashboard/src/hooks/useGitHubPRs.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { GitHubPRInfo } from './useGitHubPR';
+import { type GitHubPRInfo } from './useGitHubPR';
 import { octokit, parseRepo } from '../utils/github';
 
 export interface UseGitHubPRs {

--- a/apps/code-infra-dashboard/src/hooks/useMasterCommits.ts
+++ b/apps/code-infra-dashboard/src/hooks/useMasterCommits.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import * as React from 'react';
-import { RestEndpointMethodTypes } from '@octokit/rest';
+import { type RestEndpointMethodTypes } from '@octokit/rest';
 import { octokit, parseRepo } from '../utils/github';
 
 export type GitHubCommit =

--- a/apps/code-infra-dashboard/src/lib/ciReports/bundleSizeReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/ciReports/bundleSizeReport.test.ts
@@ -1,7 +1,8 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type * as FetchCiReport from '@/utils/fetchCiReport';
 
 vi.mock('@/utils/fetchCiReport', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/utils/fetchCiReport')>();
+  const actual = await importOriginal<typeof FetchCiReport>();
   return {
     ...actual,
     fetchCiReport: vi.fn(),

--- a/apps/code-infra-dashboard/src/views/NpmDownloads.tsx
+++ b/apps/code-infra-dashboard/src/views/NpmDownloads.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { useQueries, UseQueryResult } from '@tanstack/react-query';
+import { useQueries, type UseQueryResult } from '@tanstack/react-query';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Paper from '@mui/material/Paper';
 import Chip from '@mui/material/Chip';
-import { DateRange } from '@mui/x-date-pickers-pro/models';
-import { Dayjs } from 'dayjs';
+import { type DateRange } from '@mui/x-date-pickers-pro/models';
+import { type Dayjs } from 'dayjs';
 import {
   useSearchParamsState,
   CODEC_STRING_ARRAY,
@@ -23,8 +23,8 @@ import {
   getDefaultDateRange,
   getDefaultAggregation,
   getAvailableAggregations,
-  AggregationPeriod,
-  NpmDownloadsData,
+  type AggregationPeriod,
+  type NpmDownloadsData,
 } from '../lib/npmDownloads';
 
 export type PackageQueryResult = UseQueryResult<NpmDownloadsData, Error>;

--- a/apps/tools-public/toolpad/components/AutoDataGrid.tsx
+++ b/apps/tools-public/toolpad/components/AutoDataGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DataGrid, GridColDef } from '@mui/x-data-grid-v8';
+import { DataGrid, type GridColDef } from '@mui/x-data-grid-v8';
 import { createComponent } from '@toolpad/studio/browser';
 
 export interface AutoDataGridProps {

--- a/docs/app/docs-infra/hooks/use-types/demos/blocks-data-attr/Component/Part/ComponentPart.tsx
+++ b/docs/app/docs-infra/hooks/use-types/demos/blocks-data-attr/Component/Part/ComponentPart.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { InputType } from '../../InputType';
+import { type InputType } from '../../InputType';
 
 export interface ComponentPartState {
   /** Whether the part is visible */

--- a/docs/components/Search/Search.tsx
+++ b/docs/components/Search/Search.tsx
@@ -4,7 +4,7 @@ import * as ReactDOM from 'react-dom';
 import { useRouter } from 'next/navigation';
 import { useSearch } from '@mui/internal-docs-infra/useSearch';
 import type { SearchResult, Sitemap } from '@mui/internal-docs-infra/useSearch/types';
-import { Autocomplete } from '@base-ui/react/autocomplete';
+import { type Autocomplete } from '@base-ui/react/autocomplete';
 import { SearchButton } from './SearchButton';
 import { SearchDialog } from './SearchDialog';
 import styles from './SearchDialog.module.css';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import nPlugin from 'eslint-plugin-n';
 import { lintJavascriptDemoFocus } from '@mui/internal-docs-infra/pipeline/lintJavascriptDemoFocus';
 
 const config = defineConfig(
-  createBaseConfig({ baseDirectory: import.meta.dirname }),
+  createBaseConfig({ baseDirectory: import.meta.dirname, consistentTypeImports: true }),
   {
     files: [`**/*${EXTENSION_TS}`],
     plugins: {

--- a/packages/babel-plugin-minify-errors/index.d.ts
+++ b/packages/babel-plugin-minify-errors/index.d.ts
@@ -1,4 +1,4 @@
-import type { PluginObj, PluginPass } from '@babel/core';
+import type { PluginObj, PluginPass, types as BabelTypes } from '@babel/core';
 
 export interface Options {
   errorCodesPath?: string;
@@ -9,7 +9,7 @@ export interface Options {
 }
 
 declare function plugin(
-  babel: { types: typeof import('@babel/core').types },
+  babel: { types: typeof BabelTypes },
   options: Options,
 ): PluginObj<PluginPass>;
 

--- a/packages/babel-plugin-resolve-imports/resolve.d.ts
+++ b/packages/babel-plugin-resolve-imports/resolve.d.ts
@@ -1,5 +1,5 @@
 declare module 'resolve/sync' {
-  import { Opts } from 'resolve';
+  import { type Opts } from 'resolve';
 
   function resolve(id: string, options?: Opts): string;
   export = resolve;

--- a/packages/benchmark/src/reporter.test.ts
+++ b/packages/benchmark/src/reporter.test.ts
@@ -1,6 +1,7 @@
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
+import type { TestCase } from 'vitest/node';
 import type { RenderEvent, IterationData } from './types';
 import { generateReportFromIterations, BenchmarkReporter } from './reporter';
 import * as uploadModule from './upload';
@@ -202,7 +203,7 @@ function mockTestCase(options: {
       state: options.state,
       errors: options.errors,
     }),
-  } as unknown as import('vitest/node').TestCase;
+  } as unknown as TestCase;
 }
 
 describe('BenchmarkReporter', () => {

--- a/packages/benchmark/src/vitest.ts
+++ b/packages/benchmark/src/vitest.ts
@@ -1,6 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
-import { ViteUserConfig } from 'vitest/config';
+import { type ViteUserConfig } from 'vitest/config';
 
 export interface CreateBenchmarkVitestConfigOptions {
   /**

--- a/packages/code-infra/src/brokenLinksChecker/index.test.ts
+++ b/packages/code-infra/src/brokenLinksChecker/index.test.ts
@@ -2,13 +2,13 @@ import path from 'node:path';
 import getPort from 'get-port';
 import { describe, expect, it } from 'vitest';
 
-// eslint-disable-next-line import/extensions
 import {
   crawl,
   type BrokenLinkIssue,
   type HtmlValidateIssue,
   type Issue,
   type Link,
+  // eslint-disable-next-line import/extensions
 } from './index.mjs';
 
 type ExpectedBrokenLinkIssue = Omit<Partial<BrokenLinkIssue>, 'link'> & { link?: Partial<Link> };

--- a/packages/code-infra/src/brokenLinksChecker/index.test.ts
+++ b/packages/code-infra/src/brokenLinksChecker/index.test.ts
@@ -3,7 +3,13 @@ import getPort from 'get-port';
 import { describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line import/extensions
-import { crawl, BrokenLinkIssue, HtmlValidateIssue, Issue, Link } from './index.mjs';
+import {
+  crawl,
+  type BrokenLinkIssue,
+  type HtmlValidateIssue,
+  type Issue,
+  type Link,
+} from './index.mjs';
 
 type ExpectedBrokenLinkIssue = Omit<Partial<BrokenLinkIssue>, 'link'> & { link?: Partial<Link> };
 

--- a/packages/code-infra/src/eslint/baseConfig.mjs
+++ b/packages/code-infra/src/eslint/baseConfig.mjs
@@ -32,12 +32,14 @@ function includeIgnoreIfExists(filePath, description) {
 /**
  * @param {Object} [params]
  * @param {boolean} [params.enableReactCompiler] - Whether to enable React Compiler.
+ * @param {boolean} [params.consistentTypeImports] - Whether to enforce consistent type imports.
  * @param {boolean} [params.materialUi] - Whether to enable Material UI specific rules (mui/material-ui-*).
  * @param {string} [params.baseDirectory] - The base directory for the configuration.
  * @returns {import('eslint').Linter.Config[]}
  */
 export function createBaseConfig({
   enableReactCompiler = false,
+  consistentTypeImports = false,
   materialUi = false,
   baseDirectory = process.cwd(),
 } = {}) {
@@ -80,7 +82,7 @@ export function createBaseConfig({
               ignoreUnknownVersions: true,
             },
           },
-          extends: createCoreConfig({ enableReactCompiler, materialUi }),
+          extends: createCoreConfig({ enableReactCompiler, consistentTypeImports, materialUi }),
         },
         // Lint rule to disallow usage of typescript namespaces.We've seen at least two problems with them:
         //   * Creates non-portable types in base ui. [1]

--- a/packages/code-infra/src/eslint/baseConfig.mjs
+++ b/packages/code-infra/src/eslint/baseConfig.mjs
@@ -32,14 +32,12 @@ function includeIgnoreIfExists(filePath, description) {
 /**
  * @param {Object} [params]
  * @param {boolean} [params.enableReactCompiler] - Whether to enable React Compiler.
- * @param {boolean} [params.consistentTypeImports] - Whether to enforce consistent type imports.
  * @param {boolean} [params.materialUi] - Whether to enable Material UI specific rules (mui/material-ui-*).
  * @param {string} [params.baseDirectory] - The base directory for the configuration.
  * @returns {import('eslint').Linter.Config[]}
  */
 export function createBaseConfig({
   enableReactCompiler = false,
-  consistentTypeImports = false,
   materialUi = false,
   baseDirectory = process.cwd(),
 } = {}) {
@@ -82,7 +80,7 @@ export function createBaseConfig({
               ignoreUnknownVersions: true,
             },
           },
-          extends: createCoreConfig({ enableReactCompiler, consistentTypeImports, materialUi }),
+          extends: createCoreConfig({ enableReactCompiler, materialUi }),
         },
         // Lint rule to disallow usage of typescript namespaces.We've seen at least two problems with them:
         //   * Creates non-portable types in base ui. [1]

--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -303,6 +303,7 @@ const airbnbJsxA11y = {
 /**
  * @param {Object} [options]
  * @param {boolean} [options.enableReactCompiler] - Whether to enable React Compiler.
+ * @param {boolean} [options.consistentTypeImports] - Whether to enforce consistent type imports.
  * @param {boolean} [options.materialUi] - Whether to enable Material UI specific rules (mui/material-ui-*).
  * @returns {import('eslint').Linter.Config[]}
  */
@@ -519,15 +520,16 @@ export function createCoreConfig(options = {}) {
         'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
         'lines-around-directive': 'off',
         ...(options.enableReactCompiler ? { 'react-compiler/react-compiler': 'error' } : {}),
-        // Type-only imports get erased at compile time, which avoids
-        // downstream-bundler errors when a value-import references a TypeScript-only name
-        // (e.g. Vite 8 / Rolldown fails the build with `MISSING_EXPORT` in that case).
-        '@typescript-eslint/consistent-type-imports': [
-          'error',
-          {
-            fixStyle: 'inline-type-imports',
-          },
-        ],
+        ...(options.consistentTypeImports
+          ? {
+              '@typescript-eslint/consistent-type-imports': [
+                'error',
+                {
+                  fixStyle: 'inline-type-imports',
+                },
+              ],
+            }
+          : {}),
         // Prevent the use of `e` as a shorthand for `event`, `error`, etc.
         'id-denylist': ['error', 'e'],
         '@typescript-eslint/return-await': 'off',

--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -303,7 +303,6 @@ const airbnbJsxA11y = {
 /**
  * @param {Object} [options]
  * @param {boolean} [options.enableReactCompiler] - Whether to enable React Compiler.
- * @param {boolean} [options.consistentTypeImports] - Whether to enforce consistent type imports.
  * @param {boolean} [options.materialUi] - Whether to enable Material UI specific rules (mui/material-ui-*).
  * @returns {import('eslint').Linter.Config[]}
  */
@@ -520,16 +519,15 @@ export function createCoreConfig(options = {}) {
         'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
         'lines-around-directive': 'off',
         ...(options.enableReactCompiler ? { 'react-compiler/react-compiler': 'error' } : {}),
-        ...(options.consistentTypeImports
-          ? {
-              '@typescript-eslint/consistent-type-imports': [
-                'error',
-                {
-                  fixStyle: 'inline-type-imports',
-                },
-              ],
-            }
-          : {}),
+        // Type-only imports get erased at compile time, which avoids
+        // downstream-bundler errors when a value-import references a TypeScript-only name
+        // (e.g. Vite 8 / Rolldown fails the build with `MISSING_EXPORT` in that case).
+        '@typescript-eslint/consistent-type-imports': [
+          'error',
+          {
+            fixStyle: 'inline-type-imports',
+          },
+        ],
         // Prevent the use of `e` as a shorthand for `event`, `error`, etc.
         'id-denylist': ['error', 'e'],
         '@typescript-eslint/return-await': 'off',

--- a/packages/code-infra/src/estree-typescript.d.ts
+++ b/packages/code-infra/src/estree-typescript.d.ts
@@ -1,4 +1,4 @@
-import { BaseExpression, Expression } from 'estree';
+import { type BaseExpression, type Expression } from 'estree';
 
 export * from 'estree';
 

--- a/packages/code-infra/src/untyped-plugins.d.ts
+++ b/packages/code-infra/src/untyped-plugins.d.ts
@@ -13,77 +13,77 @@ declare module 'eslint-config-airbnb' {
 }
 
 declare module 'eslint-config-airbnb-base/rules/best-practices' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/errors' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/es6' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/imports' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/node' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/strict' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/style' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb-base/rules/variables' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb/rules/react' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module 'eslint-config-airbnb/rules/react-a11y' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   declare const config: Omit<Linter.LegacyConfig, 'extends' | 'plugins'>;
   export default config;
 }
 
 declare module '@next/eslint-plugin-next' {
-  import { Linter } from 'eslint';
+  import { type Linter } from 'eslint';
 
   interface NextEslintPluginConfig extends Linter.LegacyConfig {
     flatConfig: {

--- a/packages/docs-infra/src/CodeHighlighter/CodeHighlighterClient.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/CodeHighlighterClient.tsx
@@ -2,12 +2,17 @@
 
 import * as React from 'react';
 import { useCodeContext } from '../CodeProvider/CodeContext';
-import { Code, CodeHighlighterClientProps, ControlledCode, VariantCode } from './types';
-import { CodeHighlighterContext, CodeHighlighterContextType } from './CodeHighlighterContext';
+import {
+  type Code,
+  type CodeHighlighterClientProps,
+  type ControlledCode,
+  type VariantCode,
+} from './types';
+import { CodeHighlighterContext, type CodeHighlighterContextType } from './CodeHighlighterContext';
 import { maybeCodeInitialData } from '../pipeline/loadCodeVariant/maybeCodeInitialData';
 import { hasAllVariants } from '../pipeline/loadCodeVariant/hasAllCodeVariants';
 import { CodeHighlighterFallbackContext } from './CodeHighlighterFallbackContext';
-import { Selection, useControlledCode } from '../CodeControllerContext';
+import { type Selection, useControlledCode } from '../CodeControllerContext';
 import { codeToFallbackProps } from './codeToFallbackProps';
 import { mergeCodeMetadata } from '../pipeline/loadCodeVariant/mergeCodeMetadata';
 import * as Errors from './errors';

--- a/packages/docs-infra/src/CodeHighlighter/CodeHighlighterContext.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/CodeHighlighterContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
-import { Code, ControlledCode } from './types';
-import { Selection } from '../CodeControllerContext';
+import { type Code, type ControlledCode } from './types';
+import { type Selection } from '../CodeControllerContext';
 
 export interface CodeHighlighterContextType {
   code?: Code;

--- a/packages/docs-infra/src/CodeHighlighter/CodeHighlighterFallbackContext.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/CodeHighlighterFallbackContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 import * as React from 'react';
-import { ContentLoadingVariant } from './types';
+import { type ContentLoadingVariant } from './types';
 
 export interface CodeHighlighterFallbackContext extends ContentLoadingVariant {
   extraVariants?: Record<string, ContentLoadingVariant>;

--- a/packages/docs-infra/src/CodeHighlighter/codeToFallbackProps.ts
+++ b/packages/docs-infra/src/CodeHighlighter/codeToFallbackProps.ts
@@ -1,4 +1,9 @@
-import { BaseContentLoadingProps, Code, ContentLoadingVariant, VariantCode } from './types';
+import {
+  type BaseContentLoadingProps,
+  type Code,
+  type ContentLoadingVariant,
+  type VariantCode,
+} from './types';
 import { stringOrHastToJsx } from '../pipeline/hastUtils';
 
 function toExtraSource(variantCode: VariantCode, fileName?: string) {

--- a/packages/docs-infra/src/abstractCreateDemo/abstractCreateDemo.tsx
+++ b/packages/docs-infra/src/abstractCreateDemo/abstractCreateDemo.tsx
@@ -13,7 +13,7 @@ import type {
   SourceEnhancers,
 } from '../CodeHighlighter/types';
 import { createDemoDataWithVariants } from '../createDemoData';
-import { DemoGlobalData } from '../createDemoData/types';
+import { type DemoGlobalData } from '../createDemoData/types';
 
 type CreateDemoMeta = {
   name?: string;

--- a/packages/docs-infra/src/createDemoData/createDemoData.ts
+++ b/packages/docs-infra/src/createDemoData/createDemoData.ts
@@ -1,6 +1,11 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { extractNameAndSlugFromUrl } from '../pipeline/loaderUtils';
-import { CreateDemoDataMeta, DemoData, DemoGlobalData, DemoGlobalProvider } from './types';
+import {
+  type CreateDemoDataMeta,
+  type DemoData,
+  type DemoGlobalData,
+  type DemoGlobalProvider,
+} from './types';
 
 /**
  * Creates demo data for displaying code examples with syntax highlighting.

--- a/packages/docs-infra/src/pipeline/loadCodeVariant/diffHast.ts
+++ b/packages/docs-infra/src/pipeline/loadCodeVariant/diffHast.ts
@@ -1,6 +1,6 @@
 import { create, patch } from 'jsondiffpatch';
 import type { Nodes } from 'hast';
-import { ParseSource, Transforms } from '../../CodeHighlighter/types';
+import { type ParseSource, type Transforms } from '../../CodeHighlighter/types';
 
 const differ = create({ omitRemovedValues: true, cloneDiffValues: true });
 

--- a/packages/docs-infra/src/pipeline/loadCodeVariant/hasAllCodeVariants.ts
+++ b/packages/docs-infra/src/pipeline/loadCodeVariant/hasAllCodeVariants.ts
@@ -1,4 +1,4 @@
-import { Code, VariantSource } from '../../CodeHighlighter/types';
+import { type Code, type VariantSource } from '../../CodeHighlighter/types';
 
 /**
  * Checks if a code source is fully loaded and ready for rendering.

--- a/packages/docs-infra/src/pipeline/loadCodeVariant/maybeCodeInitialData.ts
+++ b/packages/docs-infra/src/pipeline/loadCodeVariant/maybeCodeInitialData.ts
@@ -1,5 +1,5 @@
 import { hasAllVariants } from './hasAllCodeVariants';
-import { Code, VariantExtraFiles, VariantSource } from '../../CodeHighlighter/types';
+import { type Code, type VariantExtraFiles, type VariantSource } from '../../CodeHighlighter/types';
 
 /**
  * Type guard function that determines if we have sufficient data to render a code highlighter

--- a/packages/docs-infra/src/pipeline/loadCodeVariant/transformSource.ts
+++ b/packages/docs-infra/src/pipeline/loadCodeVariant/transformSource.ts
@@ -1,4 +1,4 @@
-import { create, Delta } from 'jsondiffpatch';
+import { create, type Delta } from 'jsondiffpatch';
 import { toText } from 'hast-util-to-text';
 import type { Nodes as HastNodes } from 'hast';
 import type { VariantSource, SourceTransformers, Transforms } from '../../CodeHighlighter/types';

--- a/packages/docs-infra/src/pipeline/loadPrecomputedCodeHighlighterClient/loadPrecomputedCodeHighlighterClient.ts
+++ b/packages/docs-infra/src/pipeline/loadPrecomputedCodeHighlighterClient/loadPrecomputedCodeHighlighterClient.ts
@@ -10,7 +10,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 import {
   parseCreateFactoryCall,
-  ParsedCreateFactory,
+  type ParsedCreateFactory,
 } from '../loadPrecomputedCodeHighlighter/parseCreateFactoryCall';
 import { generateResolvedExternals } from './generateResolvedExternals';
 import { loadCodeVariant } from '../loadCodeVariant/loadCodeVariant';

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/createOptimizedProgram.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/createOptimizedProgram.ts
@@ -1,4 +1,4 @@
-import ts, { CompilerOptions } from 'typescript';
+import ts, { type CompilerOptions } from 'typescript';
 // eslint-disable-next-line n/prefer-node-protocol
 import fs from 'fs';
 // eslint-disable-next-line n/prefer-node-protocol

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatClass.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatClass.ts
@@ -1,4 +1,4 @@
-import * as tae from 'typescript-api-extractor';
+import type * as tae from 'typescript-api-extractor';
 import {
   formatParameters,
   parseMarkdownToHast,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatComponent.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatComponent.ts
@@ -1,4 +1,4 @@
-import * as tae from 'typescript-api-extractor';
+import type * as tae from 'typescript-api-extractor';
 import {
   formatProperties,
   formatEnum,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatFunction.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatFunction.ts
@@ -1,4 +1,4 @@
-import * as tae from 'typescript-api-extractor';
+import type * as tae from 'typescript-api-extractor';
 import {
   formatParameters,
   formatProperties,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatHook.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatHook.ts
@@ -1,4 +1,4 @@
-import * as tae from 'typescript-api-extractor';
+import type * as tae from 'typescript-api-extractor';
 import {
   formatProperties,
   formatParameters,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatRaw.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatRaw.ts
@@ -1,4 +1,4 @@
-import * as tae from 'typescript-api-extractor';
+import type * as tae from 'typescript-api-extractor';
 import {
   prettyFormat,
   parseMarkdownToHast,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadServerTypesMeta.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadServerTypesMeta.ts
@@ -7,19 +7,19 @@ import { parseImportsAndComments, extractNameAndSlugFromUrl } from '../loaderUti
 import { nameMark, performanceMeasure } from '../loadPrecomputedCodeHighlighter/performanceLogger';
 import { loadTypescriptConfig } from './loadTypescriptConfig';
 import { resolveLibrarySourceFiles } from './resolveLibrarySourceFiles';
-import { ClassTypeMeta as ClassType, formatClassData, isPublicClass } from './formatClass';
+import { type ClassTypeMeta as ClassType, formatClassData, isPublicClass } from './formatClass';
 import {
-  ComponentTypeMeta as ComponentType,
+  type ComponentTypeMeta as ComponentType,
   formatComponentData,
   isPublicComponent,
 } from './formatComponent';
-import { HookTypeMeta as HookType, formatHookData, isPublicHook } from './formatHook';
+import { type HookTypeMeta as HookType, formatHookData, isPublicHook } from './formatHook';
 import {
-  FunctionTypeMeta as FunctionType,
+  type FunctionTypeMeta as FunctionType,
   formatFunctionData,
   isPublicFunction,
 } from './formatFunction';
-import { RawTypeMeta as RawType, formatRawData, type ReExportInfo } from './formatRaw';
+import { type RawTypeMeta as RawType, formatRawData, type ReExportInfo } from './formatRaw';
 import {
   type FormattedProperty,
   type FormattedEnumMember,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/processTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/processTypes.ts
@@ -2,11 +2,11 @@ import type { CompilerOptions } from 'typescript';
 // eslint-disable-next-line n/prefer-node-protocol
 import { fileURLToPath } from 'url';
 import {
-  ExportNode,
+  type ExportNode,
   parseFromProgram,
-  ParserOptions,
-  TypeName,
-  AnyType,
+  type ParserOptions,
+  type TypeName,
+  type AnyType,
 } from 'typescript-api-extractor';
 import ts from 'typescript';
 import { createOptimizedProgram } from './createOptimizedProgram';

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
@@ -8,7 +8,7 @@
  * On Windows, this uses named pipes (which Node.js net module supports transparently).
  */
 
-import { connect, Socket } from 'node:net';
+import { connect, type Socket } from 'node:net';
 import { mkdir, stat } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketServer.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketServer.ts
@@ -8,7 +8,7 @@
  * On Windows, this uses named pipes (which Node.js net module supports transparently).
  */
 
-import { createServer, Server, Socket } from 'node:net';
+import { createServer, type Server, type Socket } from 'node:net';
 import { unlink, stat } from 'node:fs/promises';
 import { getSocketPath, ensureSocketDir } from './socketClient';
 import type { WorkerRequest, WorkerResponse } from './worker';

--- a/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.ts
@@ -4,7 +4,7 @@ import { visit } from 'unist-util-visit';
 import type { Heading, Paragraph, Image, Link, Root, Code } from 'mdast';
 import type { ExtractedMetadata, HeadingHierarchy } from '../transformMarkdownMetadata/types';
 import { heading, paragraph, text, link, comment } from './createMarkdownNodes';
-import { Audience } from '../../createSitemap/types';
+import { type Audience } from '../../createSitemap/types';
 
 /**
  * Escapes underscores in a string for markdown compatibility.

--- a/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
@@ -5,7 +5,7 @@ import { mergeMetadataMarkdown } from './mergeMetadataMarkdown';
 import { markdownToMetadata } from './metadataToMarkdown';
 import type { PageMetadata } from './metadataToMarkdown';
 import type { HeadingHierarchy } from '../transformMarkdownMetadata/types';
-import { Audience } from '../../createSitemap/types';
+import { type Audience } from '../../createSitemap/types';
 
 /**
  * Converts a kebab-case string to Title Case

--- a/packages/docs-infra/src/pipeline/transformMarkdownMetadata/types.ts
+++ b/packages/docs-infra/src/pipeline/transformMarkdownMetadata/types.ts
@@ -1,5 +1,5 @@
 import type { PhrasingContent } from 'mdast';
-import { Audience } from '../../createSitemap/types';
+import { type Audience } from '../../createSitemap/types';
 
 /**
  * Base options for syncing page indexes.

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { toText } from 'hast-util-to-text';
-import { ElementContent } from 'hast';
+import { type ElementContent } from 'hast';
 import type { HastRoot, VariantSource } from '../CodeHighlighter/types';
 import { hastToJsx, decompressHast } from '../pipeline/hastUtils';
 

--- a/packages/docs-infra/src/useCode/useCode.ts
+++ b/packages/docs-infra/src/useCode/useCode.ts
@@ -9,7 +9,7 @@ import { useFileNavigation } from './useFileNavigation';
 import { useUIState } from './useUIState';
 import { useCopyFunctionality } from './useCopyFunctionality';
 import { useSourceEditing } from './useSourceEditing';
-import { UseCopierOpts } from '../useCopier';
+import { type UseCopierOpts } from '../useCopier';
 
 export type UseCodeOpts = {
   preClassName?: string;

--- a/packages/docs-infra/src/useCode/useCopyFunctionality.ts
+++ b/packages/docs-infra/src/useCode/useCopyFunctionality.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { stringOrHastToString } from '../pipeline/hastUtils';
-import { useCopier, UseCopierOpts } from '../useCopier';
+import { useCopier, type UseCopierOpts } from '../useCopier';
 import type { VariantSource } from '../CodeHighlighter/types';
 
 interface UseCopyFunctionalityProps {

--- a/packages/docs-infra/src/useCode/useTransformManagement.ts
+++ b/packages/docs-infra/src/useCode/useTransformManagement.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import type { Code, VariantCode } from '../CodeHighlighter/types';
 import { getAvailableTransforms, createTransformedFiles } from './useCodeUtils';
-import { CodeHighlighterContextType } from '../CodeHighlighter/CodeHighlighterContext';
+import { type CodeHighlighterContextType } from '../CodeHighlighter/CodeHighlighterContext';
 import { usePreference } from '../usePreference';
 
 interface UseTransformManagementProps {

--- a/packages/docs-infra/src/useSearch/types.ts
+++ b/packages/docs-infra/src/useSearch/types.ts
@@ -1,4 +1,4 @@
-import { ElapsedTime, Orama, SearchParams } from '@orama/orama';
+import { type ElapsedTime, type Orama, type Result, type SearchParams } from '@orama/orama';
 import type {
   Sitemap,
   SitemapPage,
@@ -165,9 +165,7 @@ export interface UseSearchOptions {
   /** Custom function to flatten sitemap pages into search results */
   flattenPage?: (page: SitemapPage, sectionData: SitemapSectionData) => SearchResult[];
   /** Custom function to format Orama search hits into typed results */
-  formatResult?: <TDocument = unknown>(
-    hit: import('@orama/orama').Result<TDocument>,
-  ) => SearchResult;
+  formatResult?: <TDocument = unknown>(hit: Result<TDocument>) => SearchResult;
 }
 
 export type SearchBy<T> = Pick<

--- a/packages/docs-infra/src/useSearch/useSearch.tsx
+++ b/packages/docs-infra/src/useSearch/useSearch.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {
   create,
-  ElapsedTime,
+  type ElapsedTime,
   insertMultiple,
   search as oramaSearch,
   type Orama,

--- a/packages/docs-infra/src/useType/useType.ts
+++ b/packages/docs-infra/src/useType/useType.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import type * as React from 'react';
 import { useTypesDataContext, type TypeData } from './TypesDataContext';
 
 /**

--- a/packages/docs-infra/src/useType/useTypeProp.ts
+++ b/packages/docs-infra/src/useType/useTypeProp.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import type * as React from 'react';
 import { useTypesDataContext, type TypePropData } from './TypesDataContext';
 
 /**

--- a/packages/test-utils/src/chaiPlugin.ts
+++ b/packages/test-utils/src/chaiPlugin.ts
@@ -1,7 +1,7 @@
 import { isInaccessible } from '@testing-library/dom';
 // eslint-disable-next-line import/extensions
 import { prettyDOM } from '@testing-library/react/pure.js';
-import * as chai from 'chai';
+import type * as chai from 'chai';
 import { computeAccessibleDescription, computeAccessibleName } from 'dom-accessibility-api';
 import formatUtil from 'format-util';
 import { kebabCase } from 'es-toolkit/string';

--- a/packages/test-utils/src/createRenderer.tsx
+++ b/packages/test-utils/src/createRenderer.tsx
@@ -2,13 +2,13 @@ import {
   buildQueries,
   prettyDOM,
   queries,
-  RenderResult,
+  type RenderResult,
   act as rtlAct,
   fireEvent as rtlFireEvent,
   screen as rtlScreen,
-  Screen,
+  type Screen,
   render as testingLibraryRender,
-  RenderOptions as TestingLibraryRenderOptions,
+  type RenderOptions as TestingLibraryRenderOptions,
   within,
   // eslint-disable-next-line import/extensions
 } from '@testing-library/react/pure.js';

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as React from 'react';
 import { describe, it, afterAll, afterEach, beforeEach } from 'vitest';
 import createDescribe from './createDescribe';
-import { MuiRenderResult } from './createRenderer';
+import { type MuiRenderResult } from './createRenderer';
 import { isJsdom } from './env';
 
 interface DataProps {

--- a/packages/test-utils/src/initPlaywrightMatchers.ts
+++ b/packages/test-utils/src/initPlaywrightMatchers.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai';
-import * as DomTestingLibrary from '@testing-library/dom';
+import type * as DomTestingLibrary from '@testing-library/dom';
 import type { ElementHandle } from '@playwright/test';
 import { AssertionError } from 'assertion-error';
 

--- a/packages/test-utils/src/setupVitest.ts
+++ b/packages/test-utils/src/setupVitest.ts
@@ -6,7 +6,7 @@ import { cleanup, act } from '@testing-library/react/pure.js';
 import { afterEach, vi } from 'vitest';
 import chaiDom from 'chai-dom';
 import chaiPlugin from './chaiPlugin';
-import { Configuration, configure } from './configure';
+import { type Configuration, configure } from './configure';
 
 let isInitialized = false;
 


### PR DESCRIPTION
## Summary

Make `@typescript-eslint/consistent-type-imports` (`fixStyle: 'inline-type-imports'`) part of the shared base ESLint config — always on, no opt-in flag.

## Why

Type-only imports get erased at compile time, so they never reach a downstream bundler. A value-import that references a TypeScript-only name (e.g. `import { Theme } from '@mui/material/styles'`) survives the build and trips strict bundlers:

```
[MISSING_EXPORT] Error: "Theme" is not exported by "@mui/material/styles/index.mjs"
```

Vite 8 / Rolldown surfaces this as a hard error (Rollup tolerated it). We hit this in mui/mui-x#22260 while bundling MUI X regression tests — the failing import lives in `@mui/internal-core-docs`. The single-package fix is in mui/material-ui#48386 (originally also added a per-package ESLint override there); per @Janpot's suggestion we move that override into the shared config so the rule applies everywhere.

## Changes

- `packages/code-infra/src/eslint/baseConfig.mjs`: drop the `consistentTypeImports` parameter; the rule is always applied.
- `packages/code-infra/src/eslint/mui/config.mjs`: same — remove conditional, hardcode the rule with a comment explaining the bundler-strictness motivation.

## Downstream

Consumers (`mui/material-ui`, `mui/mui-x`, `mui/base-ui`, …) will pick up the rule automatically when they bump `@mui/internal-code-infra`. They will need to either run the autofix or accept the inline `type` modifier across their codebases. Because `fixStyle` is `inline-type-imports`, the autofix is non-disruptive.