### PR TITLE
Guard tsconfig merge against prototype pollution

### DIFF
--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadTypescriptConfig.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadTypescriptConfig.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mergeConfig } from './loadTypescriptConfig';
+
+describe('mergeConfig', () => {
+  it('merges flat properties from source into target', () => {
+    const target = { foo: 1, bar: 2 };
+    const source = { bar: 3, baz: 4 };
+
+    const result = mergeConfig(target, source);
+
+    expect(result).toEqual({ foo: 1, bar: 3, baz: 4 });
+  });
+
+  it('recursively merges nested objects', () => {
+    const target = { compilerOptions: { target: 'es5', strict: true } };
+    const source = { compilerOptions: { target: 'es2020', module: 'esnext' } };
+
+    const result = mergeConfig(target, source);
+
+    expect(result).toEqual({
+      compilerOptions: { target: 'es2020', strict: true, module: 'esnext' },
+    });
+  });
+
+  it('overwrites arrays rather than merging them', () => {
+    const target = { include: ['src'] };
+    const source = { include: ['lib', 'test'] };
+
+    const result = mergeConfig(target, source);
+
+    expect(result).toEqual({ include: ['lib', 'test'] });
+  });
+
+  it('does not pollute Object.prototype via __proto__ key', () => {
+    const target: Record<string, unknown> = {};
+    const source = JSON.parse('{"__proto__": {"polluted": true}}');
+
+    mergeConfig(target, source);
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+
+  it('does not pollute Object.prototype via constructor.prototype key', () => {
+    const target: Record<string, unknown> = {};
+    const source = JSON.parse('{"constructor": {"prototype": {"polluted": true}}}');
+
+    mergeConfig(target, source);
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+
+  it('does not assign a prototype key from source', () => {
+    const target: Record<string, unknown> = {};
+    const source = JSON.parse('{"prototype": {"polluted": true}}');
+
+    mergeConfig(target, source);
+
+    expect(target).not.toHaveProperty('prototype');
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadTypescriptConfig.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadTypescriptConfig.ts
@@ -75,21 +75,24 @@ function setupFileWatcher(configPath: string): void {
   })();
 }
 
-function mergeConfig(target: any, source: any): any {
-  for (const key in source) {
-    if (Object.prototype.hasOwnProperty.call(source, key)) {
-      if (
-        typeof target[key] === 'object' &&
-        target[key] !== null &&
-        typeof source[key] === 'object' &&
-        source[key] !== null &&
-        !Array.isArray(target[key]) &&
-        !Array.isArray(source[key])
-      ) {
-        mergeConfig(target[key], source[key]);
-      } else {
-        target[key] = source[key];
-      }
+export function mergeConfig(target: any, source: any): any {
+  for (const key of Object.keys(source)) {
+    // Guard against prototype pollution from extended tsconfig files
+    // that may contain `__proto__`, `constructor`, or `prototype` keys.
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+    if (
+      typeof target[key] === 'object' &&
+      target[key] !== null &&
+      typeof source[key] === 'object' &&
+      source[key] !== null &&
+      !Array.isArray(target[key]) &&
+      !Array.isArray(source[key])
+    ) {
+      mergeConfig(target[key], source[key]);
+    } else {
+      target[key] = source[key];
     }
   }
 


### PR DESCRIPTION
The recursive `mergeConfig` helper in `loadTypescriptConfig` copied keys from a parsed tsconfig (potentially reached via `extends` from `node_modules`) into a target object without filtering `__proto__`, `constructor`, or `prototype`. Skip those keys explicitly so a malicious or malformed tsconfig cannot mutate `Object.prototype`. Closes CodeQL alert #73 (`js/prototype-pollution-utility`).