### PR TITLE
Surface render-count regressions in benchmark report

### DIFF
--- a/apps/code-infra-dashboard/src/components/BenchmarkComparisonReportView.tsx
+++ b/apps/code-infra-dashboard/src/components/BenchmarkComparisonReportView.tsx
@@ -264,9 +264,16 @@ function BenchmarkAccordion({
 }) {
   const renderCount = comparison.renders.filter((row) => !row.removed).length;
 
-  const entryBar = hasBase
-    ? computeDiffBar(comparison.duration, entryDiffRange.min, entryDiffRange.max)
-    : null;
+  const renderCountSeverity = comparison.renderCount?.severity ?? 'neutral';
+  const entryBar = (() => {
+    if (!hasBase) {
+      return null;
+    }
+    if (renderCountSeverity !== 'neutral') {
+      return { left: 0, width: 100, color: DIFF_BAR_COLORS[renderCountSeverity] };
+    }
+    return computeDiffBar(comparison.duration, entryDiffRange.min, entryDiffRange.max);
+  })();
 
   return (
     <Accordion

--- a/apps/code-infra-dashboard/src/components/BenchmarkComparisonReportView.tsx
+++ b/apps/code-infra-dashboard/src/components/BenchmarkComparisonReportView.tsx
@@ -57,6 +57,21 @@ function computeDiffBar(
   };
 }
 
+function computeEntryBar(
+  comparison: ComparisonItem,
+  hasBase: boolean,
+  range: { min: number; max: number },
+): { left: number; width: number; color: string } | null {
+  if (!hasBase) {
+    return null;
+  }
+  const renderSeverity = comparison.renderCount?.severity ?? 'neutral';
+  if (renderSeverity !== 'neutral') {
+    return { left: 0, width: 100, color: DIFF_BAR_COLORS[renderSeverity] };
+  }
+  return computeDiffBar(comparison.duration, range.min, range.max);
+}
+
 function FormattedDiffMs({ diff, percent = false }: { diff: DiffValue; percent?: boolean }) {
   if (diff.absoluteDiff === 0) {
     return '\u2014';
@@ -264,16 +279,7 @@ function BenchmarkAccordion({
 }) {
   const renderCount = comparison.renders.filter((row) => !row.removed).length;
 
-  const renderCountSeverity = comparison.renderCount?.severity ?? 'neutral';
-  const entryBar = (() => {
-    if (!hasBase) {
-      return null;
-    }
-    if (renderCountSeverity !== 'neutral') {
-      return { left: 0, width: 100, color: DIFF_BAR_COLORS[renderCountSeverity] };
-    }
-    return computeDiffBar(comparison.duration, entryDiffRange.min, entryDiffRange.max);
-  })();
+  const entryBar = computeEntryBar(comparison, hasBase, entryDiffRange);
 
   return (
     <Accordion

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -3,22 +3,21 @@ import { buildBenchmarkMarkdownReport } from './buildMarkdownReport';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
 import type { BenchmarkReport, BenchmarkReportEntry } from './types';
 
-function makeEntry(totalDuration: number): BenchmarkReportEntry {
+function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
+  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
   return {
     iterations: 10,
     totalDuration,
-    renders: [
-      {
-        id: 'root',
-        phase: 'mount',
-        startTime: 0,
-        actualDuration: totalDuration,
-        stdDev: 0,
-        rawMean: totalDuration,
-        rawStdDev: 0,
-        outliers: 0,
-      },
-    ],
+    renders: Array.from({ length: renderCount }, (_unused, idx) => ({
+      id: `render-${idx}`,
+      phase: 'mount',
+      startTime: 0,
+      actualDuration: perRender,
+      stdDev: 0,
+      rawMean: perRender,
+      rawStdDev: 0,
+      outliers: 0,
+    })),
     metrics: {},
   };
 }
@@ -27,6 +26,16 @@ function makeReport(entries: Record<string, number>): BenchmarkReport {
   const report: BenchmarkReport = {};
   for (const [name, totalDuration] of Object.entries(entries)) {
     report[name] = makeEntry(totalDuration);
+  }
+  return report;
+}
+
+function makeReportFromConfig(
+  entries: Record<string, { duration: number; renders: number }>,
+): BenchmarkReport {
+  const report: BenchmarkReport = {};
+  for (const [name, { duration, renders }] of Object.entries(entries)) {
+    report[name] = makeEntry(duration, renders);
   }
   return report;
 }
@@ -79,5 +88,34 @@ describe('buildBenchmarkMarkdownReport', () => {
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).toContain('~~Button~~');
     expect(markdown).toContain('(removed)');
+  });
+
+  it('keeps rows whose render count changed even when the duration delta is within noise', () => {
+    const currentReport = makeReportFromConfig({
+      Button: { duration: 105, renders: 3 },
+      Card: { duration: 105, renders: 1 },
+    });
+    const baseReport = makeReportFromConfig({
+      Button: { duration: 100, renders: 1 },
+      Card: { duration: 100, renders: 1 },
+    });
+    const report = compareBenchmarkReports(currentReport, baseReport);
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).toContain('Button');
+    expect(markdown).not.toContain('Card');
+    expect(markdown).toContain('🔺+2');
+  });
+
+  it('does not emit the "No significant changes" branch when only render counts change', () => {
+    const currentReport = makeReportFromConfig({
+      Button: { duration: 105, renders: 2 },
+    });
+    const baseReport = makeReportFromConfig({
+      Button: { duration: 100, renders: 1 },
+    });
+    const report = compareBenchmarkReports(currentReport, baseReport);
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).not.toContain('No significant changes');
+    expect(markdown).toContain('| Test |');
   });
 });

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -1,44 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildBenchmarkMarkdownReport } from './buildMarkdownReport';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
-import type { BenchmarkReport, BenchmarkReportEntry } from './types';
-
-function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
-  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
-  return {
-    iterations: 10,
-    totalDuration,
-    renders: Array.from({ length: renderCount }, (_unused, idx) => ({
-      id: `render-${idx}`,
-      phase: 'mount',
-      startTime: 0,
-      actualDuration: perRender,
-      stdDev: 0,
-      rawMean: perRender,
-      rawStdDev: 0,
-      outliers: 0,
-    })),
-    metrics: {},
-  };
-}
-
-function makeReport(entries: Record<string, number>): BenchmarkReport {
-  const report: BenchmarkReport = {};
-  for (const [name, totalDuration] of Object.entries(entries)) {
-    report[name] = makeEntry(totalDuration);
-  }
-  return report;
-}
-
-function makeReportFromConfig(
-  entries: Record<string, { duration: number; renders: number }>,
-): BenchmarkReport {
-  const report: BenchmarkReport = {};
-  for (const [name, { duration, renders }] of Object.entries(entries)) {
-    report[name] = makeEntry(duration, renders);
-  }
-  return report;
-}
+import { makeReport, makeReportFromConfig } from './test-fixtures';
 
 describe('buildBenchmarkMarkdownReport', () => {
   it('drops within-noise rows but keeps significant regressions', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -35,6 +35,39 @@ describe('buildBenchmarkMarkdownReport', () => {
     const report = compareBenchmarkReports(makeReport(current), makeReport(base));
     const markdown = buildBenchmarkMarkdownReport(report, { maxRows: 5 });
     expect(markdown).toContain('…and 2 more');
+    expect(markdown).not.toContain('within noise');
+  });
+
+  it('mentions within-noise tests in the footer when some entries are filtered out', () => {
+    const current: Record<string, number> = { Regression: 150 };
+    const base: Record<string, number> = { Regression: 100 };
+    for (let i = 0; i < 3; i += 1) {
+      current[`Stable${i}`] = 105;
+      base[`Stable${i}`] = 100;
+    }
+    const report = compareBenchmarkReports(makeReport(current), makeReport(base));
+    const markdown = buildBenchmarkMarkdownReport(report, {
+      maxRows: 5,
+      reportUrl: 'https://example.com/details',
+    });
+    expect(markdown).toContain('3 tests within noise');
+    expect(markdown).toContain('https://example.com/details');
+  });
+
+  it('combines truncated significant count with within-noise count when both apply', () => {
+    const current: Record<string, number> = {};
+    const base: Record<string, number> = {};
+    for (let i = 0; i < 7; i += 1) {
+      current[`Reg${i}`] = 200;
+      base[`Reg${i}`] = 100;
+    }
+    for (let i = 0; i < 4; i += 1) {
+      current[`Stable${i}`] = 105;
+      base[`Stable${i}`] = 100;
+    }
+    const report = compareBenchmarkReports(makeReport(current), makeReport(base));
+    const markdown = buildBenchmarkMarkdownReport(report, { maxRows: 5 });
+    expect(markdown).toContain('…and 2 more (+4 within noise)');
   });
 
   it('renders a plain table without totals or diff columns when hasBase is false', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
@@ -69,7 +69,8 @@ export function buildBenchmarkMarkdownReport(
   lines.push('|:-----|----------:|--------:|');
 
   const visibleEntries = significant.slice(0, maxRows);
-  const remaining = significant.length - visibleEntries.length;
+  const hiddenSignificant = significant.length - visibleEntries.length;
+  const hiddenWithinNoise = report.entries.length - significant.length;
 
   for (const entry of visibleEntries) {
     const renderCount = entry.renders.filter((r) => !r.removed).length;
@@ -85,9 +86,14 @@ export function buildBenchmarkMarkdownReport(
   }
 
   const detailsLink = reportUrl ? `[details](${reportUrl})` : '';
+  const suffix = detailsLink ? ` — ${detailsLink}` : '';
   lines.push('');
-  if (remaining > 0) {
-    lines.push(`*…and ${remaining} more${detailsLink ? ` — ${detailsLink}` : ''}*`);
+  if (hiddenSignificant > 0) {
+    const noiseSuffix = hiddenWithinNoise > 0 ? ` (+${hiddenWithinNoise} within noise)` : '';
+    lines.push(`*…and ${hiddenSignificant} more${noiseSuffix}${suffix}*`);
+  } else if (hiddenWithinNoise > 0) {
+    const label = hiddenWithinNoise === 1 ? 'test' : 'tests';
+    lines.push(`*${hiddenWithinNoise} ${label} within noise${suffix}*`);
   } else if (detailsLink) {
     lines.push(detailsLink);
   }

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
@@ -54,12 +54,13 @@ export function buildBenchmarkMarkdownReport(
   const significant = report.entries.filter(
     (entry) =>
       entry.duration.severity !== 'neutral' ||
+      (entry.renderCount?.severity ?? 'neutral') !== 'neutral' ||
       entry.duration.current === null ||
       entry.duration.base === null,
   );
 
   if (report.hasBase && significant.length === 0) {
-    lines.push('*No significant changes (all within ±20%).*');
+    lines.push('*No significant changes.*');
     return lines.join('\n');
   }
 

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -1,43 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
-import type { BenchmarkReport, BenchmarkReportEntry } from './types';
-
-function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
-  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
-  return {
-    iterations: 10,
-    totalDuration,
-    renders: Array.from({ length: renderCount }, (_unused, idx) => ({
-      id: `render-${idx}`,
-      phase: 'mount',
-      startTime: 0,
-      actualDuration: perRender,
-      stdDev: 0,
-      rawMean: perRender,
-      rawStdDev: 0,
-      outliers: 0,
-    })),
-    metrics: {},
-  };
-}
-
-function makeReport(entries: Record<string, number>): BenchmarkReport {
-  const report: BenchmarkReport = {};
-  for (const [name, totalDuration] of Object.entries(entries)) {
-    report[name] = makeEntry(totalDuration);
-  }
-  return report;
-}
-
-function makeReportFromConfig(
-  entries: Record<string, { duration: number; renders: number }>,
-): BenchmarkReport {
-  const report: BenchmarkReport = {};
-  for (const [name, { duration, renders }] of Object.entries(entries)) {
-    report[name] = makeEntry(duration, renders);
-  }
-  return report;
-}
+import { makeReport, makeReportFromConfig } from './test-fixtures';
 
 describe('compareBenchmarkReports', () => {
   it('marks diffs within ±20% as neutral noise', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -155,20 +155,32 @@ describe('compareBenchmarkReports', () => {
       expect(order).toEqual(['PlusThree', 'PlusOne']);
     });
 
-    it('ranks render-count improvements ahead of zero-render-delta rows', () => {
+    it('ranks render-count improvements ahead of stable rows', () => {
       const currentReport = makeReportFromConfig({
         FewerRenders: { duration: 100, renders: 1 },
-        DurationRegression: { duration: 150, renders: 2 },
         Stable: { duration: 100, renders: 2 },
       });
       const baseReport = makeReportFromConfig({
         FewerRenders: { duration: 100, renders: 2 },
-        DurationRegression: { duration: 100, renders: 2 },
         Stable: { duration: 100, renders: 2 },
       });
       const result = compareBenchmarkReports(currentReport, baseReport);
       const order = result.entries.map((item) => item.name);
-      expect(order).toEqual(['FewerRenders', 'DurationRegression', 'Stable']);
+      expect(order).toEqual(['FewerRenders', 'Stable']);
+    });
+
+    it('ranks duration regressions ahead of render-count improvements', () => {
+      const currentReport = makeReportFromConfig({
+        FewerRenders: { duration: 100, renders: 1 },
+        DurationRegression: { duration: 150, renders: 2 },
+      });
+      const baseReport = makeReportFromConfig({
+        FewerRenders: { duration: 100, renders: 2 },
+        DurationRegression: { duration: 100, renders: 2 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['DurationRegression', 'FewerRenders']);
     });
   });
 });

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -2,22 +2,21 @@ import { describe, it, expect } from 'vitest';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
 import type { BenchmarkReport, BenchmarkReportEntry } from './types';
 
-function makeEntry(totalDuration: number): BenchmarkReportEntry {
+function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
+  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
   return {
     iterations: 10,
     totalDuration,
-    renders: [
-      {
-        id: 'root',
-        phase: 'mount',
-        startTime: 0,
-        actualDuration: totalDuration,
-        stdDev: 0,
-        rawMean: totalDuration,
-        rawStdDev: 0,
-        outliers: 0,
-      },
-    ],
+    renders: Array.from({ length: renderCount }, (_unused, idx) => ({
+      id: `render-${idx}`,
+      phase: 'mount',
+      startTime: 0,
+      actualDuration: perRender,
+      stdDev: 0,
+      rawMean: perRender,
+      rawStdDev: 0,
+      outliers: 0,
+    })),
     metrics: {},
   };
 }
@@ -26,6 +25,16 @@ function makeReport(entries: Record<string, number>): BenchmarkReport {
   const report: BenchmarkReport = {};
   for (const [name, totalDuration] of Object.entries(entries)) {
     report[name] = makeEntry(totalDuration);
+  }
+  return report;
+}
+
+function makeReportFromConfig(
+  entries: Record<string, { duration: number; renders: number }>,
+): BenchmarkReport {
+  const report: BenchmarkReport = {};
+  for (const [name, { duration, renders }] of Object.entries(entries)) {
+    report[name] = makeEntry(duration, renders);
   }
   return report;
 }
@@ -97,5 +106,67 @@ describe('compareBenchmarkReports', () => {
   it('reports hasBase: false when no base report is provided', () => {
     const result = compareBenchmarkReports(makeReport({ Button: 100 }), null);
     expect(result.hasBase).toBe(false);
+  });
+
+  describe('sort order', () => {
+    it('places render-count regressions ahead of duration-only regressions', () => {
+      const currentReport = makeReportFromConfig({
+        ExtraRenders: { duration: 105, renders: 3 },
+        DurationRegression: { duration: 150, renders: 1 },
+        Stable: { duration: 100, renders: 1 },
+      });
+      const baseReport = makeReportFromConfig({
+        ExtraRenders: { duration: 100, renders: 1 },
+        DurationRegression: { duration: 100, renders: 1 },
+        Stable: { duration: 100, renders: 1 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['ExtraRenders', 'DurationRegression', 'Stable']);
+    });
+
+    it('breaks ties on render-count delta with |duration delta| desc', () => {
+      const currentReport = makeReportFromConfig({
+        ExtraRendersSmallDuration: { duration: 105, renders: 2 },
+        ExtraRendersBigDuration: { duration: 150, renders: 2 },
+      });
+      const baseReport = makeReportFromConfig({
+        ExtraRendersSmallDuration: { duration: 100, renders: 1 },
+        ExtraRendersBigDuration: { duration: 100, renders: 1 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['ExtraRendersBigDuration', 'ExtraRendersSmallDuration']);
+    });
+
+    it('orders larger render-count regressions ahead of smaller ones', () => {
+      const currentReport = makeReportFromConfig({
+        PlusOne: { duration: 100, renders: 2 },
+        PlusThree: { duration: 100, renders: 4 },
+      });
+      const baseReport = makeReportFromConfig({
+        PlusOne: { duration: 100, renders: 1 },
+        PlusThree: { duration: 100, renders: 1 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['PlusThree', 'PlusOne']);
+    });
+
+    it('ranks render-count improvements ahead of zero-render-delta rows', () => {
+      const currentReport = makeReportFromConfig({
+        FewerRenders: { duration: 100, renders: 1 },
+        DurationRegression: { duration: 150, renders: 2 },
+        Stable: { duration: 100, renders: 2 },
+      });
+      const baseReport = makeReportFromConfig({
+        FewerRenders: { duration: 100, renders: 2 },
+        DurationRegression: { duration: 100, renders: 2 },
+        Stable: { duration: 100, renders: 2 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['FewerRenders', 'DurationRegression', 'Stable']);
+    });
   });
 });

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -52,11 +52,23 @@ describe('compareBenchmarkReports', () => {
     expect(entry.duration.hint).toBe('New');
   });
 
+  it('omits the renderCount diff for new entries so they do not look like regressions', () => {
+    const result = compareBenchmarkReports(makeReport({ Button: 100 }), makeReport({}));
+    const entry = result.entries.find((item) => item.name === 'Button')!;
+    expect(entry.renderCount).toBeUndefined();
+  });
+
   it('preserves current: null for removed entries so markdown can render them', () => {
     const result = compareBenchmarkReports(makeReport({}), makeReport({ Button: 100 }));
     const entry = result.entries.find((item) => item.name === 'Button')!;
     expect(entry.duration.current).toBeNull();
     expect(entry.duration.base).toBe(100);
+  });
+
+  it('omits the renderCount diff for removed entries so they do not look like improvements', () => {
+    const result = compareBenchmarkReports(makeReport({}), makeReport({ Button: 100 }));
+    const entry = result.entries.find((item) => item.name === 'Button')!;
+    expect(entry.renderCount).toBeUndefined();
   });
 
   it('guards against division by zero when the base value is 0', () => {
@@ -88,18 +100,45 @@ describe('compareBenchmarkReports', () => {
       expect(order).toEqual(['ExtraRenders', 'DurationRegression', 'Stable']);
     });
 
-    it('breaks ties on render-count delta with |duration delta| desc', () => {
+    it('tie-breaks equal render-count regressions by duration severity', () => {
       const currentReport = makeReportFromConfig({
-        ExtraRendersSmallDuration: { duration: 105, renders: 2 },
-        ExtraRendersBigDuration: { duration: 150, renders: 2 },
+        ExtraRendersDurationWithinNoise: { duration: 105, renders: 2 },
+        ExtraRendersDurationRegression: { duration: 150, renders: 2 },
       });
       const baseReport = makeReportFromConfig({
-        ExtraRendersSmallDuration: { duration: 100, renders: 1 },
-        ExtraRendersBigDuration: { duration: 100, renders: 1 },
+        ExtraRendersDurationWithinNoise: { duration: 100, renders: 1 },
+        ExtraRendersDurationRegression: { duration: 100, renders: 1 },
       });
       const result = compareBenchmarkReports(currentReport, baseReport);
       const order = result.entries.map((item) => item.name);
-      expect(order).toEqual(['ExtraRendersBigDuration', 'ExtraRendersSmallDuration']);
+      expect(order).toEqual(['ExtraRendersDurationRegression', 'ExtraRendersDurationWithinNoise']);
+    });
+
+    it('tie-breaks equal render-count regressions with equal duration severity by |duration delta|', () => {
+      const currentReport = makeReportFromConfig({
+        SmallDurationDelta: { duration: 125, renders: 2 },
+        BigDurationDelta: { duration: 150, renders: 2 },
+      });
+      const baseReport = makeReportFromConfig({
+        SmallDurationDelta: { duration: 100, renders: 1 },
+        BigDurationDelta: { duration: 100, renders: 1 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['BigDurationDelta', 'SmallDurationDelta']);
+    });
+
+    it('keeps new entries from outranking real render-count regressions', () => {
+      const currentReport = makeReportFromConfig({
+        BrandNew: { duration: 100, renders: 3 },
+        ExtraRenders: { duration: 100, renders: 3 },
+      });
+      const baseReport = makeReportFromConfig({
+        ExtraRenders: { duration: 100, renders: 1 },
+      });
+      const result = compareBenchmarkReports(currentReport, baseReport);
+      const order = result.entries.map((item) => item.name);
+      expect(order).toEqual(['ExtraRenders', 'BrandNew']);
     });
 
     it('orders larger render-count regressions ahead of smaller ones', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -236,7 +236,9 @@ export function compareBenchmarkReports(
     entries.push({
       name,
       duration,
-      renderCount: makeCountDiffValue(entry.renders.length, baseEntry?.renders.length ?? 0),
+      renderCount: baseEntry
+        ? makeCountDiffValue(entry.renders.length, baseEntry.renders.length)
+        : undefined,
       renders: compareRenders(entry.renders, baseEntry),
       metrics: compareMetrics(entry.metrics, baseEntry),
       iterations: entry.iterations,
@@ -266,7 +268,6 @@ export function compareBenchmarkReports(
     entries.push({
       name,
       duration,
-      renderCount: makeCountDiffValue(0, baseEntry.renders.length),
       renders: compareRenders([], baseEntry),
       metrics: compareMetrics({}, baseEntry),
       iterations: 0,

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -190,7 +190,18 @@ function compareMetrics(
   return entries;
 }
 
+function worstSeverityRank(item: ComparisonItem): number {
+  const renderRank = SEVERITY_RANK[item.renderCount?.severity ?? 'neutral'];
+  const durationRank = SEVERITY_RANK[item.duration.severity];
+  return Math.min(renderRank, durationRank);
+}
+
 function compareItems(a: ComparisonItem, b: ComparisonItem): number {
+  const worstDelta = worstSeverityRank(a) - worstSeverityRank(b);
+  if (worstDelta !== 0) {
+    return worstDelta;
+  }
+
   const aRenderSeverity = a.renderCount?.severity ?? 'neutral';
   const bRenderSeverity = b.renderCount?.severity ?? 'neutral';
   const renderSeverityDelta = SEVERITY_RANK[aRenderSeverity] - SEVERITY_RANK[bRenderSeverity];

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -191,10 +191,25 @@ function compareMetrics(
 }
 
 function compareItems(a: ComparisonItem, b: ComparisonItem): number {
-  const severityDelta = SEVERITY_RANK[a.duration.severity] - SEVERITY_RANK[b.duration.severity];
-  if (severityDelta !== 0) {
-    return severityDelta;
+  const aRenderSeverity = a.renderCount?.severity ?? 'neutral';
+  const bRenderSeverity = b.renderCount?.severity ?? 'neutral';
+  const renderSeverityDelta = SEVERITY_RANK[aRenderSeverity] - SEVERITY_RANK[bRenderSeverity];
+  if (renderSeverityDelta !== 0) {
+    return renderSeverityDelta;
   }
+
+  const renderDiffDelta =
+    Math.abs(b.renderCount?.absoluteDiff ?? 0) - Math.abs(a.renderCount?.absoluteDiff ?? 0);
+  if (renderDiffDelta !== 0) {
+    return renderDiffDelta;
+  }
+
+  const durationSeverityDelta =
+    SEVERITY_RANK[a.duration.severity] - SEVERITY_RANK[b.duration.severity];
+  if (durationSeverityDelta !== 0) {
+    return durationSeverityDelta;
+  }
+
   return Math.abs(b.duration.absoluteDiff) - Math.abs(a.duration.absoluteDiff);
 }
 

--- a/apps/code-infra-dashboard/src/lib/benchmark/test-fixtures.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/test-fixtures.ts
@@ -1,0 +1,38 @@
+import type { BenchmarkReport, BenchmarkReportEntry } from './types';
+
+export function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
+  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
+  return {
+    iterations: 10,
+    totalDuration,
+    renders: Array.from({ length: renderCount }, (_, index) => ({
+      id: `render-${index}`,
+      phase: 'mount',
+      startTime: 0,
+      actualDuration: perRender,
+      stdDev: 0,
+      rawMean: perRender,
+      rawStdDev: 0,
+      outliers: 0,
+    })),
+    metrics: {},
+  };
+}
+
+export function makeReport(entries: Record<string, number>): BenchmarkReport {
+  const report: BenchmarkReport = {};
+  for (const [name, totalDuration] of Object.entries(entries)) {
+    report[name] = makeEntry(totalDuration);
+  }
+  return report;
+}
+
+export function makeReportFromConfig(
+  entries: Record<string, { duration: number; renders: number }>,
+): BenchmarkReport {
+  const report: BenchmarkReport = {};
+  for (const [name, { duration, renders }] of Object.entries(entries)) {
+    report[name] = makeEntry(duration, renders);
+  }
+  return report;
+}


### PR DESCRIPTION
The benchmark report sort and PR-comment filter only looked at `duration.absoluteDiff`, so tests that grew extra renders but stayed within the ±20% duration noise band were sorted to the bottom of the dashboard table and dropped from the PR comment entirely.

`compareItems` now sorts by render-count severity and magnitude first, then falls back to duration severity and magnitude. The "significant" filter in the markdown builder also keeps rows whose `renderCount.severity` is non-neutral, and the no-changes message drops the misleading "±20%" parenthetical since render-count changes aren't subject to a noise threshold.

[before](https://code-infra-dashboard.onrender.com/benchmark-details/mui/base-ui-charts?sha=aad8365ca561170e2ef9f321bd4d779bdff96780&base=cec136c20af996eccffa0cc4a9f1cd7531ed3da6&prNumber=374&baseRef=master)

[after](https://code-infra-dashboard-pr-1449.onrender.com/benchmark-details/mui/base-ui-charts?sha=aad8365ca561170e2ef9f321bd4d779bdff96780&base=cec136c20af996eccffa0cc4a9f1cd7531ed3da6&prNumber=374&baseRef=master)