### PR TITLE
Always report html-validate warnings in broken links checker

### DIFF
--- a/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
+++ b/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
@@ -164,9 +164,7 @@ if (pageData.status < 200 || pageData.status >= 400) {
     );
 
     const report = await htmlValidator.validateString(rawContent, pageUrl);
-    if (!report.valid) {
-      htmlValidateResults = { pageUrl, results: report.results };
-    }
+    htmlValidateResults = { pageUrl, results: report.results };
   }
 
   postResult({ pageData, links, htmlValidateResults });


### PR DESCRIPTION
The crawl worker only forwarded html-validate results when `report.valid` was false. `report.valid` is false only when the report contains errors (severity 2); warnings (severity 1) do not invalidate the report. As a result, pages with warnings but no errors had their warnings silently dropped — warnings only appeared in the output when a page also had at least one error.

The downstream code in `index.mjs` already handles warnings via `issue.severity`, so simply always forwarding the results lets warning-only pages surface correctly.