### PR TITLE
[internal] Polish mui-public GitHub Action update

### DIFF
--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -18,4 +18,4 @@ jobs:
       issues: write
       actions: write
     name: Handle status labels
-    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@8097d2430a2237044d47b3cfca7c35a6f90c9f48 # master
+    uses: ./.github/workflows/issues_status-label-handler.yml

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -16,4 +16,4 @@ jobs:
       issues: write
       pull-requests: write
     name: Handle stale issues and PRs
-    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@8097d2430a2237044d47b3cfca7c35a6f90c9f48 # master
+    uses: ./.github/workflows/general_handle-stale-issues-and-prs.yml

--- a/renovate.json
+++ b/renovate.json
@@ -7,14 +7,6 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": ["https://github.com/mui/mui-public"],
-      "enabled": false
-    },
-    {
-      "matchDepNames": ["code-infra-gh-actions"],
-      "enabled": true
-    },
-    {
       "description": "Skip major @mui/* updates in apps/tools-public — Toolpad Studio constrains peer deps and these PRs always fail.",
       "matchFileNames": ["apps/tools-public/package.json"],
       "matchPackageNames": ["@mui/*"],


### PR DESCRIPTION
This is a scheduled task to finish the work on #1356. I had snoozed the Gmail notification for about 2-3 weeks to wait to see where the coin would land afterward.

---

1. `code-infra-gh-actions`: I forgot to remove this in #1356. Clean up dead code.
2. #1356 seems to work; for example, #1203 or https://github.com/mui/mui-x/pull/22393 are proof that it works.
3. we made this PR #908 (that has 0 context) but I assume that it was at a time when we were using `#master` to reference local GitHub actions. We don't need it anymore, so deleted.
4. I see two actions that could use local references (the 3rd one can't as it executed from other repositories).