### PR TITLE
Include details link in "No significant changes" benchmark comment

### DIFF
--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -25,6 +25,18 @@ describe('buildBenchmarkMarkdownReport', () => {
     expect(markdown).not.toContain('| Test |');
   });
 
+  it('includes the details link in the "No significant changes" branch', () => {
+    const report = compareBenchmarkReports(
+      makeReport({ Button: 110, Card: 95 }),
+      makeReport({ Button: 100, Card: 100 }),
+    );
+    const markdown = buildBenchmarkMarkdownReport(report, {
+      reportUrl: 'https://example.com/details',
+    });
+    expect(markdown).toContain('No significant changes');
+    expect(markdown).toContain('https://example.com/details');
+  });
+
   it('shows "...and N more" footer once significant entries exceed maxRows', () => {
     const current: Record<string, number> = {};
     const base: Record<string, number> = {};

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
@@ -59,8 +59,11 @@ export function buildBenchmarkMarkdownReport(
       entry.duration.base === null,
   );
 
+  const detailsLink = reportUrl ? `[details](${reportUrl})` : '';
+  const suffix = detailsLink ? ` — ${detailsLink}` : '';
+
   if (report.hasBase && significant.length === 0) {
-    lines.push('*No significant changes.*');
+    lines.push(`*No significant changes${suffix}*`);
     return lines.join('\n');
   }
 
@@ -85,8 +88,6 @@ export function buildBenchmarkMarkdownReport(
     lines.push(`| ${entry.name} | ${duration} | ${renders} |`);
   }
 
-  const detailsLink = reportUrl ? `[details](${reportUrl})` : '';
-  const suffix = detailsLink ? ` — ${detailsLink}` : '';
   lines.push('');
   if (hiddenSignificant > 0) {
     const noiseSuffix = hiddenWithinNoise > 0 ? ` (+${hiddenWithinNoise} within noise)` : '';


### PR DESCRIPTION
The no-significant-changes branch of `buildBenchmarkMarkdownReport` returned early without using `reportUrl`, so the PR comment had no link back to the full benchmark report in that case. Hoist the `detailsLink`/`suffix` computation above the early return so the branch renders `*No significant changes — [details](url)*`.