### PR TITLE
[security] Better isolate publish OIDC action

### DIFF
--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -1,8 +1,9 @@
-name: 'Publish Preparation'
-description: 'Common setup steps for publishing MUI packages (after checkout)'
+name: Publish preparation
+
+description: Common setup steps for publishing MUI packages (after checkout)
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Set up pnpm
       uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -13,6 +14,7 @@ runs:
         # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
     # Ensure npm 11.5.1 or later is installed
     - name: Update npm
       shell: bash


### PR DESCRIPTION
Looking at how TanStack got hacked https://tanstack.com/blog/npm-supply-chain-compromise-postmortem#2-github-actions-cache-poisoning-across-trust-boundaries, I don't trust GitHub Action cache.

Considering how `package-manager-cache` is implemented https://github.com/actions/setup-node/blob/670825a89dc0abd596e7a3abd0f5e3f6e5faf37c/src/main.ts#L85, it seems that if someone manages to corrupt our pnpm cache on the baseline branch, they will be able to escalate their permissions to the npm packages that we publish. So instead, why not rely on the trusted source (https://registry.npmjs.org) and better isolate our publishing GitHub Action from the rest with no cache?

From our CI measure, we concluded that no pnpm cache make the npm installation faster, so, it's only win-win.