### PR TITLE
[docs-infra] Remove extensions that shouldn't be supported

### DIFF
--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/loadIsomorphicCodeVariant.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/loadIsomorphicCodeVariant.ts
@@ -370,7 +370,8 @@ async function loadSingleFile(
         throw error;
       }
       throw new Error(
-        `Failed to load source code (variant: ${variantName}, file: ${fileName}, url: ${url}): ${JSON.stringify(error)}`,
+        `Failed to load source code (variant: ${variantName}, file: ${fileName}, url: ${url}): ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
       );
     }
   }
@@ -944,7 +945,8 @@ export async function loadIsomorphicCodeVariant(
         variant = await loadVariantMeta(variantName, variant);
       } catch (error) {
         throw new Error(
-          `Failed to load variant code (variant: ${variantName}, url: ${variant}): ${JSON.stringify(error)}`,
+          `Failed to load variant code (variant: ${variantName}, url: ${variant}): ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
         );
       }
 

--- a/packages/docs-infra/src/pipeline/loaderUtils/resolveModulePath.ts
+++ b/packages/docs-infra/src/pipeline/loaderUtils/resolveModulePath.ts
@@ -55,8 +55,6 @@ export const VALUE_IMPORT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.mdx', '.
 const STATIC_ASSET_EXTENSIONS = [
   '.css',
   '.scss',
-  '.sass',
-  '.less',
   '.json',
   '.svg',
   '.png',
@@ -64,12 +62,21 @@ const STATIC_ASSET_EXTENSIONS = [
   '.jpeg',
   '.gif',
   '.webp',
-  '.ico',
-  '.woff',
   '.woff2',
-  '.ttf',
-  '.eot',
-  '.otf',
+] as const;
+
+/**
+ * Asset extensions that are intentionally unsupported.
+ * Importing one of these throws so the issue surfaces at build time.
+ */
+const UNSUPPORTED_ASSET_EXTENSIONS = [
+  '.sass', // use '.scss' instead
+  '.less', // legacy
+  '.ico', // legacy
+  '.woff', // legacy, use '.woff2' (https://web.dev/articles/font-best-practices#use_woff2)
+  '.eot', // legacy
+  '.ttf', // desktop font format
+  '.otf', // desktop font format
 ] as const;
 
 /**
@@ -666,6 +673,10 @@ export async function resolveImportResult(
   const staticAssets: string[] = [];
 
   for (const [importPath, { url, includeTypeDefs }] of Object.entries(importResult)) {
+    if (UNSUPPORTED_ASSET_EXTENSIONS.some((ext) => importPath.endsWith(ext))) {
+      throw new Error(`Unsupported import extension: "${importPath}".`);
+    }
+
     if (isStaticAsset(importPath)) {
       // Static asset - use url as-is
       staticAssets.push(url);


### PR DESCRIPTION
Keep it simple, remove extension that we are never supposed to see:

- '.less': legacy
- '.ico': legacy
- '.woff': legacy https://web.dev/articles/font-best-practices#use_woff2
- '.eot': legacy
- '.ttf': doesn't make sense, for desktop
- '.otf': doesn't make sense, for desktop
- '.sass': we would use '.scss' if we were using this.
