### PR TITLE
[code-infra] Add org-versions script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "docs:validate": "pnpm -F \"./docs\" run docs-infra validate --command 'pnpm docs:validate'",
     "docs:lint": "pnpm -F \"./docs\" run lint",
     "docs:lib": "pnpm -F \"./packages/docs-infra\" run build",
-    "test:benchmark": "pnpm -F ./test/performance benchmark"
+    "test:benchmark": "pnpm -F ./test/performance benchmark",
+    "org-versions": "tsx scripts/orgVersions.mts"
   },
   "pnpm": {
     "packageExtensions": {

--- a/scripts/orgVersions.mts
+++ b/scripts/orgVersions.mts
@@ -1,0 +1,40 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const REPOS = [
+  'mui/material-ui',
+  'mui/mui-x',
+  'mui/base-ui',
+  'mui/base-ui-mosaic',
+  'mui/base-ui-charts',
+  'mui/base-ui-plus',
+  'mui/mui-public',
+  'mui/mui-private',
+];
+
+async function fetchVersion(repo: string, pkg: string): Promise<string> {
+  const jq = `.devDependencies["${pkg}"] // .dependencies["${pkg}"] // "—"`;
+  const { stdout } = await execFileAsync('gh', [
+    'api',
+    `repos/${repo}/contents/package.json`,
+    '-H',
+    'Accept: application/vnd.github.raw',
+    '--jq',
+    jq,
+  ]);
+  return stdout.trim();
+}
+
+const pkg = process.argv[2];
+if (!pkg) {
+  console.error('usage: org-versions <package-name>');
+  process.exit(1);
+}
+
+const results = await Promise.all(
+  REPOS.map(async (repo) => `${repo}: ${await fetchVersion(repo, pkg)}`),
+);
+
+process.stdout.write(`${results.join('\n')}\n`);


### PR DESCRIPTION
I sometimes have the need to know howdependencies are propagated across our projects. (e.g. version `pkg-pr-new` for https://github.com/mui/mui-public/pull/1354)

Adds a `pnpm org-versions <pkg>` script that reports the version of an npm package pinned in each MUI org repo's root `package.json`. Useful for tracking rollout of shared dev dependencies across MUI repos.

Uses the `gh` CLI to fetch each repo's `package.json`.