### PR TITLE
[dashboard] Stop exposing KPI fetchers as Server Actions

### DIFF
--- a/apps/code-infra-dashboard/app/(dashboard)/kpis/page.tsx
+++ b/apps/code-infra-dashboard/app/(dashboard)/kpis/page.tsx
@@ -6,7 +6,7 @@ import Grid from '@mui/material/Grid';
 import Heading from '@/components/Heading';
 import KpiCard from '@/components/KpiCard';
 import LinkCardActionArea from '@/components/LinkCardActionArea';
-import { kpiRegistry, type KpiConfig } from '@/lib/kpis';
+import { kpiRegistry, toKpiInfo, type KpiConfig } from '@/lib/kpis';
 
 export const revalidate = 3600; // 1 hour ISR
 
@@ -16,7 +16,7 @@ export const metadata = { title: 'KPIs dashboard' };
 
 async function KpiCardAsync({ kpi }: { kpi: KpiConfig<any[]> }) {
   const result = await kpi.fetch(...(kpi.fetchParams ?? []));
-  return <KpiCard kpi={kpi} result={result} />;
+  return <KpiCard kpi={toKpiInfo(kpi)} result={result} />;
 }
 
 // Group KPIs by logical category
@@ -45,7 +45,7 @@ export default function KpisPage() {
                   <Card sx={{ height: '100%' }}>
                     <LinkCardActionArea href={`/kpis/${kpi.id}`}>
                       <CardContent sx={{ flexGrow: 1 }}>
-                        <React.Suspense fallback={<KpiCard kpi={kpi} loading />}>
+                        <React.Suspense fallback={<KpiCard kpi={toKpiInfo(kpi)} loading />}>
                           <KpiCardAsync kpi={kpi} />
                         </React.Suspense>
                       </CardContent>

--- a/apps/code-infra-dashboard/app/kpis/[id]/page.tsx
+++ b/apps/code-infra-dashboard/app/kpis/[id]/page.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { notFound } from 'next/navigation';
 import Box from '@mui/material/Box';
-import { getKpiById, getAllKpiIds } from '@/lib/kpis';
+import { getKpiById, getAllKpiIds, toKpiInfo } from '@/lib/kpis';
 import KpiDetail from '@/views/KpiDetail';
 
 export async function generateStaticParams() {
@@ -26,7 +26,7 @@ export default async function KpiPage({ params }: PageProps) {
 
   return (
     <Box sx={{ p: 2 }}>
-      <KpiDetail kpi={kpi} result={result} />
+      <KpiDetail kpi={toKpiInfo(kpi)} result={result} />
     </Box>
   );
 }

--- a/apps/code-infra-dashboard/src/components/KpiCard.tsx
+++ b/apps/code-infra-dashboard/src/components/KpiCard.tsx
@@ -7,10 +7,10 @@ import Stack from '@mui/material/Stack';
 import Tooltip from '@mui/material/Tooltip';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import HealthBadge from './HealthBadge';
-import type { KpiConfig, KpiResult } from '../lib/kpis';
+import type { KpiInfo, KpiResult } from '../lib/kpis';
 
 interface KpiCardProps {
-  kpi: KpiConfig<any[]>;
+  kpi: KpiInfo;
   result?: KpiResult;
   loading?: boolean;
 }

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/circleCI.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/circleCI.ts
@@ -3,7 +3,7 @@ import { checkHttpError, errorResult, successResult } from './utils';
 
 export async function fetchCompletionTime(repository: string): Promise<KpiResult> {
   const response = await fetch(
-    `https://circleci.com/api/v2/insights/github/mui/${repository}/workflows/pipeline/summary?analytics-segmentation=web-ui-insights&reporting-window=last-7-days&workflow-name=pipeline`,
+    `https://circleci.com/api/v2/insights/github/mui/${encodeURIComponent(repository)}/workflows/pipeline/summary?analytics-segmentation=web-ui-insights&reporting-window=last-7-days&workflow-name=pipeline`,
     { next: { revalidate: 3600 } },
   );
 

--- a/apps/code-infra-dashboard/src/lib/kpis/index.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/index.ts
@@ -1,2 +1,2 @@
-export type { KpiConfig, KpiResult } from './types';
-export { kpiRegistry, getKpiById, getAllKpiIds } from './registry';
+export type { KpiConfig, KpiInfo, KpiResult } from './types';
+export { kpiRegistry, getKpiById, getAllKpiIds, toKpiInfo } from './registry';

--- a/apps/code-infra-dashboard/src/lib/kpis/registry.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/registry.ts
@@ -1,4 +1,4 @@
-import type { KpiConfig } from './types';
+import type { KpiConfig, KpiInfo } from './types';
 import type { Repository } from '../../constants';
 import { MUI_KPI_REPOS } from '../../constants';
 import * as github from './fetchers/github';
@@ -13,7 +13,6 @@ type Repo = Repository & { ossInsightId: string };
 const REPOS = MUI_KPI_REPOS.filter((r): r is Repo => !!r.ossInsightId);
 
 async function fetchOpenPRs(repoName: string) {
-  'use server';
   return github.fetchOpenPRs(repoName);
 }
 
@@ -31,7 +30,6 @@ function createOpenPRsCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchWaitingForMaintainer(repoName: string) {
-  'use server';
   return github.fetchWaitingForMaintainer(repoName);
 }
 
@@ -49,7 +47,6 @@ function createWaitingForMaintainerCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchHeadCISuccessRate(repoName: string) {
-  'use server';
   return github.fetchCommitStatuses(repoName);
 }
 
@@ -67,7 +64,6 @@ function createHeadCISuccessRateCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchMedianTimeToCompletion(ossInsightId: string) {
-  'use server';
   return ossInsight.fetchMedianTimeToCompletion(ossInsightId);
 }
 
@@ -85,7 +81,6 @@ function createMedianTimeToCompletionCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchIssueFirstComment(ossInsightId: string) {
-  'use server';
   return ossInsight.fetchIssueFirstComment(ossInsightId);
 }
 
@@ -103,7 +98,6 @@ function createIssueFirstCommentCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchClosedVsOpenedIssues(ossInsightId: string) {
-  'use server';
   return ossInsight.fetchClosedVsOpenedIssues(ossInsightId);
 }
 
@@ -121,7 +115,6 @@ function createClosedVsOpenedIssuesCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchCommunityContributors(ossInsightId: string) {
-  'use server';
   return ossInsight.fetchContributorsPerMonth(ossInsightId);
 }
 
@@ -139,7 +132,6 @@ function createCommunityContributorsCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchCommunityPRs(ossInsightId: string) {
-  'use server';
   return ossInsight.fetchPrsPerMonth(ossInsightId);
 }
 
@@ -157,7 +149,6 @@ function createCommunityPRsCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchCICompletionTime(repoName: string) {
-  'use server';
   return circleCI.fetchCompletionTime(repoName);
 }
 
@@ -175,7 +166,6 @@ function createCICompletionTimeCard(repo: Repo): KpiConfig<[string]> {
 }
 
 async function fetchMissingGitHubLabel(repoName: string) {
-  'use server';
   return github.fetchMissingGitHubLabel(repoName);
 }
 
@@ -216,7 +206,6 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
     thresholds: { warning: 5, problem: 8, lowerIsBetter: true },
     group: 'Support',
     fetch: async () => {
-      'use server';
       return zendesk.fetchFirstReply();
     },
   },
@@ -228,7 +217,6 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
     thresholds: { warning: 90, problem: 80, lowerIsBetter: false },
     group: 'Support',
     fetch: async () => {
-      'use server';
       return zendesk.fetchSatisfactionScore();
     },
   },
@@ -242,7 +230,6 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
     thresholds: { warning: 30, problem: 15, lowerIsBetter: false },
     group: 'People',
     fetch: async () => {
-      'use server';
       return hibob.fetchGender();
     },
   },
@@ -254,7 +241,6 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
     thresholds: { warning: 14, problem: 7, lowerIsBetter: false },
     group: 'People',
     fetch: async () => {
-      'use server';
       return hibob.fetchGender('256186803');
     },
   },
@@ -266,7 +252,6 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
     thresholds: { warning: 30, problem: 15, lowerIsBetter: false },
     group: 'People',
     fetch: async () => {
-      'use server';
       return hibob.fetchGenderManagement();
     },
   },
@@ -280,7 +265,6 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
     thresholds: { warning: 10, problem: 15, lowerIsBetter: true },
     group: 'Store',
     fetch: async () => {
-      'use server';
       return store.fetchOverdueRatio();
     },
   },
@@ -288,6 +272,11 @@ export const kpiRegistry: KpiConfig<any[]>[] = [
 
 export function getKpiById(id: string): KpiConfig<any[]> | undefined {
   return kpiRegistry.find((kpi) => kpi.id === id);
+}
+
+export function toKpiInfo(kpi: KpiConfig<any[]>): KpiInfo {
+  const { id, title, description, unit, thresholds, group } = kpi;
+  return { id, title, description, unit, thresholds, group };
 }
 
 export function getAllKpiIds(): string[] {

--- a/apps/code-infra-dashboard/src/lib/kpis/types.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/types.ts
@@ -4,13 +4,16 @@ export interface KpiThresholds {
   lowerIsBetter: boolean;
 }
 
-export type KpiConfig<TArgs extends unknown[] = []> = {
+export interface KpiInfo {
   id: string;
   title: string;
   description?: string;
   unit: string;
   thresholds: KpiThresholds;
   group: string;
+}
+
+export type KpiConfig<TArgs extends unknown[] = []> = KpiInfo & {
   fetch: (...args: TArgs) => Promise<KpiResult>;
 } & ([] extends TArgs ? { fetchParams?: TArgs } : { fetchParams: TArgs });
 

--- a/apps/code-infra-dashboard/src/views/KpiDetail.tsx
+++ b/apps/code-infra-dashboard/src/views/KpiDetail.tsx
@@ -2,10 +2,10 @@
 
 import * as React from 'react';
 import KpiCard from '../components/KpiCard';
-import type { KpiConfig, KpiResult } from '../lib/kpis';
+import type { KpiInfo, KpiResult } from '../lib/kpis';
 
 interface KpiDetailProps {
-  kpi: KpiConfig<any[]>;
+  kpi: KpiInfo;
   result: KpiResult;
 }
 


### PR DESCRIPTION
## Summary

- Drop the `'use server'` directives in `lib/kpis/registry.ts`. They were only needed because the full `kpi` object (with `.fetch`) was passed to client components — but `KpiCard` and `KpiDetail` never invoke the fetcher, they only read display metadata.
- Introduce a `KpiInfo` type and a `toKpiInfo()` helper that strips `fetch`/`fetchParams` server-side before crossing the boundary.
- Removes the Server Action endpoints CodeQL flagged in [`js/request-forgery` alert #63](https://github.com/mui/mui-public/security/code-scanning/63), plus latent same-shape exposure on the other 9 per-repo fetchers.
- Keeps `encodeURIComponent` on the CircleCI URL as defense in depth.