### PR TITLE
[infra] Skip major @mui/* updates in apps/tools-public

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,13 @@
     {
       "matchDepNames": ["code-infra-gh-actions"],
       "enabled": true
+    },
+    {
+      "description": "Skip major @mui/* updates in apps/tools-public — Toolpad Studio constrains peer deps and these PRs always fail.",
+      "matchFileNames": ["apps/tools-public/package.json"],
+      "matchPackageNames": ["@mui/*"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Renovate keeps proposing major bumps of `@mui/*` packages in `apps/tools-public/package.json` (the Toolpad Studio internal tools app). Toolpad Studio's peer dep ranges constrain what's compatible, so these PRs always fail (e.g. mui/material-ui#48365).

Adds a packageRule scoped to `apps/tools-public/package.json` that disables major updates for `@mui/*`. Minor and patch updates still flow.