### PR TITLE
[code-infra] Disable consistent-type-imports for .d.ts files

### DIFF
--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -1,5 +1,6 @@
 // TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
 import { defineConfig } from '@eslint/config-helpers';
+import { EXTENSION_DTS } from '../extensions.mjs';
 
 const restrictedMethods = ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'];
 
@@ -534,6 +535,13 @@ export function createCoreConfig(options = {}) {
         // Prevent the use of `e` as a shorthand for `event`, `error`, etc.
         'id-denylist': ['error', 'e'],
         '@typescript-eslint/return-await': 'off',
+      },
+    },
+    {
+      name: 'mui-base/dts',
+      files: [`**/*${EXTENSION_DTS}`],
+      rules: {
+        '@typescript-eslint/consistent-type-imports': 'off',
       },
     },
   ]);


### PR DESCRIPTION
In `.d.ts` files every import is type-only by definition (no runtime emit), so requiring explicit `import type` is just noise. Add an override that turns `@typescript-eslint/consistent-type-imports` off for declaration files, using the existing `EXTENSION_DTS` glob constant.