### PR TITLE
[docs-infra] Avoid using node:path in client code

### DIFF
--- a/docs/app/docs-infra/components/code-controller-context/demos/demo-live/createLiveDemo.ts
+++ b/docs/app/docs-infra/components/code-controller-context/demos/demo-live/createLiveDemo.ts
@@ -7,7 +7,7 @@ import {
 
 import { DemoLiveContent as DemoContent } from './DemoLiveContent';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -19,7 +19,7 @@ const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 export const createLiveDemo = createDemoFactory({
   DemoContent,
   controlled: true,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -33,6 +33,6 @@ export const createLiveDemo = createDemoFactory({
 export const createLiveDemoWithVariants = createDemoWithVariantsFactory({
   DemoContent,
   controlled: true,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/app/docs-infra/components/code-highlighter/demos/createDemo.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/createDemo.ts
@@ -8,7 +8,7 @@ import {
 import { DemoContent } from './DemoContent';
 import { DemoTitle } from './DemoTitle';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -20,7 +20,7 @@ const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 export const createDemo = createDemoFactory({
   DemoContent,
   DemoTitle,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -34,6 +34,6 @@ export const createDemo = createDemoFactory({
 export const createDemoWithVariants = createDemoWithVariantsFactory({
   DemoContent,
   DemoTitle,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-files/createDemo.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-files/createDemo.ts
@@ -8,7 +8,7 @@ import {
 import { DemoContentLoading } from './DemoContentLoading';
 import { DemoContent } from '../DemoContent';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -21,7 +21,7 @@ export const createDemo = createDemoFactory({
   DemoContentLoading,
   DemoContent,
   fallbackUsesExtraFiles: true,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -36,6 +36,6 @@ export const createDemoWithVariants = createDemoWithVariantsFactory({
   DemoContentLoading,
   DemoContent,
   fallbackUsesExtraFiles: true,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-variants/createDemo.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-variants/createDemo.ts
@@ -8,7 +8,7 @@ import {
 import { DemoContentLoading } from './DemoContentLoading';
 import { DemoContent } from '../DemoContent';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -21,7 +21,7 @@ export const createDemo = createDemoFactory({
   DemoContentLoading,
   DemoContent,
   fallbackUsesAllVariants: true,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -36,6 +36,6 @@ export const createDemoWithVariants = createDemoWithVariantsFactory({
   DemoContentLoading,
   DemoContent,
   fallbackUsesAllVariants: true,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback/createDemo.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback/createDemo.ts
@@ -8,7 +8,7 @@ import {
 import { DemoContentLoading } from './DemoContentLoading';
 import { DemoContent } from '../DemoContent';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -20,7 +20,7 @@ const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 export const createDemo = createDemoFactory({
   DemoContentLoading,
   DemoContent,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -34,6 +34,6 @@ export const createDemo = createDemoFactory({
 export const createDemoWithVariants = createDemoWithVariantsFactory({
   DemoContentLoading,
   DemoContent,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-server-loaded/createDemo.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-server-loaded/createDemo.ts
@@ -25,7 +25,7 @@ export const createDemo = createDemoFactory({
   loadCodeMeta: loadServerCodeMeta,
   loadSource,
   sourceParser,
-  projectPath: process.env.SOURCE_CODE_ROOT_PATH,
+  projectDir: process.env.SOURCE_CODE_ROOT_DIR,
   projectUrl: process.env.SOURCE_CODE_ROOT_URL,
 });
 
@@ -41,6 +41,6 @@ export const createDemoWithVariants = createDemoWithVariantsFactory({
   loadCodeMeta: loadServerCodeMeta,
   loadSource,
   sourceParser,
-  projectPath: process.env.SOURCE_CODE_ROOT_PATH,
+  projectDir: process.env.SOURCE_CODE_ROOT_DIR,
   projectUrl: process.env.SOURCE_CODE_ROOT_URL,
 });

--- a/docs/app/docs-infra/components/code-provider/demos/createDemo.ts
+++ b/docs/app/docs-infra/components/code-provider/demos/createDemo.ts
@@ -6,7 +6,7 @@ import {
 import { DemoContent } from '../../code-highlighter/demos/DemoContent';
 import { DemoTitle } from '../../code-highlighter/demos/DemoTitle';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -18,7 +18,7 @@ const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 export const createDemo = createDemoFactory({
   DemoContent,
   DemoTitle,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -32,6 +32,6 @@ export const createDemo = createDemoFactory({
 export const createDemoWithVariants = createDemoWithVariantsFactory({
   DemoContent,
   DemoTitle,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-demo/createDemo.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-demo/createDemo.ts
@@ -8,19 +8,19 @@ import {
 import { CollapsibleDemoContent as DemoContent } from '../CollapsibleDemoContent';
 import { DemoTitle } from '../../../../components/code-highlighter/demos/DemoTitle';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 export const createDemo = createDemoFactory({
   DemoContent,
   DemoTitle,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
 export const createDemoWithVariants = createDemoWithVariantsFactory({
   DemoContent,
   DemoTitle,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/docs/functions/createDemoPerformance/createDemoPerformance.tsx
+++ b/docs/functions/createDemoPerformance/createDemoPerformance.tsx
@@ -8,7 +8,7 @@ import {
 import { DemoPerformanceContent } from '@/components/DemoPerformanceContent';
 import { DemoPerformanceContentLoading } from '@/components/DemoPerformanceContentLoading';
 
-const projectPath = process.env.SOURCE_CODE_ROOT_PATH;
+const projectDir = process.env.SOURCE_CODE_ROOT_DIR;
 const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 
 /**
@@ -21,7 +21,7 @@ const projectUrl = process.env.SOURCE_CODE_ROOT_URL;
 export const createDemoPerformance = createDemoFactory({
   DemoContent: DemoPerformanceContent,
   DemoContentLoading: DemoPerformanceContentLoading,
-  projectPath,
+  projectDir,
   projectUrl,
 });
 
@@ -36,6 +36,6 @@ export const createDemoPerformance = createDemoFactory({
 export const createDemoPerformanceWithVariants = createDemoWithVariantsFactory({
   DemoContent: DemoPerformanceContent,
   DemoContentLoading: DemoPerformanceContentLoading,
-  projectPath,
+  projectDir,
   projectUrl,
 });

--- a/packages/docs-infra/src/abstractCreateDemo/abstractCreateDemo.tsx
+++ b/packages/docs-infra/src/abstractCreateDemo/abstractCreateDemo.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { pathToFileURL } from 'node:url';
 import { CodeHighlighter } from '../CodeHighlighter';
 import {
   applyUrlPrefixToCode,
@@ -51,20 +50,20 @@ type AbstractCreateDemoOptions<T extends {}> = {
   sourceParser?: Promise<ParseSource>;
   sourceEnhancers?: SourceEnhancers;
   /**
-   * Absolute filesystem path of the project root used to resolve `url`s
-   * gathered from `import.meta.url`. Combined with `projectUrl` to rewrite
-   * local `file://` URLs into hosted Git URLs (e.g.
+   * `file://` URL of the project root used to resolve `url`s gathered from
+   * `import.meta.url`. Combined with `projectUrl` to rewrite local `file://`
+   * URLs into hosted Git URLs (e.g.
    * `https://github.com/owner/repo/tree/<branch>/`) before they reach the
    * `CodeHighlighter`.
    *
    * Typically read from an environment variable populated by the build
-   * pipeline (e.g. Netlify's `REPOSITORY_URL`/`BRANCH` plus
-   * `git rev-parse --show-toplevel`). When either `projectPath` or
-   * `projectUrl` is missing, URLs are left untouched.
+   * pipeline (e.g. `process.env.SOURCE_CODE_ROOT_DIR` from
+   * `withDeploymentConfig`). When either `projectDir` or `projectUrl` is
+   * missing, URLs are left untouched.
    */
-  projectPath?: string;
+  projectDir?: string;
   /**
-   * Public URL prefix that maps to `projectPath`. See `projectPath` for
+   * Public URL prefix that maps to `projectDir`. See `projectDir` for
    * details.
    */
   projectUrl?: string;
@@ -100,7 +99,7 @@ export function abstractCreateDemo<T extends {}>(
   // the `urlPrefix` prop on `<CodeHighlighter>` (forwarded into
   // `loadIsomorphicCodeVariant`) takes care of rewriting the loaded variant after the
   // file is read.
-  const urlPrefix = resolveUrlPrefix(options.projectPath, options.projectUrl);
+  const urlPrefix = resolveUrlPrefix(options.projectDir, options.projectUrl);
   const resolvedUrl =
     urlPrefix && demoData.precompute
       ? (replaceUrlPrefix(demoData.url, urlPrefix) ?? demoData.url)
@@ -177,13 +176,13 @@ export function abstractCreateDemo<T extends {}>(
 }
 
 function resolveUrlPrefix(
-  projectPath: string | undefined,
+  projectDir: string | undefined,
   projectUrl: string | undefined,
 ): UrlPrefix | undefined {
-  if (!projectPath || !projectUrl) {
+  if (!projectDir || !projectUrl) {
     return undefined;
   }
-  const from = `${pathToFileURL(projectPath).href}/`;
+  const from = projectDir.endsWith('/') ? projectDir : `${projectDir}/`;
   const to = projectUrl.endsWith('/') ? projectUrl : `${projectUrl}/`;
   return { from, to };
 }

--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -68,13 +68,23 @@ process.env.SHOW_PRIVATE_PAGES = SHOW_PRIVATE_PAGES;
  * Resolves to an empty string when neither source yields a value.
  */
 const repoRootDir = findRepoRootDir();
-// Stored as a `file://` URL (with trailing slash) so consumers can use it in
-// isomorphic code without depending on Node's `url` module to convert from a
-// filesystem path.
-const SOURCE_CODE_ROOT_DIR = repoRootDir ? `${pathToFileURL(repoRootDir).href}/` : '';
+// Stored as a `file://` URL (with exactly one trailing slash) so consumers
+// can use it in isomorphic code without depending on Node's `url` module to
+// convert from a filesystem path. We normalize via the `URL` object so a repo
+// root that already ends in a separator (e.g. `/` or `C:\` at a drive root)
+// doesn't produce a double-slash suffix.
+const SOURCE_CODE_ROOT_DIR = repoRootDir ? toDirFileUrl(repoRootDir) : '';
 const SOURCE_CODE_ROOT_URL = resolveSourceCodeRootUrl(repoRootDir);
 process.env.SOURCE_CODE_ROOT_DIR = SOURCE_CODE_ROOT_DIR;
 process.env.SOURCE_CODE_ROOT_URL = SOURCE_CODE_ROOT_URL;
+
+function toDirFileUrl(dir: string): string {
+  const url = pathToFileURL(dir);
+  if (!url.pathname.endsWith('/')) {
+    url.pathname = `${url.pathname}/`;
+  }
+  return url.href;
+}
 
 function resolveSourceCodeRootUrl(rootDir: string | undefined): string {
   const repositoryUrl =

--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -4,6 +4,7 @@ import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import * as os from 'node:os';
 import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 // Read Next.js version to handle version-specific config
 const nextMajorVersion = parseInt(pkgJson.version.split('.')[0], 10);
@@ -67,9 +68,12 @@ process.env.SHOW_PRIVATE_PAGES = SHOW_PRIVATE_PAGES;
  * Resolves to an empty string when neither source yields a value.
  */
 const repoRootDir = findRepoRootDir();
-const SOURCE_CODE_ROOT_PATH = repoRootDir ?? '';
+// Stored as a `file://` URL (with trailing slash) so consumers can use it in
+// isomorphic code without depending on Node's `url` module to convert from a
+// filesystem path.
+const SOURCE_CODE_ROOT_DIR = repoRootDir ? `${pathToFileURL(repoRootDir).href}/` : '';
 const SOURCE_CODE_ROOT_URL = resolveSourceCodeRootUrl(repoRootDir);
-process.env.SOURCE_CODE_ROOT_PATH = SOURCE_CODE_ROOT_PATH;
+process.env.SOURCE_CODE_ROOT_DIR = SOURCE_CODE_ROOT_DIR;
 process.env.SOURCE_CODE_ROOT_URL = SOURCE_CODE_ROOT_URL;
 
 function resolveSourceCodeRootUrl(rootDir: string | undefined): string {
@@ -215,10 +219,10 @@ export function withDeploymentConfig<T extends NextConfig>(nextConfig: T): T {
       // commit (e.g. `https://github.com/owner/repo/tree/<branch>/`). Derived
       // from REPOSITORY_URL/BRANCH with package.json/git fallbacks.
       SOURCE_CODE_ROOT_URL,
-      // Absolute filesystem path of the repository root, used to translate
-      // `import.meta.url` file URLs into paths relative to the repo root
-      // before applying SOURCE_CODE_ROOT_URL.
-      SOURCE_CODE_ROOT_PATH,
+      // `file://` URL (with trailing slash) of the repository root, used to
+      // translate `import.meta.url` file URLs into paths relative to the repo
+      // root before applying SOURCE_CODE_ROOT_URL.
+      SOURCE_CODE_ROOT_DIR,
       // For template images
       TEMPLATE_IMAGE_URL: '',
     },


### PR DESCRIPTION
Refactor the code to replace instances of `process.env.SOURCE_CODE_ROOT_PATH` with `process.env.SOURCE_CODE_ROOT_DIR`, eliminating the use of `node:path` in client-side code. This change enhances compatibility and simplifies the environment variable usage.