### PR TITLE
Fix incomplete-sanitization warnings in docs-infra pipeline

### DIFF
--- a/packages/docs-infra/src/cli/ensureDemoClients.ts
+++ b/packages/docs-infra/src/cli/ensureDemoClients.ts
@@ -245,6 +245,9 @@ function patternToRegExp(pattern: string): RegExp {
     .replace(/^\.\//, '') // drop leading ./
     .replace(/\*\*\//g, DOUBLE_STAR)
     .replace(/\*/g, NOT_SEP)
+    // Escape backslashes before escaping dots, so a literal `\` in the input
+    // is preserved rather than fusing with the inserted dot-escape.
+    .replace(/\\/g, '\\\\')
     .replace(/\./g, '\\.')
     .replace(new RegExp(DOUBLE_STAR, 'g'), `(?:${NOT_SEP}${SEP})*`)
     .replace(/\//g, SEP)

--- a/packages/docs-infra/src/pipeline/enhanceCodeTypes/enhanceChildren.ts
+++ b/packages/docs-infra/src/pipeline/enhanceCodeTypes/enhanceChildren.ts
@@ -1793,8 +1793,10 @@ function extractStringLiteralValue(node: Element): string | null {
       return null; // Handled by handleTemplateLiteral
     }
   }
-  // Escape embedded single quotes so the output is a valid JS string literal.
-  const raw = parts.join('').replace(/'/g, "\\'");
+  // Escape backslashes first, then embedded single quotes so the output is a
+  // valid JS string literal even when the source already contained escape
+  // sequences such as `\\` or `\n`.
+  const raw = parts.join('').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
   return `${quote}${raw}${quote}`;
 }
 
@@ -1863,7 +1865,10 @@ function extractTemplateLiteralTokens(
         if (tokens.length > 0) {
           tokens.push({ kind: 'operator', value: '+' });
         }
-        tokens.push({ kind: 'string', value: `'${child.value.replace(/'/g, "\\'")}'` });
+        // Escape backslashes first, then single quotes so escape sequences
+        // in the source survive and the resulting literal stays well-formed.
+        const escaped = child.value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+        tokens.push({ kind: 'string', value: `'${escaped}'` });
       }
       // Ignore whitespace-only text inside interpolation so `${ name }`
       // works regardless of whether the highlighter emits spaces as text nodes

--- a/packages/docs-infra/src/pipeline/enhanceCodeTypes/enhanceCodeTypes.test.ts
+++ b/packages/docs-infra/src/pipeline/enhanceCodeTypes/enhanceCodeTypes.test.ts
@@ -3331,6 +3331,24 @@ describe('enhanceCodeTypes', () => {
 
         expect(output).toContain('data-value="&#x27;can\\&#x27;t&#x27;"');
       });
+
+      it('escapes embedded backslashes so the emitted JS string stays well-formed', async () => {
+        // const x = 'a\b'; use(x) — the source already contains a backslash
+        // followed by `b`. Without escaping it, the emitted literal `'a\b'`
+        // would be parsed as a backslash escape and silently truncate.
+        const input =
+          '<code class="language-tsx">' +
+          '<span class="pl-k">const</span> <span class="pl-c1">x</span> <span class="pl-k">=</span> ' +
+          '<span class="pl-s"><span class="pl-pds">\'</span>a\\b<span class="pl-pds">\'</span></span>; ' +
+          '<span class="pl-smi">x</span>' +
+          '</code>';
+
+        const output = await processWithValues(input, { js: {} });
+
+        // The emitted attribute is HTML-escaped: `\` stays literal but the
+        // backslash should now be doubled so the literal evaluates to `a\b`.
+        expect(output).toContain('data-value="&#x27;a\\\\b&#x27;"');
+      });
     });
 
     describe('semicolon-free initializers (ASI)', () => {

--- a/packages/docs-infra/src/pipeline/enhanceCodeTypes/processTextNode.ts
+++ b/packages/docs-infra/src/pipeline/enhanceCodeTypes/processTextNode.ts
@@ -1031,21 +1031,27 @@ function evaluatePartialConcat(
 }
 
 /**
- * Strips surrounding quotes from a string literal value.
+ * Strips surrounding quotes from a string literal value, undoing the
+ * backslash escapes produced by `escapeQuotes`. Single quotes are
+ * unescaped first so that an escaped backslash (`\\`) preceding a
+ * literal quote does not get interpreted as a quote escape.
  * `'hello'` → `hello`, `"world"` → `world`
  */
 function stripQuotes(s: string): string {
   if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith('"') && s.endsWith('"'))) {
-    return s.slice(1, -1).replace(/\\'/g, "'");
+    return s.slice(1, -1).replace(/\\'/g, "'").replace(/\\\\/g, '\\');
   }
   return s;
 }
 
 /**
- * Escapes single quotes in a string for inclusion in a single-quoted literal.
+ * Escapes characters in a string for inclusion in a single-quoted JS literal.
+ * Backslashes must be escaped first so that pre-existing backslash
+ * sequences (e.g. `\n`) are not misinterpreted, and so that the
+ * subsequent single-quote escape does not produce ambiguous output.
  */
 function escapeQuotes(s: string): string {
-  return s.replace(/'/g, "\\'");
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 }
 
 /**

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatRaw.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatRaw.ts
@@ -301,7 +301,11 @@ async function generateFormattedCode(
           const nameParts = dottedName.split('.');
           if (nameParts.length >= 2 && nameParts[0] === currentNamespace) {
             const memberName = nameParts.slice(1).join('.');
-            const memberPattern = `\\w+\\.${memberName.replace(/\./g, '\\.')}`;
+            // memberName is a TypeScript dotted member name (`Foo.Bar`).
+            // TS identifiers cannot contain `\`, but escape it first anyway
+            // so any unexpected character is treated literally rather than
+            // colliding with the dot-escape inserted on the next pass.
+            const memberPattern = `\\w+\\.${memberName.replace(/\\/g, '\\\\').replace(/\./g, '\\.')}`;
             const regex = new RegExp(memberPattern, 'g');
             transformedTypeText = transformedTypeText.replace(regex, dottedName);
           }

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/resolveLibrarySourceFiles.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/resolveLibrarySourceFiles.ts
@@ -37,7 +37,10 @@ function transformTsconfigPaths(tsconfigPaths: ts.MapLike<string[]>): Record<str
   const paths: Record<string, string[]> = {};
 
   Object.keys(tsconfigPaths).forEach((key) => {
-    const regex = `^${key.replace('**', '(.+)').replace('*', '([^/]+)')}$`;
+    // Replace globally so patterns with multiple wildcards (or accidental
+    // duplicates) are converted consistently rather than only on the first
+    // occurrence. `**` must be matched before `*` to avoid splitting it apart.
+    const regex = `^${key.replace(/\*\*/g, '(.+)').replace(/\*/g, '([^/]+)')}$`;
     paths[regex] = tsconfigPaths[key].map((p) => {
       let index = 0;
       return p.replace(/\*\*|\*/g, () => {

--- a/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.test.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.test.ts
@@ -1493,6 +1493,24 @@ describe('round-trip conversion', () => {
     expect(parsed?.pageMetadata).toEqual(original.pageMetadata);
   });
 
+  it('should round-trip pageMetadata strings containing backslashes and quotes', async () => {
+    const original: PagesMetadata = {
+      title: 'Components',
+      pages: [],
+      pageMetadata: {
+        // The serializer wraps strings in single quotes, so a backslash or
+        // a quote in the value must survive a round-trip without breaking
+        // the generated `export const metadata = ...` statement.
+        custom: "back\\slash and 'quote'",
+      },
+    };
+
+    const markdown = metadataToMarkdown(original);
+    const parsed = await markdownToMetadata(markdown);
+
+    expect(parsed?.pageMetadata).toEqual(original.pageMetadata);
+  });
+
   it('should handle empty pages array', async () => {
     const original: PagesMetadata = {
       title: 'Empty Components',

--- a/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.ts
@@ -9,6 +9,9 @@ import { type Audience } from '../../createSitemap/types';
 /**
  * Escapes underscores in a string for markdown compatibility.
  * Prevents underscores from being interpreted as emphasis markers.
+ *
+ * Inputs are JS/TS identifier names or CSS variable names — none of
+ * which can contain a backslash — so backslashes do not need escaping.
  * @example escapeUnderscores('_options') -> '\_options'
  */
 function escapeUnderscores(str: string): string {
@@ -17,6 +20,9 @@ function escapeUnderscores(str: string): string {
 
 /**
  * Unescapes underscores in a string that was escaped for markdown.
+ * Inverse of `escapeUnderscores` for any input that survives
+ * `extractPlainTextFromNode` (the markdown parser already collapses
+ * backslash escapes, so this only handles a defensive `\_` case).
  * @example unescapeUnderscores('\_options') -> '_options'
  */
 function unescapeUnderscores(str: string): string {
@@ -166,8 +172,9 @@ function serializeJsValue(value: unknown, indent: number): string {
     return String(value);
   }
   if (typeof value === 'string') {
-    // Use single quotes for strings, escaping any internal single quotes
-    return `'${String(value).replace(/'/g, "\\'")}'`;
+    // Use single quotes for strings. Escape backslashes first so that escape
+    // sequences in the input survive intact, then escape any single quotes.
+    return `'${String(value).replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
   }
   if (typeof value !== 'object') {
     return String(value);

--- a/packages/docs-infra/src/withDocsInfra/withDocsInfra.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDocsInfra.ts
@@ -553,6 +553,9 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
               .replace(/^\.\//, '') // Remove leading ./
               .replace(/\*\*\//g, 'DOUBLE_STAR_PLACEHOLDER') // Replace **/ with placeholder
               .replace(/\*/g, NOT_SEP) // Replace single * with placeholder
+              // Escape backslashes before escaping dots so a literal `\` in
+              // the input is preserved rather than fusing with the dot-escape.
+              .replace(/\\/g, '\\\\')
               .replace(/\./g, '\\.') // Escape dots
               .replace(/DOUBLE_STAR_PLACEHOLDER/g, `(?:${NOT_SEP}${SEP})*`) // Replace placeholder with zero or more directories
               .replace(/\//g, SEP) // Convert all path separators to placeholder
@@ -579,6 +582,9 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
               .replace(/^\.\//, '/') // Remove leading ./
               .replace(/\*\*\//g, 'DOUBLE_STAR_PLACEHOLDER') // Replace **/ with placeholder
               .replace(/\*/g, '[^/\\\\]+') // Replace single * with single dir pattern
+              // Escape backslashes before escaping dots so a literal `\` in
+              // the input is preserved rather than fusing with the dot-escape.
+              .replace(/\\/g, '\\\\')
               .replace(/\./g, '\\.') // Escape dots
               .replace(/DOUBLE_STAR_PLACEHOLDER/g, '(?:[^/\\\\]+/)*'); // Replace placeholder with zero or more directories
 


### PR DESCRIPTION
## Summary

Address CodeQL `js/incomplete-sanitization` findings across the docs-infra build pipeline. Most of the alerts flag escape helpers that escape one meta-character (single quote, dot, underscore) without first escaping backslashes, so a backslash in the input could allow a meta-character to slip through unescaped. One alert flags a glob-to-regex helper that replaces only the first `*` instead of all of them.

## Alerts fixed

- 53, 60 — `withDocsInfra.ts`: glob-to-regex conversions now escape backslashes before escaping dots so a literal `\` in a user-supplied glob does not fuse with the inserted dot-escape.
- 62 — `metadataToMarkdown.ts` `serializeJsValue`: arbitrary string values in `pageMetadata` now have backslashes escaped before single quotes when serializing to a JS literal. New round-trip test exercises a value containing both characters.
- 66 — `processTextNode.ts` `escapeQuotes`/`stripQuotes`: backslashes are escaped first when emitting a single-quoted literal, and unescaped last when stripping.
- 68, 74 — `enhanceChildren.ts`: string-literal extraction (plain and template literal) now escapes backslashes before single quotes so emitted JS string literals stay well-formed for source containing `\\`, `\n`, etc. New unit test covers the string-literal path.
- 69 — `formatRaw.ts`: regex built from a TypeScript dotted member name now escapes backslashes before dots, even though TS identifiers cannot contain `\` in practice.
- 70 — `resolveLibrarySourceFiles.ts` `transformTsconfigPaths`: the `key.replace('**', ...).replace('*', ...)` chain now uses global regex replacements so patterns with multiple wildcards convert correctly instead of silently mangling.
- 77 — `ensureDemoClients.ts` `patternToRegExp`: same backslash-before-dot fix as the `withDocsInfra` glob helpers.

## Alerts dismissed

- 71 — `metadataToMarkdown.ts` `escapeUnderscores`: false positive. Inputs are TypeScript identifier names and CSS variable names; neither can contain a backslash by language definition. The function is left as a single-meta-character escape with a clarifying comment.