### PR TITLE
[docs-infra] Fix visibility detection for CSS-collapsed frames in `<Pre>` component

### DIFF
--- a/packages/docs-infra/src/useCode/Pre.test.tsx
+++ b/packages/docs-infra/src/useCode/Pre.test.tsx
@@ -310,6 +310,14 @@ describe('Pre', () => {
   });
 
   it('shares a single document `toggle` listener across mounted <Pre> instances', () => {
+    // Belt-and-suspenders: this test has tight numeric invariants on
+    // subscriber accounting (`toHaveLength(1)` etc.) and `<Pre>`'s
+    // `<details>` toggle subscriber registry lives at module scope, so
+    // any leaked mount from a prior test (e.g. one that threw before
+    // the global `afterEach` ran) would already have a listener
+    // attached and our new mount would be a no-op for the spy.
+    cleanup();
+
     const addSpy = vi.spyOn(document, 'addEventListener');
     const removeSpy = vi.spyOn(document, 'removeEventListener');
 

--- a/packages/docs-infra/src/useCode/Pre.test.tsx
+++ b/packages/docs-infra/src/useCode/Pre.test.tsx
@@ -2,8 +2,9 @@
  * @vitest-environment jsdom
  */
 import * as React from 'react';
+// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
 import { render, screen, waitFor, cleanup } from '@testing-library/react';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi, afterEach } from 'vitest';
 import type { HastRoot, ParseSource, SourceComments } from '../CodeHighlighter/types';
 import { createParseSource } from '../pipeline/parseSource';
 import { enhanceCodeEmphasis } from '../pipeline/enhanceCodeEmphasis';
@@ -213,6 +214,20 @@ function EditablePreview() {
 }
 
 describe('Pre', () => {
+  // Tests share module-level state (the per-test mock hooks above and
+  // `<Pre>`'s own module-level toggle subscriber registry). Reset
+  // everything between tests so a future test that throws synchronously
+  // — or simply forgets explicit cleanup — can't leak hooks/subscribers
+  // into the next one. RTL's auto-cleanup is a no-op here because the
+  // root vitest config does not set `globals: true`.
+  afterEach(() => {
+    cleanup();
+    mockIntersectionRect = null;
+    observeCalls = null;
+    unobserveCalls = null;
+    resizeObserverInstances = null;
+  });
+
   it('keeps the </p> line and following </div> line separate after rerender', async () => {
     render(<EditablePreview />);
     const pre = screen.getByText('Type Whatever You Want Below', { exact: false }).closest('pre');
@@ -261,62 +276,51 @@ describe('Pre', () => {
       return { x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
     };
 
-    try {
-      const { container } = render(<EditablePreview />);
-      // Inspecting internal frame elements (`.frame` / `data-frame-type`),
-      // not user-facing roles, so reach in via the container.
-      // eslint-disable-next-line testing-library/no-container
-      const pre = container.querySelector('pre');
-      expect(pre).not.toBeNull();
+    const { container } = render(<EditablePreview />);
+    // Inspecting internal frame elements (`.frame` / `data-frame-type`),
+    // not user-facing roles, so reach in via the container.
+    // eslint-disable-next-line testing-library/no-container
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
 
-      await waitFor(() => {
-        const frames = Array.from(pre!.querySelectorAll('.frame'));
-        expect(frames.length).toBeGreaterThan(0);
-      });
-
+    await waitFor(() => {
       const frames = Array.from(pre!.querySelectorAll('.frame'));
-      const highlightedFrames = frames.filter(
-        (frame) => frame.getAttribute('data-frame-type') === 'highlighted',
-      );
-      const collapsedFrames = frames.filter(
-        (frame) => frame.getAttribute('data-frame-type') !== 'highlighted',
-      );
+      expect(frames.length).toBeGreaterThan(0);
+    });
 
-      expect(highlightedFrames.length).toBeGreaterThan(0);
-      expect(collapsedFrames.length).toBeGreaterThan(0);
+    const frames = Array.from(pre!.querySelectorAll('.frame'));
+    const highlightedFrames = frames.filter(
+      (frame) => frame.getAttribute('data-frame-type') === 'highlighted',
+    );
+    const collapsedFrames = frames.filter(
+      (frame) => frame.getAttribute('data-frame-type') !== 'highlighted',
+    );
 
-      // Highlighted (visible) frames should be hydrated.
-      highlightedFrames.forEach((frame) => {
-        expect(frame.getAttribute('data-lined')).not.toBeNull();
-      });
-      // Collapsed (zero-area) frames should remain plain text.
-      collapsedFrames.forEach((frame) => {
-        expect(frame.getAttribute('data-lined')).toBeNull();
-      });
-    } finally {
-      mockIntersectionRect = null;
-    }
+    expect(highlightedFrames.length).toBeGreaterThan(0);
+    expect(collapsedFrames.length).toBeGreaterThan(0);
+
+    // Highlighted (visible) frames should be hydrated.
+    highlightedFrames.forEach((frame) => {
+      expect(frame.getAttribute('data-lined')).not.toBeNull();
+    });
+    // Collapsed (zero-area) frames should remain plain text.
+    collapsedFrames.forEach((frame) => {
+      expect(frame.getAttribute('data-lined')).toBeNull();
+    });
   });
 
   it('shares a single document `toggle` listener across mounted <Pre> instances', () => {
-    // Auto-cleanup between tests is not enabled in this project (root
-    // vitest config does not set `globals: true`, so RTL's automatic
-    // `afterEach(cleanup)` registration is a no-op). Unmount any leftover
-    // mounts from previous tests so the module-level subscriber set
-    // starts empty and our spy captures the first add.
-    cleanup();
-
     const addSpy = vi.spyOn(document, 'addEventListener');
     const removeSpy = vi.spyOn(document, 'removeEventListener');
 
     try {
-      const first = render(<EditablePreview />);
+      const { unmount: unmountFirst } = render(<EditablePreview />);
       const toggleAddsAfterFirst = addSpy.mock.calls.filter(
         ([eventName]) => eventName === 'toggle',
       );
       expect(toggleAddsAfterFirst).toHaveLength(1);
 
-      const second = render(<EditablePreview />);
+      const { unmount: unmountSecond } = render(<EditablePreview />);
       // Mounting a second `<Pre>` must reuse the existing capture-phase
       // listener rather than installing a per-instance one.
       const toggleAddsAfterSecond = addSpy.mock.calls.filter(
@@ -324,14 +328,14 @@ describe('Pre', () => {
       );
       expect(toggleAddsAfterSecond).toHaveLength(1);
 
-      first.unmount();
+      unmountFirst();
       // One subscriber still active → listener must remain attached.
       const toggleRemovesAfterFirstUnmount = removeSpy.mock.calls.filter(
         ([eventName]) => eventName === 'toggle',
       );
       expect(toggleRemovesAfterFirstUnmount).toHaveLength(0);
 
-      second.unmount();
+      unmountSecond();
       // Last subscriber gone → shared listener must be detached.
       const toggleRemovesAfterAllUnmount = removeSpy.mock.calls.filter(
         ([eventName]) => eventName === 'toggle',
@@ -344,53 +348,46 @@ describe('Pre', () => {
   });
 
   it('re-observes every frame when the <pre> ResizeObserver fires', async () => {
-    cleanup();
     resizeObserverInstances = [];
     observeCalls = [];
     unobserveCalls = [];
 
-    try {
-      const { container } = render(<EditablePreview />);
-      // eslint-disable-next-line testing-library/no-container
-      const pre = container.querySelector('pre');
-      expect(pre).not.toBeNull();
+    const { container } = render(<EditablePreview />);
+    // eslint-disable-next-line testing-library/no-container
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
 
-      await waitFor(() => {
-        expect(pre!.querySelectorAll('.frame').length).toBeGreaterThan(0);
-      });
+    await waitFor(() => {
+      expect(pre!.querySelectorAll('.frame').length).toBeGreaterThan(0);
+    });
 
-      const frames = Array.from(pre!.querySelectorAll('.frame'));
-      // Sanity: every frame was observed at least once during initial mount.
-      frames.forEach((frame) => {
-        expect(observeCalls).toContain(frame);
-      });
+    const frames = Array.from(pre!.querySelectorAll('.frame'));
+    // Sanity: every frame was observed at least once during initial mount.
+    frames.forEach((frame) => {
+      expect(observeCalls).toContain(frame);
+    });
 
-      // The Pre installs exactly one RO (on the <pre> itself).
-      expect(resizeObserverInstances).toHaveLength(1);
-      expect(resizeObserverInstances![0].observed).toEqual([pre]);
+    // The Pre installs exactly one RO (on the <pre> itself).
+    expect(resizeObserverInstances).toHaveLength(1);
+    expect(resizeObserverInstances![0].observed).toEqual([pre]);
 
-      // Reset counters so we can assert *re-observe* behavior in isolation.
-      observeCalls!.length = 0;
-      unobserveCalls!.length = 0;
+    // Reset counters so we can assert *re-observe* behavior in isolation.
+    observeCalls!.length = 0;
+    unobserveCalls!.length = 0;
 
-      // Trigger the RO callback as a real browser would after a layout
-      // change (e.g. CSS-driven collapse animation).
-      resizeObserverInstances![0].callback(
-        [] as unknown as ResizeObserverEntry[],
-        {} as ResizeObserver,
-      );
+    // Trigger the RO callback as a real browser would after a layout
+    // change (e.g. CSS-driven collapse animation).
+    resizeObserverInstances![0].callback(
+      [] as unknown as ResizeObserverEntry[],
+      {} as ResizeObserver,
+    );
 
-      // Each tracked frame must be unobserved+re-observed so the IO
-      // re-evaluates its clipped/unclipped state without a synchronous
-      // `getBoundingClientRect()` call.
-      frames.forEach((frame) => {
-        expect(unobserveCalls).toContain(frame);
-        expect(observeCalls).toContain(frame);
-      });
-    } finally {
-      resizeObserverInstances = null;
-      observeCalls = null;
-      unobserveCalls = null;
-    }
+    // Each tracked frame must be unobserved+re-observed so the IO
+    // re-evaluates its clipped/unclipped state without a synchronous
+    // `getBoundingClientRect()` call.
+    frames.forEach((frame) => {
+      expect(unobserveCalls).toContain(frame);
+      expect(observeCalls).toContain(frame);
+    });
   });
 });

--- a/packages/docs-infra/src/useCode/Pre.test.tsx
+++ b/packages/docs-infra/src/useCode/Pre.test.tsx
@@ -32,6 +32,11 @@ const HIGHLIGHT_COMMENTS: SourceComments = {
 
 let parseSource: ParseSource;
 
+// Test-scoped hook: when set, controls the intersection rect the mock IO
+// reports for each observed element. Returning a zero-area rect simulates a
+// frame hidden by a CSS collapse (`max-height: 0`, `visibility: hidden`).
+let mockIntersectionRect: ((target: Element) => DOMRectInit) | null = null;
+
 beforeAll(async () => {
   class MockIntersectionObserver {
     private readonly callback: IntersectionObserverCallback;
@@ -41,14 +46,41 @@ beforeAll(async () => {
     }
 
     observe(target: Element) {
+      // JSDOM's `getBoundingClientRect()` returns a zero-sized rect, but
+      // `<Pre>` now treats a zero-area intersection rect as "not visible"
+      // (mirrors how browsers report collapsed/`visibility:hidden`
+      // frames). Default to a non-zero rect so the mock represents an
+      // actually visible frame; tests can override per-target via
+      // `mockIntersectionRect`.
+      const init = mockIntersectionRect?.(target) ?? {
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 20,
+        width: 100,
+        height: 20,
+      };
+      const rect = init as DOMRectReadOnly;
+      // Always report `isIntersecting: true` regardless of rect area —
+      // this mirrors real browsers, which compute `isIntersecting` from
+      // the target's geometric position relative to the root and happily
+      // report `true` for elements whose layout box has collapsed to zero
+      // area (e.g. `max-height: 0; overflow: hidden;` or
+      // `visibility: hidden`). The whole point of `<Pre>`'s zero-area
+      // guard is to reject those.
+      const hasArea = (rect.width ?? 0) > 0 && (rect.height ?? 0) > 0;
       this.callback(
         [
           {
             target,
             isIntersecting: true,
-            intersectionRatio: 1,
-            boundingClientRect: target.getBoundingClientRect(),
-            intersectionRect: target.getBoundingClientRect(),
+            // Real browsers report ratio 0 for zero-area targets even
+            // when `isIntersecting` is true; keep the mock consistent.
+            intersectionRatio: hasArea ? 1 : 0,
+            boundingClientRect: rect,
+            intersectionRect: rect,
             rootBounds: null,
             time: 0,
           } as IntersectionObserverEntry,
@@ -175,5 +207,59 @@ describe('Pre', () => {
       expect((highlightedLine as HTMLElement).textContent).not.toContain('</div>');
       expect((nextLine as HTMLElement).textContent).toBe('    </div>');
     });
+  });
+
+  it('does not hydrate frames whose intersection rect has zero area (CSS-collapsed)', async () => {
+    // Simulate the hidden-when-collapsed state: highlighted frames have a
+    // visible rect, but the surrounding `normal` frames are clipped to
+    // zero height by the host's collapse CSS. The browser still reports
+    // them to IntersectionObserver based on their geometric position;
+    // `<Pre>` should treat the zero-area intersection as "not visible"
+    // and leave them as plain text instead of hydrating them to
+    // highlighted HAST.
+    mockIntersectionRect = (target) => {
+      const frameType = target.getAttribute('data-frame-type');
+      if (frameType === 'highlighted') {
+        return { x: 0, y: 0, top: 0, left: 0, right: 100, bottom: 20, width: 100, height: 20 };
+      }
+      // Collapsed frames: in viewport position-wise, but zero-area.
+      return { x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 };
+    };
+
+    try {
+      const { container } = render(<EditablePreview />);
+      // Inspecting internal frame elements (`.frame` / `data-frame-type`),
+      // not user-facing roles, so reach in via the container.
+      // eslint-disable-next-line testing-library/no-container
+      const pre = container.querySelector('pre');
+      expect(pre).not.toBeNull();
+
+      await waitFor(() => {
+        const frames = Array.from(pre!.querySelectorAll('.frame'));
+        expect(frames.length).toBeGreaterThan(0);
+      });
+
+      const frames = Array.from(pre!.querySelectorAll('.frame'));
+      const highlightedFrames = frames.filter(
+        (frame) => frame.getAttribute('data-frame-type') === 'highlighted',
+      );
+      const collapsedFrames = frames.filter(
+        (frame) => frame.getAttribute('data-frame-type') !== 'highlighted',
+      );
+
+      expect(highlightedFrames.length).toBeGreaterThan(0);
+      expect(collapsedFrames.length).toBeGreaterThan(0);
+
+      // Highlighted (visible) frames should be hydrated.
+      highlightedFrames.forEach((frame) => {
+        expect(frame.getAttribute('data-lined')).not.toBeNull();
+      });
+      // Collapsed (zero-area) frames should remain plain text.
+      collapsedFrames.forEach((frame) => {
+        expect(frame.getAttribute('data-lined')).toBeNull();
+      });
+    } finally {
+      mockIntersectionRect = null;
+    }
   });
 });

--- a/packages/docs-infra/src/useCode/Pre.test.tsx
+++ b/packages/docs-infra/src/useCode/Pre.test.tsx
@@ -2,8 +2,8 @@
  * @vitest-environment jsdom
  */
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import type { HastRoot, ParseSource, SourceComments } from '../CodeHighlighter/types';
 import { createParseSource } from '../pipeline/parseSource';
 import { enhanceCodeEmphasis } from '../pipeline/enhanceCodeEmphasis';
@@ -37,6 +37,19 @@ let parseSource: ParseSource;
 // frame hidden by a CSS collapse (`max-height: 0`, `visibility: hidden`).
 let mockIntersectionRect: ((target: Element) => DOMRectInit) | null = null;
 
+// Per-test instrumentation for the IO mock. When set, `observe` and
+// `unobserve` calls are recorded so tests can assert re-observe behavior
+// without depending on internal observer references.
+let observeCalls: Element[] | null = null;
+let unobserveCalls: Element[] | null = null;
+
+// Per-test capture of constructed ResizeObserver instances so tests can
+// trigger their callbacks manually (JSDOM doesn't actually compute layout).
+let resizeObserverInstances: Array<{
+  callback: ResizeObserverCallback;
+  observed: Element[];
+}> | null = null;
+
 beforeAll(async () => {
   class MockIntersectionObserver {
     private readonly callback: IntersectionObserverCallback;
@@ -46,6 +59,7 @@ beforeAll(async () => {
     }
 
     observe(target: Element) {
+      observeCalls?.push(target);
       // JSDOM's `getBoundingClientRect()` returns a zero-sized rect, but
       // `<Pre>` now treats a zero-area intersection rect as "not visible"
       // (mirrors how browsers report collapsed/`visibility:hidden`
@@ -89,7 +103,9 @@ beforeAll(async () => {
       );
     }
 
-    unobserve() {}
+    unobserve(target: Element) {
+      unobserveCalls?.push(target);
+    }
 
     disconnect() {}
 
@@ -100,6 +116,25 @@ beforeAll(async () => {
 
   globalThis.IntersectionObserver =
     MockIntersectionObserver as unknown as typeof IntersectionObserver;
+
+  class MockResizeObserver {
+    private readonly observed: Element[] = [];
+
+    constructor(callback: ResizeObserverCallback) {
+      resizeObserverInstances?.push({ callback, observed: this.observed });
+    }
+
+    observe(target: Element) {
+      this.observed.push(target);
+    }
+
+    unobserve() {}
+
+    disconnect() {}
+  }
+
+  globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
   parseSource = await createParseSource();
 });
 
@@ -260,6 +295,102 @@ describe('Pre', () => {
       });
     } finally {
       mockIntersectionRect = null;
+    }
+  });
+
+  it('shares a single document `toggle` listener across mounted <Pre> instances', () => {
+    // Auto-cleanup between tests is not enabled in this project (root
+    // vitest config does not set `globals: true`, so RTL's automatic
+    // `afterEach(cleanup)` registration is a no-op). Unmount any leftover
+    // mounts from previous tests so the module-level subscriber set
+    // starts empty and our spy captures the first add.
+    cleanup();
+
+    const addSpy = vi.spyOn(document, 'addEventListener');
+    const removeSpy = vi.spyOn(document, 'removeEventListener');
+
+    try {
+      const first = render(<EditablePreview />);
+      const toggleAddsAfterFirst = addSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'toggle',
+      );
+      expect(toggleAddsAfterFirst).toHaveLength(1);
+
+      const second = render(<EditablePreview />);
+      // Mounting a second `<Pre>` must reuse the existing capture-phase
+      // listener rather than installing a per-instance one.
+      const toggleAddsAfterSecond = addSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'toggle',
+      );
+      expect(toggleAddsAfterSecond).toHaveLength(1);
+
+      first.unmount();
+      // One subscriber still active → listener must remain attached.
+      const toggleRemovesAfterFirstUnmount = removeSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'toggle',
+      );
+      expect(toggleRemovesAfterFirstUnmount).toHaveLength(0);
+
+      second.unmount();
+      // Last subscriber gone → shared listener must be detached.
+      const toggleRemovesAfterAllUnmount = removeSpy.mock.calls.filter(
+        ([eventName]) => eventName === 'toggle',
+      );
+      expect(toggleRemovesAfterAllUnmount).toHaveLength(1);
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  it('re-observes every frame when the <pre> ResizeObserver fires', async () => {
+    cleanup();
+    resizeObserverInstances = [];
+    observeCalls = [];
+    unobserveCalls = [];
+
+    try {
+      const { container } = render(<EditablePreview />);
+      // eslint-disable-next-line testing-library/no-container
+      const pre = container.querySelector('pre');
+      expect(pre).not.toBeNull();
+
+      await waitFor(() => {
+        expect(pre!.querySelectorAll('.frame').length).toBeGreaterThan(0);
+      });
+
+      const frames = Array.from(pre!.querySelectorAll('.frame'));
+      // Sanity: every frame was observed at least once during initial mount.
+      frames.forEach((frame) => {
+        expect(observeCalls).toContain(frame);
+      });
+
+      // The Pre installs exactly one RO (on the <pre> itself).
+      expect(resizeObserverInstances).toHaveLength(1);
+      expect(resizeObserverInstances![0].observed).toEqual([pre]);
+
+      // Reset counters so we can assert *re-observe* behavior in isolation.
+      observeCalls!.length = 0;
+      unobserveCalls!.length = 0;
+
+      // Trigger the RO callback as a real browser would after a layout
+      // change (e.g. CSS-driven collapse animation).
+      resizeObserverInstances![0].callback(
+        [] as unknown as ResizeObserverEntry[],
+        {} as ResizeObserver,
+      );
+
+      // Each tracked frame must be unobserved+re-observed so the IO
+      // re-evaluates its clipped/unclipped state without a synchronous
+      // `getBoundingClientRect()` call.
+      frames.forEach((frame) => {
+        expect(unobserveCalls).toContain(frame);
+        expect(observeCalls).toContain(frame);
+      });
+    } finally {
+      resizeObserverInstances = null;
+      observeCalls = null;
+      unobserveCalls = null;
     }
   });
 });

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -52,6 +52,14 @@ function syncToggleListener(): void {
 }
 
 function subscribeToggleNudge(nudge: ToggleNudge): () => void {
+  // Defensive SSR no-op: there is no `document` to attach a listener to,
+  // and module state in Node persists across requests — leaking a
+  // subscriber here would also leak the closure it captures. `useEffect`
+  // already won't run on the server, but make the contract explicit so
+  // any future non-effect caller can't strand entries in the registry.
+  if (typeof document === 'undefined') {
+    return () => {};
+  }
   toggleSubscribers.add(nudge);
   syncToggleListener();
   return () => {
@@ -413,7 +421,12 @@ export function Pre({
   // ignored. `node.isConnected` is the cheapest available signal.
   const sweepDetachedFrames = React.useCallback(() => {
     const io = observer.current;
-    observedFrames.current.forEach((frame) => {
+    // Snapshot before iterating: we mutate `observedFrames` inside the
+    // loop, so iterating the live Set would rely on its (well-defined
+    // but subtle) skip-deleted-entries semantics. An array snapshot makes
+    // the intent explicit and decouples iteration order from insertion
+    // order should the storage ever change.
+    Array.from(observedFrames.current).forEach((frame) => {
       if (!frame.isConnected) {
         observedFrames.current.delete(frame);
         frameIndexMap.current.delete(frame);
@@ -433,7 +446,8 @@ export function Pre({
     if (!io) {
       return;
     }
-    observedFrames.current.forEach((frame) => {
+    // Snapshot before iterating — see `sweepDetachedFrames` above.
+    Array.from(observedFrames.current).forEach((frame) => {
       if (!frame.isConnected) {
         observedFrames.current.delete(frame);
         frameIndexMap.current.delete(frame);
@@ -464,21 +478,30 @@ export function Pre({
     setPreNode(root);
   }, []);
 
+  // Mirror the latest forwarded `ref` into a ref so the reconciliation
+  // effect below can run only when `preNode` actually changes. If we
+  // depended on `ref` directly, an inline arrow `ref={(node) => ...}`
+  // — which has a fresh identity every parent render — would tear
+  // down (`oldRef(null)`) and re-run (`newRef(preNode)`) on every parent
+  // render, momentarily exposing `null` to any consumer that observes
+  // null/non-null transitions.
+  const latestRef = React.useRef(ref);
+  React.useInsertionEffect(() => {
+    latestRef.current = ref;
+  }, [ref]);
+
   React.useEffect(() => {
-    if (typeof ref === 'function') {
-      ref(preNode);
-      return () => {
-        ref(null);
-      };
-    }
-    if (ref) {
-      ref.current = preNode;
-      return () => {
-        ref.current = null;
-      };
-    }
-    return undefined;
-  }, [ref, preNode]);
+    const apply = (value: HTMLPreElement | null) => {
+      const current = latestRef.current;
+      if (typeof current === 'function') {
+        current(value);
+      } else if (current) {
+        current.current = value;
+      }
+    };
+    apply(preNode);
+    return () => apply(null);
+  }, [preNode]);
 
   const handleIntersection = React.useCallback((entries: IntersectionObserverEntry[]) => {
     setVisibleFrames((prev) => {

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -16,9 +16,14 @@ const textChildrenCache = new WeakMap<ElementContent[], string>();
 // `<Pre>` would otherwise install its own capture-phase listener; on docs
 // pages with many code blocks that's N listeners all firing on every
 // toggle anywhere in the document. A single shared listener fans out to
-// each subscriber's nudge function instead.
-type ToggleNudge = (target: EventTarget | null) => void;
-const toggleSubscribers = new Set<ToggleNudge>();
+// the relevant subscribers instead.
+//
+// Subscribers register their `<pre>` element so the dispatcher can do a
+// single `target.contains(pre)` ancestry check per subscriber and skip
+// the nudge entirely for unrelated toggles — no JS-side work runs in
+// `<Pre>` instances whose subtree the toggle didn't touch.
+type ToggleNudge = () => void;
+const toggleSubscribers = new Map<HTMLElement, ToggleNudge>();
 let toggleListenerAttached = false;
 let sharedToggleListener: ((event: Event) => void) | null = null;
 
@@ -44,17 +49,26 @@ function syncToggleListener(): void {
   }
   if (!toggleListenerAttached || !sharedToggleListener) {
     sharedToggleListener = (event) => {
-      // Pass the event target so each subscriber can decide whether the
-      // toggled element is relevant to its own subtree, rather than
-      // running every subscriber on every unrelated `<details>` toggle.
-      toggleSubscribers.forEach((subscriber) => subscriber(event.target));
+      const target = event.target;
+      if (!(target instanceof Node)) {
+        return;
+      }
+      // Centralized ancestry filter: only nudge subscribers whose `<pre>`
+      // is a descendant of the toggled element. Done here (rather than
+      // in each subscriber) so unrelated toggles short-circuit before
+      // any subscriber-side work runs.
+      toggleSubscribers.forEach((nudge, preNode) => {
+        if (target.contains(preNode)) {
+          nudge();
+        }
+      });
     };
     document.addEventListener('toggle', sharedToggleListener, true);
     toggleListenerAttached = true;
   }
 }
 
-function subscribeToggleNudge(nudge: ToggleNudge): () => void {
+function subscribeToggleNudge(preNode: HTMLElement, nudge: ToggleNudge): () => void {
   // Defensive SSR no-op: there is no `document` to attach a listener to,
   // and module state in Node persists across requests — leaking a
   // subscriber here would also leak the closure it captures. `useEffect`
@@ -63,10 +77,10 @@ function subscribeToggleNudge(nudge: ToggleNudge): () => void {
   if (typeof document === 'undefined') {
     return () => {};
   }
-  toggleSubscribers.add(nudge);
+  toggleSubscribers.set(preNode, nudge);
   syncToggleListener();
   return () => {
-    toggleSubscribers.delete(nudge);
+    toggleSubscribers.delete(preNode);
     syncToggleListener();
   };
 }
@@ -481,35 +495,32 @@ export function Pre({
     setPreNode(root);
   }, []);
 
-  // Mirror the latest forwarded `ref` into a ref so the reconciliation
-  // effect below can run only when `preNode` actually changes. If we
-  // depended on `ref` directly, an inline arrow `ref={(node) => ...}`
-  // — which has a fresh identity every parent render — would tear
-  // down (`oldRef(null)`) and re-run (`newRef(preNode)`) on every parent
-  // render, momentarily exposing `null` to any consumer that observes
-  // null/non-null transitions.
-  //
-  // `useLayoutEffect` (rather than `useInsertionEffect`) keeps this
-  // compatible with the React 17 lower bound of the package's peer
-  // range. It still runs synchronously after commit and before the
-  // `apply` effect below, so the apply path always reads the latest ref.
-  const latestRef = React.useRef(ref);
-  React.useLayoutEffect(() => {
-    latestRef.current = ref;
-  }, [ref]);
-
+  // Forward the `<pre>` to the consumer's ref using React's standard
+  // callback-ref semantics: when either `ref` or `preNode` changes, the
+  // previous ref is detached (called with `null` / `.current = null`)
+  // and the new ref is attached. This effect is intentionally separate
+  // from the IO/RO/toggle setup effect (which keys only on `preNode` and
+  // therefore does not churn when `ref` identity changes), so a parent
+  // passing an inline arrow `ref={(node) => ...}` doesn't tear down
+  // observers on every render — only the lightweight ref reassignment
+  // re-runs. Consumers that pass an unmemoized arrow will see the same
+  // null/non-null cycle React itself produces for any callback ref with
+  // unstable identity; memoize the ref upstream to avoid it.
   React.useEffect(() => {
-    const apply = (value: HTMLPreElement | null) => {
-      const current = latestRef.current;
-      if (typeof current === 'function') {
-        current(value);
-      } else if (current) {
-        current.current = value;
-      }
-    };
-    apply(preNode);
-    return () => apply(null);
-  }, [preNode]);
+    if (typeof ref === 'function') {
+      ref(preNode);
+      return () => {
+        ref(null);
+      };
+    }
+    if (ref) {
+      ref.current = preNode;
+      return () => {
+        ref.current = null;
+      };
+    }
+    return undefined;
+  }, [ref, preNode]);
 
   const handleIntersection = React.useCallback((entries: IntersectionObserverEntry[]) => {
     setVisibleFrames((prev) => {
@@ -596,16 +607,11 @@ export function Pre({
 
     // Native <details> toggle events do not bubble, but a capture-phase
     // listener on the document still intercepts them. A single shared
-    // listener (see `subscribeToggleNudge`) fans the event out to every
-    // mounted `<Pre>` instead of installing N listeners on heavy pages.
-    // Filter by ancestry: only nudge when the toggled element actually
-    // contains this `<pre>`, so unrelated toggles elsewhere in the
-    // document don't trigger a frame re-observe pass per `<Pre>`.
-    const unsubscribeToggle = subscribeToggleNudge((target) => {
-      if (target instanceof Node && target.contains(preNode)) {
-        nudgeFrameObserver();
-      }
-    });
+    // listener (see `subscribeToggleNudge`) fans the event out only to
+    // mounted `<Pre>` instances whose `<pre>` is a descendant of the
+    // toggled element, so unrelated toggles elsewhere in the document
+    // don't trigger any per-instance work.
+    const unsubscribeToggle = subscribeToggleNudge(preNode, nudgeFrameObserver);
 
     return () => {
       io.disconnect();

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -22,22 +22,41 @@ const toggleSubscribers = new Set<ToggleNudge>();
 let toggleListenerAttached = false;
 let sharedToggleListener: ((event: Event) => void) | null = null;
 
-function subscribeToggleNudge(nudge: ToggleNudge): () => void {
-  toggleSubscribers.add(nudge);
-  if (!toggleListenerAttached && typeof document !== 'undefined') {
+// Reconcile the document-level capture listener with the current
+// subscriber set. Idempotent: callable from any code path (including
+// test teardowns that want to defensively assert no leaked listener)
+// without risk of leaving the document in a half-attached state.
+function syncToggleListener(): void {
+  if (typeof document === 'undefined') {
+    if (toggleSubscribers.size === 0) {
+      sharedToggleListener = null;
+      toggleListenerAttached = false;
+    }
+    return;
+  }
+  if (toggleSubscribers.size === 0) {
+    if (toggleListenerAttached && sharedToggleListener) {
+      document.removeEventListener('toggle', sharedToggleListener, true);
+    }
+    sharedToggleListener = null;
+    toggleListenerAttached = false;
+    return;
+  }
+  if (!toggleListenerAttached || !sharedToggleListener) {
     sharedToggleListener = () => {
       toggleSubscribers.forEach((subscriber) => subscriber());
     };
     document.addEventListener('toggle', sharedToggleListener, true);
     toggleListenerAttached = true;
   }
+}
+
+function subscribeToggleNudge(nudge: ToggleNudge): () => void {
+  toggleSubscribers.add(nudge);
+  syncToggleListener();
   return () => {
     toggleSubscribers.delete(nudge);
-    if (toggleSubscribers.size === 0 && toggleListenerAttached && sharedToggleListener) {
-      document.removeEventListener('toggle', sharedToggleListener, true);
-      sharedToggleListener = null;
-      toggleListenerAttached = false;
-    }
+    syncToggleListener();
   };
 }
 
@@ -434,18 +453,32 @@ export function Pre({
   // being called with `null`.
   const [preNode, setPreNode] = React.useState<HTMLPreElement | null>(null);
 
-  const bindPre = React.useCallback(
-    (root: HTMLPreElement | null) => {
-      preRef.current = root;
-      setPreNode(root);
-      if (typeof ref === 'function') {
-        ref(root);
-      } else if (ref) {
-        ref.current = root;
-      }
-    },
-    [ref],
-  );
+  // `bindPre` must be stable: if it depended on the forwarded `ref`, a
+  // parent re-render that supplies a new ref function would recreate
+  // `bindPre`, causing React to invoke the previous callback with `null`
+  // and the new one with the same DOM node. That sequence would tear
+  // down and rebuild the IO/RO/toggle subscription on every parent
+  // render. Forwarded-ref reconciliation runs in its own effect below.
+  const bindPre = React.useCallback((root: HTMLPreElement | null) => {
+    preRef.current = root;
+    setPreNode(root);
+  }, []);
+
+  React.useEffect(() => {
+    if (typeof ref === 'function') {
+      ref(preNode);
+      return () => {
+        ref(null);
+      };
+    }
+    if (ref) {
+      ref.current = preNode;
+      return () => {
+        ref.current = null;
+      };
+    }
+    return undefined;
+  }, [ref, preNode]);
 
   const handleIntersection = React.useCallback((entries: IntersectionObserverEntry[]) => {
     setVisibleFrames((prev) => {
@@ -544,35 +577,46 @@ export function Pre({
     };
   }, [preNode, hydrateMargin, handleIntersection, nudgeFrameObserver, sweepDetachedFrames]);
 
-  const observeFrame = React.useCallback((node: HTMLSpanElement | null) => {
-    if (!node) {
-      return undefined;
-    }
-    // Derive frame index from DOM position among .frame siblings.
-    // This avoids putting data-frame in server-rendered HTML.
-    let index = 0;
-    let sibling = node.previousElementSibling;
-    while (sibling) {
-      if (sibling.classList.contains('frame')) {
-        index += 1;
+  const observeFrame = React.useCallback(
+    (node: HTMLSpanElement | null) => {
+      if (!node) {
+        // React 17/18 invoke ref callbacks with `null` on detach but
+        // ignore the cleanup return value below, and a single shared
+        // callback can't tell which span detached. Prune any tracked
+        // frame that's no longer in the DOM so detached nodes don't
+        // accumulate strongly-referenced inside `observedFrames` for
+        // the lifetime of the `<Pre>` instance.
+        sweepDetachedFrames();
+        return undefined;
       }
-      sibling = sibling.previousElementSibling;
-    }
-    frameIndexMap.current.set(node, index);
-    observedFrames.current.add(node);
-    if (observer.current) {
-      observer.current.observe(node);
-    }
-    // React 19 ref-callback cleanup. On React 17/18 the return value is
-    // ignored; `nudgeFrameObserver` and `sweepDetachedFrames` defensively
-    // drop entries whose `node.isConnected` is false, so the tracking
-    // sets stay bounded on those versions too.
-    return () => {
-      observedFrames.current.delete(node);
-      frameIndexMap.current.delete(node);
-      observer.current?.unobserve(node);
-    };
-  }, []);
+      // Derive frame index from DOM position among .frame siblings.
+      // This avoids putting data-frame in server-rendered HTML.
+      let index = 0;
+      let sibling = node.previousElementSibling;
+      while (sibling) {
+        if (sibling.classList.contains('frame')) {
+          index += 1;
+        }
+        sibling = sibling.previousElementSibling;
+      }
+      frameIndexMap.current.set(node, index);
+      observedFrames.current.add(node);
+      if (observer.current) {
+        observer.current.observe(node);
+      }
+      // React 19 ref-callback cleanup. On React 17/18 the return value is
+      // ignored; the `if (!node)` branch above + `sweepDetachedFrames`
+      // (also called from `nudgeFrameObserver` and the IO setup effect)
+      // drop entries whose `node.isConnected` is false, so the tracking
+      // sets stay bounded on those versions too.
+      return () => {
+        observedFrames.current.delete(node);
+        frameIndexMap.current.delete(node);
+        observer.current?.unobserve(node);
+      };
+    },
+    [sweepDetachedFrames],
+  );
 
   const frames = React.useMemo(() => {
     let frameIndex = 0;

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -384,10 +384,24 @@ export function Pre({
   });
 
   const observer = React.useRef<IntersectionObserver | null>(null);
-  const resizeObserver = React.useRef<ResizeObserver | null>(null);
-  const toggleUnsubscribe = React.useRef<(() => void) | null>(null);
   const observedFrames = React.useRef<Set<Element>>(new Set());
   const frameIndexMap = React.useRef(new WeakMap<Element, number>());
+
+  // Drop frame spans that have been detached from the DOM. Used as a
+  // defensive sweep in `nudgeFrameObserver` (and the IO effect) so the
+  // tracking sets don't grow unboundedly across re-renders, even on
+  // React 17/18 where the cleanup return value of `observeFrame` is
+  // ignored. `node.isConnected` is the cheapest available signal.
+  const sweepDetachedFrames = React.useCallback(() => {
+    const io = observer.current;
+    observedFrames.current.forEach((frame) => {
+      if (!frame.isConnected) {
+        observedFrames.current.delete(frame);
+        frameIndexMap.current.delete(frame);
+        io?.unobserve(frame);
+      }
+    });
+  }, []);
 
   // Re-observe every tracked frame so the IntersectionObserver re-evaluates
   // visibility without a synchronous `getBoundingClientRect()` call. Used
@@ -401,136 +415,134 @@ export function Pre({
       return;
     }
     observedFrames.current.forEach((frame) => {
+      if (!frame.isConnected) {
+        observedFrames.current.delete(frame);
+        frameIndexMap.current.delete(frame);
+        io.unobserve(frame);
+        return;
+      }
       io.unobserve(frame);
       io.observe(frame);
     });
   }, []);
 
-  const bindIntersectionObserver = React.useCallback(
+  // Holds the mounted `<pre>` element so the IO/RO/toggle setup effect can
+  // key on it. Using a state + callback-ref pair (rather than driving the
+  // setup from inside the ref callback) lets React's effect lifecycle
+  // guarantee teardown — including under StrictMode's double-invoke and
+  // for any abrupt unmount path — instead of relying on the ref callback
+  // being called with `null`.
+  const [preNode, setPreNode] = React.useState<HTMLPreElement | null>(null);
+
+  const bindPre = React.useCallback(
     (root: HTMLPreElement | null) => {
       preRef.current = root;
-
-      if (!root) {
-        if (observer.current) {
-          observer.current.disconnect();
-        }
-        observer.current = null;
-        if (resizeObserver.current) {
-          resizeObserver.current.disconnect();
-        }
-        resizeObserver.current = null;
-        observedFrames.current.clear();
-        if (toggleUnsubscribe.current) {
-          toggleUnsubscribe.current();
-          toggleUnsubscribe.current = null;
-        }
-
-        return;
+      setPreNode(root);
+      if (typeof ref === 'function') {
+        ref(root);
+      } else if (ref) {
+        ref.current = root;
       }
+    },
+    [ref],
+  );
 
-      const indexMap = frameIndexMap.current;
+  const handleIntersection = React.useCallback((entries: IntersectionObserverEntry[]) => {
+    setVisibleFrames((prev) => {
+      const visible: number[] = [];
+      const invisible: number[] = [];
 
-      observer.current = new IntersectionObserver(
-        (entries) =>
-          setVisibleFrames((prev) => {
-            const visible: number[] = [];
-            const invisible: number[] = [];
-
-            entries.forEach((entry) => {
-              const index = indexMap.get(entry.target);
-              if (index === undefined) {
-                return;
-              }
-              // A frame counts as visible only when it intersects the
-              // viewport AND its intersection rect has non-zero area.
-              // Frames hidden by a CSS-driven collapse (`max-height: 0;
-              // overflow: hidden;` or `visibility: hidden`) collapse to a
-              // zero-area rect; some browsers still report
-              // `isIntersecting: true` for them based on their geometric
-              // position in the document. Checking the rect dimensions
-              // matches what the user actually sees and prevents hidden
-              // frames from being upgraded to highlighted HAST.
-              const rect = entry.intersectionRect;
-              const isVisuallyVisible = entry.isIntersecting && rect.width > 0 && rect.height > 0;
-              if (isVisuallyVisible) {
-                visible.push(index);
-              } else {
-                invisible.push(index);
-              }
-            });
-
-            // avoid mutating the object if nothing changed
-            let frames: { [key: number]: boolean } | undefined;
-            visible.forEach((frame) => {
-              if (prev[frame] !== true) {
-                if (!frames) {
-                  frames = { ...prev };
-                }
-                frames[frame] = true;
-              }
-            });
-
-            invisible.forEach((frame) => {
-              if (prev[frame]) {
-                if (!frames) {
-                  frames = { ...prev };
-                }
-                delete frames[frame];
-              }
-            });
-
-            return frames || prev;
-          }),
-        { rootMargin: hydrateMargin },
-      );
-
-      // Watch the `<pre>` itself for size changes (CSS-driven collapse
-      // animations resize ancestors, accordions/tabs swap layout). When
-      // the pre resizes, re-observe every frame so the IO re-evaluates
-      // their clipped-vs-unclipped state. Guarded so older runtimes (and
-      // JSDOM in unit tests) without ResizeObserver still work.
-      if (typeof ResizeObserver !== 'undefined') {
-        resizeObserver.current = new ResizeObserver(nudgeFrameObserver);
-        resizeObserver.current.observe(root);
-      }
-
-      // Native <details> toggle events do not bubble, but a capture-phase
-      // listener on the document still intercepts them. A single shared
-      // listener (see `subscribeToggleNudge`) fans the event out to every
-      // mounted `<Pre>` instead of installing N listeners on heavy pages.
-      toggleUnsubscribe.current = subscribeToggleNudge(nudgeFrameObserver);
-
-      // <pre><code><span class="frame">...</span><span class="frame">...</span>...</code></pre>
-      const codeElement = root.querySelector('code');
-      if (!codeElement) {
-        return;
-      }
-      let frameIndex = 0;
-      codeElement.childNodes.forEach((node) => {
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          const element = node as Element;
-          if (!element.classList.contains('frame')) {
-            console.warn('Expected frame element in useCode <Pre>', element);
-            return;
-          }
-
-          indexMap.set(element, frameIndex);
-          frameIndex += 1;
-          observedFrames.current.add(element);
-          observer.current?.observe(element);
+      entries.forEach((entry) => {
+        const index = frameIndexMap.current.get(entry.target);
+        if (index === undefined) {
+          return;
+        }
+        // A frame counts as visible only when it intersects the
+        // viewport AND its intersection rect has non-zero area.
+        // Frames hidden by a CSS-driven collapse (`max-height: 0;
+        // overflow: hidden;` or `visibility: hidden`) collapse to a
+        // zero-area rect; some browsers still report
+        // `isIntersecting: true` for them based on their geometric
+        // position in the document. Checking the rect dimensions
+        // matches what the user actually sees and prevents hidden
+        // frames from being upgraded to highlighted HAST.
+        const rect = entry.intersectionRect;
+        const isVisuallyVisible = entry.isIntersecting && rect.width > 0 && rect.height > 0;
+        if (isVisuallyVisible) {
+          visible.push(index);
+        } else {
+          invisible.push(index);
         }
       });
 
-      if (ref) {
-        if (typeof ref === 'function') {
-          ref(root);
-        } else {
-          ref.current = root;
+      // avoid mutating the object if nothing changed
+      let frames: { [key: number]: boolean } | undefined;
+      visible.forEach((frame) => {
+        if (prev[frame] !== true) {
+          if (!frames) {
+            frames = { ...prev };
+          }
+          frames[frame] = true;
         }
-      }
-    },
-    [ref, hydrateMargin, nudgeFrameObserver],
-  );
+      });
+
+      invisible.forEach((frame) => {
+        if (prev[frame]) {
+          if (!frames) {
+            frames = { ...prev };
+          }
+          delete frames[frame];
+        }
+      });
+
+      return frames || prev;
+    });
+  }, []);
+
+  // Set up IntersectionObserver, ResizeObserver, and the shared
+  // <details> toggle subscription whenever the pre element changes.
+  // Running this in `useEffect` (rather than in the ref callback)
+  // delegates teardown to React's effect lifecycle, so cleanup is
+  // guaranteed even under StrictMode's double-invoke and for any
+  // unmount path.
+  React.useEffect(() => {
+    if (!preNode) {
+      return undefined;
+    }
+
+    const io = new IntersectionObserver(handleIntersection, { rootMargin: hydrateMargin });
+    observer.current = io;
+
+    // Sweep any spans that detached between the previous IO's teardown
+    // and this one, then start observing every frame whose ref callback
+    // has registered it.
+    sweepDetachedFrames();
+    observedFrames.current.forEach((frame) => io.observe(frame));
+
+    // Watch the `<pre>` itself for size changes (CSS-driven collapse
+    // animations resize ancestors, accordions/tabs swap layout). When
+    // the pre resizes, re-observe every frame so the IO re-evaluates
+    // their clipped-vs-unclipped state. Guarded so older runtimes (and
+    // JSDOM in unit tests) without ResizeObserver still work.
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(nudgeFrameObserver);
+      ro.observe(preNode);
+    }
+
+    // Native <details> toggle events do not bubble, but a capture-phase
+    // listener on the document still intercepts them. A single shared
+    // listener (see `subscribeToggleNudge`) fans the event out to every
+    // mounted `<Pre>` instead of installing N listeners on heavy pages.
+    const unsubscribeToggle = subscribeToggleNudge(nudgeFrameObserver);
+
+    return () => {
+      io.disconnect();
+      observer.current = null;
+      ro?.disconnect();
+      unsubscribeToggle();
+    };
+  }, [preNode, hydrateMargin, handleIntersection, nudgeFrameObserver, sweepDetachedFrames]);
 
   const observeFrame = React.useCallback((node: HTMLSpanElement | null) => {
     if (!node) {
@@ -551,11 +563,10 @@ export function Pre({
     if (observer.current) {
       observer.current.observe(node);
     }
-    // React 19 ref-callback cleanup: when the frame span unmounts (or is
-    // replaced on rerender), drop it from `observedFrames` so the
-    // resize/toggle nudge stops re-observing a detached element. Without
-    // this the set grows unboundedly during editing as React swaps frame
-    // spans, keeping detached nodes strongly referenced.
+    // React 19 ref-callback cleanup. On React 17/18 the return value is
+    // ignored; `nudgeFrameObserver` and `sweepDetachedFrames` defensively
+    // drop entries whose `node.isConnected` is false, so the tracking
+    // sets stay bounded on those versions too.
     return () => {
       observedFrames.current.delete(node);
       frameIndexMap.current.delete(node);
@@ -732,7 +743,7 @@ export function Pre({
     // useEditable). jsx-a11y can't see that, so disable its rule here.
     // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     <pre
-      ref={bindIntersectionObserver}
+      ref={bindPre}
       className={className}
       spellCheck={false}
       tabIndex={isEditable ? -1 : undefined}

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -12,6 +12,35 @@ import { hastToJsx, decompressHast } from '../pipeline/hastUtils';
 const hastChildrenCache = new WeakMap<ElementContent[], React.ReactNode>();
 const textChildrenCache = new WeakMap<ElementContent[], string>();
 
+// Document-level subscriber registry for `<details>` toggle events. Each
+// `<Pre>` would otherwise install its own capture-phase listener; on docs
+// pages with many code blocks that's N listeners all firing on every
+// toggle anywhere in the document. A single shared listener fans out to
+// each subscriber's nudge function instead.
+type ToggleNudge = () => void;
+const toggleSubscribers = new Set<ToggleNudge>();
+let toggleListenerAttached = false;
+let sharedToggleListener: ((event: Event) => void) | null = null;
+
+function subscribeToggleNudge(nudge: ToggleNudge): () => void {
+  toggleSubscribers.add(nudge);
+  if (!toggleListenerAttached && typeof document !== 'undefined') {
+    sharedToggleListener = () => {
+      toggleSubscribers.forEach((subscriber) => subscriber());
+    };
+    document.addEventListener('toggle', sharedToggleListener, true);
+    toggleListenerAttached = true;
+  }
+  return () => {
+    toggleSubscribers.delete(nudge);
+    if (toggleSubscribers.size === 0 && toggleListenerAttached && sharedToggleListener) {
+      document.removeEventListener('toggle', sharedToggleListener, true);
+      sharedToggleListener = null;
+      toggleListenerAttached = false;
+    }
+  };
+}
+
 const INITIAL_VISIBLE_FRAME_TYPES = new Set([
   'highlighted',
   'focus',
@@ -355,7 +384,28 @@ export function Pre({
   });
 
   const observer = React.useRef<IntersectionObserver | null>(null);
+  const resizeObserver = React.useRef<ResizeObserver | null>(null);
+  const toggleUnsubscribe = React.useRef<(() => void) | null>(null);
+  const observedFrames = React.useRef<Set<Element>>(new Set());
   const frameIndexMap = React.useRef(new WeakMap<Element, number>());
+
+  // Re-observe every tracked frame so the IntersectionObserver re-evaluates
+  // visibility without a synchronous `getBoundingClientRect()` call. Used
+  // when ancestor layout changes (CSS-driven collapse/expand, <details>
+  // toggle, tab/accordion swaps) clip or unclip frames in ways that don't
+  // themselves trigger an IntersectionObserver entry. Mirrors the
+  // `nudgeObserver` pattern in `<TypeCode>`.
+  const nudgeFrameObserver = React.useCallback(() => {
+    const io = observer.current;
+    if (!io) {
+      return;
+    }
+    observedFrames.current.forEach((frame) => {
+      io.unobserve(frame);
+      io.observe(frame);
+    });
+  }, []);
+
   const bindIntersectionObserver = React.useCallback(
     (root: HTMLPreElement | null) => {
       preRef.current = root;
@@ -365,6 +415,15 @@ export function Pre({
           observer.current.disconnect();
         }
         observer.current = null;
+        if (resizeObserver.current) {
+          resizeObserver.current.disconnect();
+        }
+        resizeObserver.current = null;
+        observedFrames.current.clear();
+        if (toggleUnsubscribe.current) {
+          toggleUnsubscribe.current();
+          toggleUnsubscribe.current = null;
+        }
 
         return;
       }
@@ -382,7 +441,18 @@ export function Pre({
               if (index === undefined) {
                 return;
               }
-              if (entry.isIntersecting) {
+              // A frame counts as visible only when it intersects the
+              // viewport AND its intersection rect has non-zero area.
+              // Frames hidden by a CSS-driven collapse (`max-height: 0;
+              // overflow: hidden;` or `visibility: hidden`) collapse to a
+              // zero-area rect; some browsers still report
+              // `isIntersecting: true` for them based on their geometric
+              // position in the document. Checking the rect dimensions
+              // matches what the user actually sees and prevents hidden
+              // frames from being upgraded to highlighted HAST.
+              const rect = entry.intersectionRect;
+              const isVisuallyVisible = entry.isIntersecting && rect.width > 0 && rect.height > 0;
+              if (isVisuallyVisible) {
                 visible.push(index);
               } else {
                 invisible.push(index);
@@ -414,6 +484,22 @@ export function Pre({
         { rootMargin: hydrateMargin },
       );
 
+      // Watch the `<pre>` itself for size changes (CSS-driven collapse
+      // animations resize ancestors, accordions/tabs swap layout). When
+      // the pre resizes, re-observe every frame so the IO re-evaluates
+      // their clipped-vs-unclipped state. Guarded so older runtimes (and
+      // JSDOM in unit tests) without ResizeObserver still work.
+      if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver.current = new ResizeObserver(nudgeFrameObserver);
+        resizeObserver.current.observe(root);
+      }
+
+      // Native <details> toggle events do not bubble, but a capture-phase
+      // listener on the document still intercepts them. A single shared
+      // listener (see `subscribeToggleNudge`) fans the event out to every
+      // mounted `<Pre>` instead of installing N listeners on heavy pages.
+      toggleUnsubscribe.current = subscribeToggleNudge(nudgeFrameObserver);
+
       // <pre><code><span class="frame">...</span><span class="frame">...</span>...</code></pre>
       const codeElement = root.querySelector('code');
       if (!codeElement) {
@@ -430,6 +516,7 @@ export function Pre({
 
           indexMap.set(element, frameIndex);
           frameIndex += 1;
+          observedFrames.current.add(element);
           observer.current?.observe(element);
         }
       });
@@ -442,26 +529,38 @@ export function Pre({
         }
       }
     },
-    [ref, hydrateMargin],
+    [ref, hydrateMargin, nudgeFrameObserver],
   );
 
   const observeFrame = React.useCallback((node: HTMLSpanElement | null) => {
-    if (node) {
-      // Derive frame index from DOM position among .frame siblings.
-      // This avoids putting data-frame in server-rendered HTML.
-      let index = 0;
-      let sibling = node.previousElementSibling;
-      while (sibling) {
-        if (sibling.classList.contains('frame')) {
-          index += 1;
-        }
-        sibling = sibling.previousElementSibling;
-      }
-      frameIndexMap.current.set(node, index);
-      if (observer.current) {
-        observer.current.observe(node);
-      }
+    if (!node) {
+      return undefined;
     }
+    // Derive frame index from DOM position among .frame siblings.
+    // This avoids putting data-frame in server-rendered HTML.
+    let index = 0;
+    let sibling = node.previousElementSibling;
+    while (sibling) {
+      if (sibling.classList.contains('frame')) {
+        index += 1;
+      }
+      sibling = sibling.previousElementSibling;
+    }
+    frameIndexMap.current.set(node, index);
+    observedFrames.current.add(node);
+    if (observer.current) {
+      observer.current.observe(node);
+    }
+    // React 19 ref-callback cleanup: when the frame span unmounts (or is
+    // replaced on rerender), drop it from `observedFrames` so the
+    // resize/toggle nudge stops re-observing a detached element. Without
+    // this the set grows unboundedly during editing as React swaps frame
+    // spans, keeping detached nodes strongly referenced.
+    return () => {
+      observedFrames.current.delete(node);
+      frameIndexMap.current.delete(node);
+      observer.current?.unobserve(node);
+    };
   }, []);
 
   const frames = React.useMemo(() => {

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -22,8 +22,15 @@ const textChildrenCache = new WeakMap<ElementContent[], string>();
 // single `target.contains(pre)` ancestry check per subscriber and skip
 // the nudge entirely for unrelated toggles — no JS-side work runs in
 // `<Pre>` instances whose subtree the toggle didn't touch.
+//
+// The value is a Set rather than a single function so the registry
+// tolerates the (unlikely but possible) case where two `<Pre>` instances
+// transiently share the same DOM node — e.g. a fast unmount/remount
+// where the next mount's setup runs before the prior mount's cleanup.
+// Without the set the second subscribe would silently overwrite the
+// first nudge and a single unsubscribe would orphan the other instance.
 type ToggleNudge = () => void;
-const toggleSubscribers = new Map<HTMLElement, ToggleNudge>();
+const toggleSubscribers = new Map<HTMLElement, Set<ToggleNudge>>();
 let toggleListenerAttached = false;
 let sharedToggleListener: ((event: Event) => void) | null = null;
 
@@ -53,14 +60,20 @@ function syncToggleListener(): void {
       if (!(target instanceof Node)) {
         return;
       }
-      // Centralized ancestry filter: only nudge subscribers whose `<pre>`
-      // is a descendant of the toggled element. Done here (rather than
-      // in each subscriber) so unrelated toggles short-circuit before
-      // any subscriber-side work runs.
-      toggleSubscribers.forEach((nudge, preNode) => {
-        if (target.contains(preNode)) {
-          nudge();
+      // Snapshot before iterating: a nudge may synchronously trigger an
+      // unmount that mutates `toggleSubscribers` mid-dispatch. Iterating
+      // a snapshot keeps dispatch order independent of subscriber
+      // mutations and matches the snapshot pattern used by
+      // `sweepDetachedFrames` / `nudgeFrameObserver`.
+      Array.from(toggleSubscribers).forEach(([preNode, nudges]) => {
+        // Centralized ancestry filter: only nudge subscribers whose `<pre>`
+        // is a descendant of the toggled element. Done here (rather than
+        // in each subscriber) so unrelated toggles short-circuit before
+        // any subscriber-side work runs.
+        if (!target.contains(preNode)) {
+          return;
         }
+        Array.from(nudges).forEach((nudge) => nudge());
       });
     };
     document.addEventListener('toggle', sharedToggleListener, true);
@@ -77,10 +90,21 @@ function subscribeToggleNudge(preNode: HTMLElement, nudge: ToggleNudge): () => v
   if (typeof document === 'undefined') {
     return () => {};
   }
-  toggleSubscribers.set(preNode, nudge);
+  let nudges = toggleSubscribers.get(preNode);
+  if (!nudges) {
+    nudges = new Set();
+    toggleSubscribers.set(preNode, nudges);
+  }
+  nudges.add(nudge);
   syncToggleListener();
   return () => {
-    toggleSubscribers.delete(preNode);
+    const existing = toggleSubscribers.get(preNode);
+    if (existing) {
+      existing.delete(nudge);
+      if (existing.size === 0) {
+        toggleSubscribers.delete(preNode);
+      }
+    }
     syncToggleListener();
   };
 }
@@ -484,43 +508,65 @@ export function Pre({
   // being called with `null`.
   const [preNode, setPreNode] = React.useState<HTMLPreElement | null>(null);
 
-  // `bindPre` must be stable: if it depended on the forwarded `ref`, a
-  // parent re-render that supplies a new ref function would recreate
-  // `bindPre`, causing React to invoke the previous callback with `null`
-  // and the new one with the same DOM node. That sequence would tear
-  // down and rebuild the IO/RO/toggle subscription on every parent
-  // render. Forwarded-ref reconciliation runs in its own effect below.
+  // Mirror the latest forwarded `ref` so `bindPre` can read it without
+  // depending on `ref` in its deps (which would re-create `bindPre` on
+  // every parent re-render and tear down the IO/RO/toggle setup effect
+  // below). Using `useLayoutEffect` (React 17 safe) keeps this in sync
+  // before any consumer's layout effect or imperative-handle read.
+  const forwardedRef = React.useRef(ref);
+  React.useLayoutEffect(() => {
+    const previous = forwardedRef.current;
+    forwardedRef.current = ref;
+    if (previous === ref) {
+      return;
+    }
+    // Consumer swapped to a different ref function/object on a render
+    // where the DOM node didn't change (so `bindPre` wasn't called by
+    // React). Reconcile manually: detach the old, attach the new with
+    // the current node, matching React's standard callback-ref
+    // semantics for ref swaps.
+    const current = preRef.current;
+    if (typeof previous === 'function') {
+      previous(null);
+    } else if (previous) {
+      previous.current = null;
+    }
+    if (typeof ref === 'function') {
+      ref(current);
+    } else if (ref) {
+      ref.current = current;
+    }
+  }, [ref]);
+
+  // `bindPre` is stable (empty deps): if it depended on the forwarded
+  // `ref`, a parent re-render that supplies a new ref function would
+  // recreate `bindPre`, causing React to invoke the previous callback
+  // with `null` and the new one with the same DOM node. That sequence
+  // would tear down and rebuild the IO/RO/toggle subscription on every
+  // parent render. Ref-function swaps that don't change the DOM node
+  // are reconciled by the layout effect above.
+  //
+  // Forward the consumer's ref synchronously inside the callback (not in
+  // a separate `useEffect`) so any parent `useLayoutEffect` or
+  // imperative handle that reads `ref.current` right after mount sees
+  // the `<pre>` rather than `null`.
   const bindPre = React.useCallback((root: HTMLPreElement | null) => {
+    // React 18+ StrictMode (and some normal-update paths) can invoke a
+    // ref callback with the same node it already holds. Short-circuit
+    // so we don't trigger an extra render via `setPreNode` or a
+    // redundant ref-forward cycle for the consumer.
+    if (preRef.current === root) {
+      return;
+    }
     preRef.current = root;
+    const current = forwardedRef.current;
+    if (typeof current === 'function') {
+      current(root);
+    } else if (current) {
+      current.current = root;
+    }
     setPreNode(root);
   }, []);
-
-  // Forward the `<pre>` to the consumer's ref using React's standard
-  // callback-ref semantics: when either `ref` or `preNode` changes, the
-  // previous ref is detached (called with `null` / `.current = null`)
-  // and the new ref is attached. This effect is intentionally separate
-  // from the IO/RO/toggle setup effect (which keys only on `preNode` and
-  // therefore does not churn when `ref` identity changes), so a parent
-  // passing an inline arrow `ref={(node) => ...}` doesn't tear down
-  // observers on every render — only the lightweight ref reassignment
-  // re-runs. Consumers that pass an unmemoized arrow will see the same
-  // null/non-null cycle React itself produces for any callback ref with
-  // unstable identity; memoize the ref upstream to avoid it.
-  React.useEffect(() => {
-    if (typeof ref === 'function') {
-      ref(preNode);
-      return () => {
-        ref(null);
-      };
-    }
-    if (ref) {
-      ref.current = preNode;
-      return () => {
-        ref.current = null;
-      };
-    }
-    return undefined;
-  }, [ref, preNode]);
 
   const handleIntersection = React.useCallback((entries: IntersectionObserverEntry[]) => {
     setVisibleFrames((prev) => {

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -17,7 +17,7 @@ const textChildrenCache = new WeakMap<ElementContent[], string>();
 // pages with many code blocks that's N listeners all firing on every
 // toggle anywhere in the document. A single shared listener fans out to
 // each subscriber's nudge function instead.
-type ToggleNudge = () => void;
+type ToggleNudge = (target: EventTarget | null) => void;
 const toggleSubscribers = new Set<ToggleNudge>();
 let toggleListenerAttached = false;
 let sharedToggleListener: ((event: Event) => void) | null = null;
@@ -43,8 +43,11 @@ function syncToggleListener(): void {
     return;
   }
   if (!toggleListenerAttached || !sharedToggleListener) {
-    sharedToggleListener = () => {
-      toggleSubscribers.forEach((subscriber) => subscriber());
+    sharedToggleListener = (event) => {
+      // Pass the event target so each subscriber can decide whether the
+      // toggled element is relevant to its own subtree, rather than
+      // running every subscriber on every unrelated `<details>` toggle.
+      toggleSubscribers.forEach((subscriber) => subscriber(event.target));
     };
     document.addEventListener('toggle', sharedToggleListener, true);
     toggleListenerAttached = true;
@@ -485,8 +488,13 @@ export function Pre({
   // down (`oldRef(null)`) and re-run (`newRef(preNode)`) on every parent
   // render, momentarily exposing `null` to any consumer that observes
   // null/non-null transitions.
+  //
+  // `useLayoutEffect` (rather than `useInsertionEffect`) keeps this
+  // compatible with the React 17 lower bound of the package's peer
+  // range. It still runs synchronously after commit and before the
+  // `apply` effect below, so the apply path always reads the latest ref.
   const latestRef = React.useRef(ref);
-  React.useInsertionEffect(() => {
+  React.useLayoutEffect(() => {
     latestRef.current = ref;
   }, [ref]);
 
@@ -590,7 +598,14 @@ export function Pre({
     // listener on the document still intercepts them. A single shared
     // listener (see `subscribeToggleNudge`) fans the event out to every
     // mounted `<Pre>` instead of installing N listeners on heavy pages.
-    const unsubscribeToggle = subscribeToggleNudge(nudgeFrameObserver);
+    // Filter by ancestry: only nudge when the toggled element actually
+    // contains this `<pre>`, so unrelated toggles elsewhere in the
+    // document don't trigger a frame re-observe pass per `<Pre>`.
+    const unsubscribeToggle = subscribeToggleNudge((target) => {
+      if (target instanceof Node && target.contains(preNode)) {
+        nudgeFrameObserver();
+      }
+    });
 
     return () => {
       io.disconnect();


### PR DESCRIPTION
## Summary

Frames hidden by a CSS-driven collapse (e.g. `max-height: 0; overflow: hidden;` or `visibility: hidden`) were being upgraded to highlighted HAST because IntersectionObserver still reports `isIntersecting: true` for elements whose layout box has collapsed to zero area but whose geometric position is in the viewport. This wastes memory on frames the user can't see and (more importantly for `useCodeWindow`-driven collapse animations) hydrates frames at the wrong time.

## Primary fix

Treat a frame as visible only when its `intersectionRect` has non-zero area in addition to `isIntersecting` being true.

## Related infrastructure changes (also in this PR)

A zero-area gate alone isn't enough — once a frame is gated out, nothing re-fires the IO when the host CSS un-collapses the ancestor (CSS collapse animations, `<details>` toggles, tab/accordion swaps don't generate IO entries on their own). To make the gate actually unblock frames again when they become visible, this PR also lands:

- **Process-wide shared `<details>` `toggle` listener.** A single capture-phase listener on `document` fans out to all mounted `<Pre>` instances instead of N per-instance listeners. (Toggle events don't bubble, so a capture-phase document listener is the cheapest cross-instance signal.)
- **`ResizeObserver` on the `<pre>`** — re-evaluates frame visibility when ancestor layout changes resize the pre. Guarded by `typeof ResizeObserver !== 'undefined'` so JSDOM/older runtimes still work.
- **`observedFrames` Set + `sweepDetachedFrames` / `nudgeFrameObserver`** — tracks live frame spans and prunes detached ones. Uses React 19 ref-callback cleanup as the fast path; falls back to an `isConnected` sweep on React 17/18 (peer dep range) so the set stays bounded.
- **Observer setup moved from a callback ref into `useState` + `useEffect`** keyed on the pre element. Delegates teardown to React's effect lifecycle so cleanup is guaranteed under StrictMode double-invoke and any abrupt unmount path. The forwarded ref is reconciled in its own effect so a parent re-render that supplies a new ref function no longer churns the IO/RO/toggle subscription.

## Tests

- Regression test for the zero-area visibility gate (mock IO reports `isIntersecting: true` regardless of rect area, mirroring real browsers).
- Subscriber-accounting test for the shared `toggle` listener (one add for two mounts; remove only after the last unmount).
- ResizeObserver-driven re-observe test (RO callback fires → every frame is unobserved+re-observed).
