### PR TITLE
[code-infra] Use union semantics for per-path htmlValidate overrides

### DIFF
--- a/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
+++ b/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
@@ -30,44 +30,6 @@ function matchesAnyPattern(value, patterns) {
 }
 
 /**
- * Merges html-validate configs from all matching entries. `extends` arrays are
- * concatenated and deduped (preserving first occurrence); `rules` objects are
- * shallow-merged so non-overlapping rules accumulate and later entries win on
- * conflicting keys. Other top-level fields use last-wins-per-key.
- * @param {import('html-validate').ConfigData[]} configs
- * @returns {import('html-validate').ConfigData}
- */
-function mergeHtmlValidateConfigs(configs) {
-  /** @type {import('html-validate').ConfigData} */
-  const merged = {};
-  /** @type {string[]} */
-  const extendsList = [];
-  /** @type {import('html-validate').RuleConfig} */
-  const rules = {};
-  for (const config of configs) {
-    const { extends: ext, rules: ruleSet, ...rest } = config;
-    if (ext) {
-      for (const name of ext) {
-        if (!extendsList.includes(name)) {
-          extendsList.push(name);
-        }
-      }
-    }
-    if (ruleSet) {
-      Object.assign(rules, ruleSet);
-    }
-    Object.assign(merged, rest);
-  }
-  if (extendsList.length > 0) {
-    merged.extends = extendsList;
-  }
-  if (Object.keys(rules).length > 0) {
-    merged.rules = rules;
-  }
-  return merged;
-}
-
-/**
  * Posts the crawl result back to the parent thread.
  * @param {import('./index.mjs').CrawlWorkerOutput} output
  */
@@ -199,17 +161,22 @@ if (pageData.status < 200 || pageData.status >= 400) {
   }));
 
   // HTML validation. Every entry whose path matches contributes to the
-  // page's config; configs are merged so callers can layer specific overrides
-  // on top of a baseline entry without re-stating the baseline rules.
+  // page's config: each is registered as a synthetic preset and the page's
+  // root config `extends` them in order. html-validate's own resolution then
+  // merges them, so callers can layer path-specific overrides on top of a
+  // baseline entry without re-stating the baseline rules.
   /** @type {{ pageUrl: string, results: import('html-validate').Result[] } | null} */
   let htmlValidateResults = null;
   if (type === 'text/html' && options.htmlValidate.length > 0) {
-    const matchedConfigs = options.htmlValidate
-      .filter((entry) => matchesAnyPattern(pageUrl, entry.path))
-      .map((entry) => entry.config);
+    const matchedEntries = options.htmlValidate.filter((entry) =>
+      matchesAnyPattern(pageUrl, entry.path),
+    );
 
-    if (matchedConfigs.length > 0) {
-      const mergedConfig = mergeHtmlValidateConfigs(matchedConfigs);
+    if (matchedEntries.length > 0) {
+      const overridePresets = Object.fromEntries(
+        matchedEntries.map((entry, index) => [`mui:override-${index}`, entry.config]),
+      );
+
       const muiHtmlValidateResolver = staticResolver({
         configs: {
           'mui:recommended': {
@@ -219,12 +186,22 @@ if (pageData.status < 200 || pageData.status >= 400) {
               'require-sri': 'off',
             },
           },
+          ...overridePresets,
         },
       });
 
       const htmlValidator = new HtmlValidate(
-        new StaticConfigLoader([muiHtmlValidateResolver], mergedConfig),
+        new StaticConfigLoader([muiHtmlValidateResolver], {
+          extends: Object.keys(overridePresets),
+        }),
       );
+
+      if (options.verbose) {
+        const resolved = await htmlValidator.getConfigFor(pageUrl);
+        console.warn(
+          `[html-validate config] ${pageUrl}\n${JSON.stringify(resolved.getConfigData(), null, 2)}`,
+        );
+      }
 
       const report = await htmlValidator.validateString(rawContent, pageUrl);
       htmlValidateResults = { pageUrl, results: report.results };

--- a/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
+++ b/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
@@ -30,6 +30,44 @@ function matchesAnyPattern(value, patterns) {
 }
 
 /**
+ * Merges html-validate configs from all matching entries. `extends` arrays are
+ * concatenated and deduped (preserving first occurrence); `rules` objects are
+ * shallow-merged so non-overlapping rules accumulate and later entries win on
+ * conflicting keys. Other top-level fields use last-wins-per-key.
+ * @param {import('html-validate').ConfigData[]} configs
+ * @returns {import('html-validate').ConfigData}
+ */
+function mergeHtmlValidateConfigs(configs) {
+  /** @type {import('html-validate').ConfigData} */
+  const merged = {};
+  /** @type {string[]} */
+  const extendsList = [];
+  /** @type {import('html-validate').RuleConfig} */
+  const rules = {};
+  for (const config of configs) {
+    const { extends: ext, rules: ruleSet, ...rest } = config;
+    if (ext) {
+      for (const name of ext) {
+        if (!extendsList.includes(name)) {
+          extendsList.push(name);
+        }
+      }
+    }
+    if (ruleSet) {
+      Object.assign(rules, ruleSet);
+    }
+    Object.assign(merged, rest);
+  }
+  if (extendsList.length > 0) {
+    merged.extends = extendsList;
+  }
+  if (Object.keys(rules).length > 0) {
+    merged.rules = rules;
+  }
+  return merged;
+}
+
+/**
  * Posts the crawl result back to the parent thread.
  * @param {import('./index.mjs').CrawlWorkerOutput} output
  */
@@ -160,21 +198,18 @@ if (pageData.status < 200 || pageData.status >= 400) {
     contentType: type,
   }));
 
-  // HTML validation. Walk every entry and remember the last one whose path
-  // matches the current page — last match wins, so callers can layer
-  // specific overrides after a default entry.
+  // HTML validation. Every entry whose path matches contributes to the
+  // page's config; configs are merged so callers can layer specific overrides
+  // on top of a baseline entry without re-stating the baseline rules.
   /** @type {{ pageUrl: string, results: import('html-validate').Result[] } | null} */
   let htmlValidateResults = null;
   if (type === 'text/html' && options.htmlValidate.length > 0) {
-    /** @type {import('./index.mjs').ResolvedHtmlValidateEntry | null} */
-    let matchedEntry = null;
-    for (const entry of options.htmlValidate) {
-      if (matchesAnyPattern(pageUrl, entry.path)) {
-        matchedEntry = entry;
-      }
-    }
+    const matchedConfigs = options.htmlValidate
+      .filter((entry) => matchesAnyPattern(pageUrl, entry.path))
+      .map((entry) => entry.config);
 
-    if (matchedEntry) {
+    if (matchedConfigs.length > 0) {
+      const mergedConfig = mergeHtmlValidateConfigs(matchedConfigs);
       const muiHtmlValidateResolver = staticResolver({
         configs: {
           'mui:recommended': {
@@ -188,7 +223,7 @@ if (pageData.status < 200 || pageData.status >= 400) {
       });
 
       const htmlValidator = new HtmlValidate(
-        new StaticConfigLoader([muiHtmlValidateResolver], matchedEntry.config),
+        new StaticConfigLoader([muiHtmlValidateResolver], mergedConfig),
       );
 
       const report = await htmlValidator.validateString(rawContent, pageUrl);

--- a/packages/code-infra/src/brokenLinksChecker/index.mjs
+++ b/packages/code-infra/src/brokenLinksChecker/index.mjs
@@ -351,7 +351,8 @@ function shouldIgnoreLink(link, ignores) {
  * @property {number} [concurrency] - Number of concurrent page fetches (defaults to 4)
  * @property {string[]} [seedUrls] - Starting URLs for the crawl (defaults to ['/'])
  * @property {IgnoreRule[]} [ignores] - Rules to ignore broken links. Each rule can have path, href, contentType, and/or has properties. All specified properties must match (AND logic). Within a property, multiple values use OR logic.
- * @property {HtmlValidateOption} [htmlValidate] - Enable HTML validation on crawled pages. `false` (default): disabled. `true`: validate with recommended rules. Object: use as html-validate config — `extends` defaults to `['mui:recommended']` when omitted, so most callers only need to set `rules`. Array: per-path config overrides — entries are walked in order and the **last** entry whose `path` matches the page URL wins; an entry without `path` matches every page (use as a default and put more specific overrides after it). If no entry matches, the page is not validated.
+ * @property {HtmlValidateOption} [htmlValidate] - Enable HTML validation on crawled pages. `false` (default): disabled. `true`: validate with recommended rules. Object: use as html-validate config — `extends` defaults to `['mui:recommended']` when omitted, so most callers only need to set `rules`. Array: per-path config overrides — every entry whose `path` matches the page URL contributes to the merged config (later entries win on conflicting rule keys); an entry without `path` matches every page (use as a baseline and layer more specific overrides on top). If no entry matches, the page is not validated.
+ * @property {boolean} [verbose] - Log extra diagnostics during crawling (e.g. resolved html-validate config per page). Defaults to `false`.
  */
 
 /**
@@ -449,6 +450,7 @@ function resolveOptions(rawOptions) {
     seedUrls: rawOptions.seedUrls ?? ['/'],
     ignores: normalizedIgnores,
     htmlValidate: resolveHtmlValidateConfig(rawOptions.htmlValidate),
+    verbose: rawOptions.verbose ?? false,
   };
 }
 

--- a/packages/code-infra/src/brokenLinksChecker/index.test.ts
+++ b/packages/code-infra/src/brokenLinksChecker/index.test.ts
@@ -62,19 +62,14 @@ describe('Broken Links Checker', () => {
         // Test href-only rule (matches from any page) - note: matches the actual href value
         { href: 'broken-relative.html' },
       ],
-      // Exercise the array form. Three entries all match /invalid-html.html;
-      // the last one wins, so its rules apply (no-dup-id ON, no-raw-characters
-      // OFF). The middle entry's `no-dup-id: off` is shadowed by the regex
-      // entry below it, demonstrating last-match-wins. The default entry
-      // applies to every other page (markdown, etc.) since the regex only
-      // matches `.html`.
+      // Exercise the array form with union semantics: every matching entry
+      // contributes to the page's config. The baseline entry (no `path`)
+      // turns off `no-raw-characters` everywhere; the path-specific entry
+      // turns off `no-dup-id` only on /invalid-html.html. Both rules are
+      // silenced on that page because the configs are merged, not replaced.
       htmlValidate: [
         { config: { rules: { 'no-raw-characters': 'off' } } },
-        {
-          path: '/invalid-html.html',
-          config: { rules: { 'no-dup-id': 'off', 'no-raw-characters': 'off' } },
-        },
-        { path: /\.html$/, config: { rules: { 'no-raw-characters': 'off' } } },
+        { path: '/invalid-html.html', config: { rules: { 'no-dup-id': 'off' } } },
       ],
     });
 
@@ -281,31 +276,16 @@ describe('Broken Links Checker', () => {
     expect(result.pages.get('/example.md')?.contentType).toBe('text/markdown');
     expect(result.pages.get('/')?.contentType).toBe('text/html');
 
-    // Test htmlValidate: invalid-html.html has duplicate IDs which should be reported
+    // Test htmlValidate union semantics: invalid-html.html has both a duplicate
+    // ID (no-dup-id) and a raw `&` (no-raw-characters). The path-specific
+    // entry silences no-dup-id; the baseline entry silences no-raw-characters.
+    // Under union semantics both apply, so the page reports zero issues.
     const htmlValidateIssues = result.issues.filter(
       (issue): issue is HtmlValidateIssue => issue.type === 'html-validate',
     );
     const invalidHtmlIssues = htmlValidateIssues.filter(
       (issue) => issue.pageUrl === '/invalid-html.html',
     );
-    expect(invalidHtmlIssues.length).toBeGreaterThan(0);
-    expect(invalidHtmlIssues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'html-validate',
-          pageUrl: '/invalid-html.html',
-          ruleId: 'no-dup-id',
-        }),
-      ]),
-    );
-
-    // Test htmlValidate override: no-raw-characters is off, so raw & should NOT be reported
-    expect(invalidHtmlIssues).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          ruleId: 'no-raw-characters',
-        }),
-      ]),
-    );
+    expect(invalidHtmlIssues).toEqual([]);
   }, 30000);
 });


### PR DESCRIPTION
Switches the broken-links checker's per-path `htmlValidate` overrides from last-match-wins to union semantics, leveraging html-validate's own preset composition.

Each entry whose path matches the current page is registered as a synthetic preset (`mui:override-N`); the page's root config `extends` them in order, so html-validate resolves and merges them with its documented semantics — no custom merge logic on our side. This lets callers layer path-specific overrides on top of a baseline entry without re-stating the baseline rules.

Also adds a generic `verbose` option to the crawl config. When set, the worker logs each page's resolved html-validate config (after `extends` resolution) via `getConfigFor(url).getConfigData()`. The flag is intentionally generic so future verbose-only diagnostics can reuse it.