### PR TITLE
Fix polynomial-redos warnings in docs-infra pipeline

### DIFF
--- a/packages/docs-infra/src/pipeline/loadPrecomputedCodeHighlighterClient/collectDeclaredNames.test.ts
+++ b/packages/docs-infra/src/pipeline/loadPrecomputedCodeHighlighterClient/collectDeclaredNames.test.ts
@@ -56,4 +56,47 @@ describe('collectDeclaredNames', () => {
   it('returns an empty set for empty source', () => {
     expect(collectDeclaredNames('')).toEqual(new Set());
   });
+
+  it('handles whitespace-heavy adversarial input in linear time', () => {
+    // Inputs crafted to expose the previously polynomial regex behavior
+    // (many leading newlines/spaces, dangling `import {{`, etc.). They
+    // should each return quickly and not collect any meaningful names.
+    const inputs = [
+      `${'\n'.repeat(20000)}`,
+      `${'import {{'.repeat(5000)}`,
+      `import ${' '.repeat(20000)}`,
+      `let${' '.repeat(20000)}`,
+    ];
+    for (const input of inputs) {
+      const start = performance.now();
+      const result = collectDeclaredNames(input);
+      const elapsedMs = performance.now() - start;
+      // Generous bound — polynomial behavior would blow well past this.
+      expect(elapsedMs).toBeLessThan(1000);
+      expect(result).toBeInstanceOf(Set);
+    }
+  });
+
+  it('ignores `import` substrings inside identifiers', () => {
+    const source = `
+      const myImporter = 1;
+      const importable = 2;
+    `;
+    const names = collectDeclaredNames(source);
+    expect(names.has('myImporter')).toBe(true);
+    expect(names.has('importable')).toBe(true);
+  });
+
+  it('handles type-only default imports', () => {
+    const source = `import type Foo from './x';`;
+    const names = collectDeclaredNames(source);
+    expect(names.has('Foo')).toBe(true);
+  });
+
+  it('handles default + named combo', () => {
+    const source = `import Default, { Named } from './x';`;
+    const names = collectDeclaredNames(source);
+    expect(names.has('Default')).toBe(true);
+    expect(names.has('Named')).toBe(true);
+  });
 });

--- a/packages/docs-infra/src/pipeline/loadPrecomputedCodeHighlighterClient/collectDeclaredNames.ts
+++ b/packages/docs-infra/src/pipeline/loadPrecomputedCodeHighlighterClient/collectDeclaredNames.ts
@@ -1,3 +1,6 @@
+const IDENTIFIER_REGEX = /[A-Za-z_$][\w$]*/g;
+const LEADING_IDENTIFIER_REGEX = /^([A-Za-z_$][\w$]*)/;
+
 /**
  * Collects identifier names that are already declared in the given source
  * (top-level imports, `const`/`let`/`var` bindings, function and class
@@ -15,33 +18,13 @@ export function collectDeclaredNames(source: string): Set<string> {
   const names = new Set<string>();
 
   // Imports: default, namespace, and named (with optional `as` aliases).
-  const importRegex =
-    /import\s+(?:type\s+)?(?:([A-Za-z_$][\w$]*)\s*(?:,\s*)?)?(?:\*\s+as\s+([A-Za-z_$][\w$]*))?(?:\{([^}]*)\})?\s*from\s*['"][^'"]+['"]/g;
-  for (const match of source.matchAll(importRegex)) {
-    const [, defaultName, namespaceName, namedBlock] = match;
-    if (defaultName) {
-      names.add(defaultName);
-    }
-    if (namespaceName) {
-      names.add(namespaceName);
-    }
-    if (namedBlock) {
-      for (const part of namedBlock.split(',')) {
-        const trimmed = part.trim().replace(/^type\s+/, '');
-        if (!trimmed) {
-          continue;
-        }
-        const aliasMatch = trimmed.match(/\s+as\s+([A-Za-z_$][\w$]*)\s*$/);
-        if (aliasMatch) {
-          names.add(aliasMatch[1]);
-        } else {
-          const nameMatch = trimmed.match(/^([A-Za-z_$][\w$]*)/);
-          if (nameMatch) {
-            names.add(nameMatch[1]);
-          }
-        }
-      }
-    }
+  // Locate each `import ... from '...';` statement with cheap string ops
+  // and then parse the head separately. Doing the search with `indexOf`
+  // and a single-character class avoids the polynomial backtracking that a
+  // monolithic regex with multiple optional `\s+`-separated groups can
+  // exhibit on adversarial input (e.g. many `import {{` repetitions).
+  for (const head of iterateImportHeads(source)) {
+    collectImportNames(head, names);
   }
 
   // Top-level `const`/`let`/`var` bindings (including destructuring, both
@@ -49,20 +32,265 @@ export function collectDeclaredNames(source: string): Set<string> {
   // terminating `;` and harvest every identifier inside — over-collecting
   // (e.g. picking up a value identifier on the right-hand side) is harmless
   // because it only causes the new import to be aliased.
-  const declarationRegex = /(?:^|[\n;{}])\s*(?:export\s+)?(?:const|let|var)\s+([^;]+);/g;
+  // The leading anchor uses `[ \t]*` instead of `\s*` so it cannot overlap
+  // with the preceding `\n`/`;`/`{`/`}` separator (which `\s` would also
+  // match), eliminating polynomial backtracking on whitespace-heavy input.
+  const declarationRegex = /(?:^|[\n;{}])[ \t]*(?:export[ \t]+)?(?:const|let|var)[ \t]+([^;]+);/g;
   for (const match of source.matchAll(declarationRegex)) {
     const binding = match[1];
-    for (const idMatch of binding.matchAll(/[A-Za-z_$][\w$]*/g)) {
+    for (const idMatch of binding.matchAll(IDENTIFIER_REGEX)) {
       names.add(idMatch[0]);
     }
   }
 
-  // Top-level function and class declarations.
+  // Top-level function and class declarations. Same `[ \t]*` trick keeps
+  // the leading-whitespace consumption non-overlapping with the line break.
   const functionRegex =
-    /(?:^|\n)\s*(?:export\s+(?:default\s+)?)?(?:async\s+)?(?:function\*?|class)\s+([A-Za-z_$][\w$]*)/g;
+    /(?:^|\n)[ \t]*(?:export[ \t]+(?:default[ \t]+)?)?(?:async[ \t]+)?(?:function\*?|class)[ \t]+([A-Za-z_$][\w$]*)/g;
   for (const match of source.matchAll(functionRegex)) {
     names.add(match[1]);
   }
 
   return names;
+}
+
+/**
+ * Yields the "head" of every plausible `import ... from '...'` statement in
+ * `source` — the substring between the `import` keyword and the matching
+ * `from`. This walks the source linearly, so every regex consumer
+ * downstream operates on a bounded slice and cannot trigger the polynomial
+ * backtracking that a single monolithic import-statement regex can.
+ */
+function* iterateImportHeads(source: string): Generator<string> {
+  let cursor = 0;
+  while (cursor < source.length) {
+    const importIndex = source.indexOf('import', cursor);
+    if (importIndex === -1) {
+      return;
+    }
+    const afterImport = importIndex + 6;
+    // Require word boundaries around the keyword so we don't match
+    // identifiers like `myImport` or `importable`.
+    const prevCode = importIndex > 0 ? source.charCodeAt(importIndex - 1) : 0;
+    const nextCode = source.charCodeAt(afterImport);
+    if (isWordChar(prevCode) || isWordChar(nextCode)) {
+      cursor = importIndex + 1;
+      continue;
+    }
+    // Look for the first quote or terminating `;`/`{` that would invalidate
+    // a single-line `import ... from '...'` statement.
+    let scan = afterImport;
+    let quoteIndex = -1;
+    let quoteChar = 0;
+    while (scan < source.length) {
+      const code = source.charCodeAt(scan);
+      if (code === 34 /* '"' */ || code === 39 /* "'" */) {
+        quoteIndex = scan;
+        quoteChar = code;
+        break;
+      }
+      if (code === 59 /* ';' */) {
+        // Statement terminator with no quoted source — bail out.
+        break;
+      }
+      scan += 1;
+    }
+    if (quoteIndex === -1) {
+      cursor = afterImport;
+      continue;
+    }
+    // Find the matching `from` token immediately before the quote.
+    const fromIndex = findFromBefore(source, afterImport, quoteIndex);
+    if (fromIndex === -1) {
+      cursor = quoteIndex + 1;
+      continue;
+    }
+    // Find the closing quote.
+    const closeQuote = source.indexOf(String.fromCharCode(quoteChar), quoteIndex + 1);
+    if (closeQuote === -1) {
+      return;
+    }
+    yield source.slice(afterImport, fromIndex);
+    cursor = closeQuote + 1;
+  }
+}
+
+/**
+ * Returns the index of the `from` token between `start` and `quoteIndex`,
+ * or `-1` if there is none. Requires whitespace on both sides.
+ */
+function findFromBefore(source: string, start: number, quoteIndex: number): number {
+  for (let index = start; index <= quoteIndex - 4; index += 1) {
+    if (
+      source.charCodeAt(index) === 102 /* 'f' */ &&
+      source.charCodeAt(index + 1) === 114 /* 'r' */ &&
+      source.charCodeAt(index + 2) === 111 /* 'o' */ &&
+      source.charCodeAt(index + 3) === 109 /* 'm' */
+    ) {
+      const before = index > 0 ? source.charCodeAt(index - 1) : 0;
+      const after = source.charCodeAt(index + 4);
+      if (!isWordChar(before) && !isWordChar(after)) {
+        return index;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * True when `code` is an ASCII word character (`[A-Za-z0-9_$]`). Used for
+ * cheap word-boundary checks during the manual import scan.
+ */
+function isWordChar(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 97 && code <= 122) || // a-z
+    code === 95 || // _
+    code === 36 // $
+  );
+}
+
+/**
+ * Parses the head of an `import` statement (everything between `import` and
+ * `from`) and adds the bound identifier names to `names`.
+ *
+ * Handles:
+ * - `import Foo from '...'` — default import
+ * - `import * as Foo from '...'` — namespace import
+ * - `import { Foo, Bar as Baz } from '...'` — named imports with aliases
+ * - `import type { Foo } from '...'` and inline `type` specifiers
+ * - any combination of the above
+ */
+function collectImportNames(head: string, names: Set<string>): void {
+  // Strip an optional leading `type ` keyword from `import type ...`.
+  let cursor = 0;
+  while (cursor < head.length && isWhitespace(head.charCodeAt(cursor))) {
+    cursor += 1;
+  }
+  if (head.startsWith('type', cursor) && isWhitespace(head.charCodeAt(cursor + 4))) {
+    cursor += 4;
+  }
+
+  // Optional default name.
+  while (cursor < head.length && isWhitespace(head.charCodeAt(cursor))) {
+    cursor += 1;
+  }
+  const defaultMatch = LEADING_IDENTIFIER_REGEX.exec(head.slice(cursor));
+  if (defaultMatch) {
+    names.add(defaultMatch[1]);
+    cursor += defaultMatch[1].length;
+    while (cursor < head.length && isWhitespace(head.charCodeAt(cursor))) {
+      cursor += 1;
+    }
+    if (head.charCodeAt(cursor) === 44 /* ',' */) {
+      cursor += 1;
+      while (cursor < head.length && isWhitespace(head.charCodeAt(cursor))) {
+        cursor += 1;
+      }
+    }
+  }
+
+  // Optional namespace import: `* as Foo`.
+  if (head.charCodeAt(cursor) === 42 /* '*' */) {
+    cursor += 1;
+    while (cursor < head.length && isWhitespace(head.charCodeAt(cursor))) {
+      cursor += 1;
+    }
+    if (head.startsWith('as', cursor) && isWhitespace(head.charCodeAt(cursor + 2))) {
+      cursor += 2;
+      while (cursor < head.length && isWhitespace(head.charCodeAt(cursor))) {
+        cursor += 1;
+      }
+      const namespaceMatch = LEADING_IDENTIFIER_REGEX.exec(head.slice(cursor));
+      if (namespaceMatch) {
+        names.add(namespaceMatch[1]);
+        cursor += namespaceMatch[1].length;
+      }
+    }
+  }
+
+  // Optional named-imports block: `{ Foo, Bar as Baz }`.
+  const openBrace = head.indexOf('{', cursor);
+  if (openBrace === -1) {
+    return;
+  }
+  const closeBrace = head.indexOf('}', openBrace + 1);
+  if (closeBrace === -1) {
+    return;
+  }
+  const namedBlock = head.slice(openBrace + 1, closeBrace);
+  for (const part of namedBlock.split(',')) {
+    const trimmed = stripLeadingType(part.trim());
+    if (!trimmed) {
+      continue;
+    }
+    // If there's an ` as ` alias, take the identifier after it; otherwise
+    // take the identifier at the start. Splitting/searching with string
+    // methods here avoids regex backtracking on whitespace-heavy specifiers.
+    const aliasName = extractAliasName(trimmed);
+    if (aliasName) {
+      names.add(aliasName);
+      continue;
+    }
+    const nameMatch = LEADING_IDENTIFIER_REGEX.exec(trimmed);
+    if (nameMatch) {
+      names.add(nameMatch[1]);
+    }
+  }
+}
+
+/**
+ * Removes a leading `type ` keyword (followed by whitespace) from a named
+ * import specifier such as `type Foo as Bar`.
+ */
+function stripLeadingType(specifier: string): string {
+  if (
+    specifier.startsWith('type') &&
+    specifier.length > 4 &&
+    isWhitespace(specifier.charCodeAt(4))
+  ) {
+    let index = 5;
+    while (index < specifier.length && isWhitespace(specifier.charCodeAt(index))) {
+      index += 1;
+    }
+    return specifier.slice(index);
+  }
+  return specifier;
+}
+
+/**
+ * If the specifier contains an ` as ` alias clause, returns the alias name.
+ * Returns `undefined` otherwise.
+ */
+function extractAliasName(specifier: string): string | undefined {
+  // Walk forward looking for the literal token `as` surrounded by
+  // whitespace on both sides. A linear scan keeps this O(n) regardless of
+  // how many spaces or stray `as` substrings appear.
+  for (let index = 1; index < specifier.length - 2; index += 1) {
+    if (
+      isWhitespace(specifier.charCodeAt(index)) &&
+      specifier.charCodeAt(index + 1) === 97 /* 'a' */ &&
+      specifier.charCodeAt(index + 2) === 115 /* 's' */ &&
+      isWhitespace(specifier.charCodeAt(index + 3))
+    ) {
+      let cursor = index + 4;
+      while (cursor < specifier.length && isWhitespace(specifier.charCodeAt(cursor))) {
+        cursor += 1;
+      }
+      const aliasMatch = LEADING_IDENTIFIER_REGEX.exec(specifier.slice(cursor));
+      if (aliasMatch) {
+        return aliasMatch[1];
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * True when `code` is a whitespace character (space, tab, newline, carriage
+ * return, form feed, or NaN/undefined which we treat as boundary).
+ */
+function isWhitespace(code: number): boolean {
+  return code === 32 || code === 9 || code === 10 || code === 13 || code === 12;
 }

--- a/packages/docs-infra/src/pipeline/loaderUtils/extractNameAndSlugFromUrl.ts
+++ b/packages/docs-infra/src/pipeline/loaderUtils/extractNameAndSlugFromUrl.ts
@@ -99,10 +99,15 @@ function isCamelCase(str: string): boolean {
  * @returns kebab-case string
  */
 function toKebabCase(str: string): string {
+  // Split on any run of non-alphanumeric characters and rejoin with `-`,
+  // dropping empty segments (which removes any leading/trailing separators).
+  // Using `split` + `filter` + `join` avoids the polynomial backtracking that
+  // chained `replace` calls with anchored quantifiers can exhibit.
   return str
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+    .join('-');
 }
 
 /**

--- a/packages/docs-infra/src/pipeline/loaderUtils/resolveModulePath.ts
+++ b/packages/docs-infra/src/pipeline/loaderUtils/resolveModulePath.ts
@@ -87,8 +87,15 @@ function isStaticAsset(path: string): boolean {
  * @returns true if it's a JS/TS module, false otherwise
  */
 export function isJavaScriptModule(path: string): boolean {
-  // If the path has an extension, check if it's one of the JS/TS extensions
-  if (/\.[^/]+$/.test(path)) {
+  // Determine whether the last path segment contains a `.` followed by at
+  // least one character — equivalent to the original `/\.[^/]+$/` test but
+  // using string indices to avoid the polynomial backtracking that the regex
+  // can exhibit on input dominated by `.` characters.
+  const lastSlashIndex = path.lastIndexOf('/');
+  const lastSegment = lastSlashIndex >= 0 ? path.slice(lastSlashIndex + 1) : path;
+  const dotIndex = lastSegment.indexOf('.');
+  const hasExtension = dotIndex !== -1 && dotIndex < lastSegment.length - 1;
+  if (hasExtension) {
     return JAVASCRIPT_MODULE_EXTENSIONS.some((ext) => path.endsWith(ext));
   }
   // If no extension, assume it's a JS/TS module (will be resolved to one)

--- a/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
@@ -54,8 +54,44 @@ function getParentDir(path: string, skipRouteGroups: boolean = false): string {
  * @returns true if the path should be included, false otherwise
  */
 function shouldIncludePath(path: string, include?: string[], exclude?: string[]): boolean {
-  // Normalize path separators to forward slashes and remove Next.js route groups
-  const normalizedPath = path.replace(/\\/g, '/').replace(/\/\([^)]+\)/g, '');
+  // Normalize path separators to forward slashes, then strip Next.js route
+  // groups (a `/` followed by `(...)`). A single forward scan over the
+  // string with a monotonically advancing search position keeps the total
+  // work linear and avoids the polynomial backtracking that an unanchored
+  // `\/\([^)]+\)` regex can exhibit on input dominated by `/(`.
+  const forwardSlashPath = path.replaceAll('\\', '/');
+  const segments: string[] = [];
+  let segmentStart = 0;
+  let cursor = 0;
+  let searchFrom = 0;
+  while (cursor < forwardSlashPath.length) {
+    if (
+      forwardSlashPath.charCodeAt(cursor) === 47 /* '/' */ &&
+      forwardSlashPath.charCodeAt(cursor + 1) === 40 /* '(' */
+    ) {
+      // `searchFrom` only ever advances, so the cumulative work of every
+      // `indexOf(')')` across all iterations remains O(n).
+      if (searchFrom < cursor + 2) {
+        searchFrom = cursor + 2;
+      }
+      const closeIndex = forwardSlashPath.indexOf(')', searchFrom);
+      if (closeIndex === -1) {
+        // No further `)` characters exist; nothing else can match.
+        break;
+      }
+      searchFrom = closeIndex + 1;
+      if (closeIndex > cursor + 2) {
+        // Match `[^)]+` (one or more non-`)` characters) before the `)`.
+        segments.push(forwardSlashPath.slice(segmentStart, cursor));
+        segmentStart = closeIndex + 1;
+        cursor = closeIndex + 1;
+        continue;
+      }
+    }
+    cursor += 1;
+  }
+  segments.push(forwardSlashPath.slice(segmentStart));
+  const normalizedPath = segments.join('');
 
   // Check exclude patterns first
   if (exclude && exclude.length > 0) {


### PR DESCRIPTION
Rewrites the seven regular expressions flagged by the CodeQL `js/polynomial-redos` rule in the build-time docs-infra pipeline so adversarial input (long runs of `\n`, `import {{`, `/(`, `.`, or `-`) can no longer drive the parser into quadratic backtracking. Each rewrite preserves the original behavior, prefers cheap string operations where possible per AGENTS.md rule 7.11, and is covered by the existing unit tests (with extra polynomial-resistance cases added for `collectDeclaredNames`).

- Alert 81: `collectDeclaredNames` function-declaration regex (`(?:^|\n)\s*` overlap)
- Alert 80: `collectDeclaredNames` declaration regex (`[\n;{}]\s*` overlap)
- Alert 79: `collectDeclaredNames` named-import alias regex (`\s+as\s+...\s*$`)
- Alert 78: `collectDeclaredNames` import-statement regex (replaced with linear scan)
- Alert 59: `syncPageIndex.shouldIncludePath` route-group strip (`\/\([^)]+\)`)
- Alert 56: `resolveModulePath.isJavaScriptModule` extension test (`\.[^/]+$`)
- Alert 55: `extractNameAndSlugFromUrl.toKebabCase` trim chain (`^-+|-+$`)