### PR TITLE
Fix identity replacement in loadServerTypes

### DIFF
--- a/packages/docs-infra/src/pipeline/loadServerTypes/loadServerTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypes/loadServerTypes.ts
@@ -163,7 +163,7 @@ export async function loadServerTypes(
         return parts.slice(1).join('.').toLowerCase();
       }
       // No prefix match, use the full name
-      return name.replace(/\./g, '.').toLowerCase();
+      return name.toLowerCase();
     }
     // Non-dotted name: use as-is
     return name.toLowerCase();


### PR DESCRIPTION
## Summary

CodeQL alert #64 (`js/identity-replacement`) flagged `name.replace(/\./g, '.')` in `computeSlug` at `packages/docs-infra/src/pipeline/loadServerTypes/loadServerTypes.ts:166`, which replaces `.` with itself and is a no-op. The surrounding logic intentionally preserves dots in dotted slug names (e.g. `Foo.Bar` -> `foo.bar`), so the replace served no purpose; only the following `.toLowerCase()` was doing work. Removing the redundant call clarifies intent without changing behavior.