### PR TITLE
Show credits/run instead of credits/day in CI report

### DIFF
--- a/apps/code-infra-dashboard/src/components/CiSummaryTable.tsx
+++ b/apps/code-infra-dashboard/src/components/CiSummaryTable.tsx
@@ -14,8 +14,6 @@ import Tooltip from '@mui/material/Tooltip';
 import type { WorkflowMetrics, PeriodSummary } from '../lib/ciAnalytics';
 import { formatDuration, formatSuccessRate } from '../lib/ciAnalytics';
 
-const WEEK_DAYS = 7;
-const MONTH_DAYS = 30;
 const THRESHOLD_PCT = 5;
 const HIGH_RUNTIME_DELTA = 20;
 const LOW_SUCCESS_RATE = 0.85;
@@ -34,9 +32,9 @@ export interface WorkflowAnalysis {
   runtimeDelta: number;
   runtimeDeltaSeverity: MetricSeverity;
 
-  creditsPerDay: number | null;
-  creditsDelta: number | null;
-  creditsDeltaSeverity: MetricSeverity;
+  creditsPerRun: number | null;
+  creditsPerRunDelta: number | null;
+  creditsPerRunDeltaSeverity: MetricSeverity;
 }
 
 function formatDelta(delta: number): string {
@@ -50,23 +48,19 @@ function getCircleCiInsightsUrl(slug: string, workflow: string): string {
   return `https://app.circleci.com/insights/github/${orgRepo}/workflows/${workflow}/overview?branch=master`;
 }
 
-function computeDeltas(
-  week: PeriodSummary,
-  month: PeriodSummary,
-  allBranchCredits?: { week: number; month: number },
-) {
+function computeDeltas(week: PeriodSummary, month: PeriodSummary) {
   const weekSuccessPct = week.successRate * 100;
   const monthSuccessPct = month.successRate * 100;
   const successDelta = weekSuccessPct - monthSuccessPct;
 
-  let creditsDelta: number | null = null;
-  let weekCreditsPerDay: number | null = null;
-  if (allBranchCredits) {
-    weekCreditsPerDay = allBranchCredits.week / WEEK_DAYS;
-    const monthCreditsPerDay = allBranchCredits.month / MONTH_DAYS;
-    creditsDelta =
-      monthCreditsPerDay > 0
-        ? ((weekCreditsPerDay - monthCreditsPerDay) / monthCreditsPerDay) * 100
+  let creditsPerRunDelta: number | null = null;
+  let weekCreditsPerRun: number | null = null;
+  if (week.totalRuns > 0 && month.totalRuns > 0) {
+    weekCreditsPerRun = week.totalCredits / week.totalRuns;
+    const monthCreditsPerRun = month.totalCredits / month.totalRuns;
+    creditsPerRunDelta =
+      monthCreditsPerRun > 0
+        ? ((weekCreditsPerRun - monthCreditsPerRun) / monthCreditsPerRun) * 100
         : 0;
   }
 
@@ -78,14 +72,13 @@ function computeDeltas(
       100;
   }
 
-  return { successDelta, runtimeDelta, creditsDelta, weekCreditsPerDay };
+  return { successDelta, runtimeDelta, creditsPerRunDelta, weekCreditsPerRun };
 }
 
 export function computeWorkflowAnalysis(wf: WorkflowMetrics): WorkflowAnalysis {
-  const { successDelta, runtimeDelta, creditsDelta, weekCreditsPerDay } = computeDeltas(
+  const { successDelta, runtimeDelta, creditsPerRunDelta, weekCreditsPerRun } = computeDeltas(
     wf.week,
     wf.month,
-    wf.allBranchCredits,
   );
 
   const successSeverity: MetricSeverity = wf.week.successRate < LOW_SUCCESS_RATE ? 'error' : null;
@@ -96,8 +89,8 @@ export function computeWorkflowAnalysis(wf: WorkflowMetrics): WorkflowAnalysis {
   } else if (runtimeDelta > THRESHOLD_PCT) {
     runtimeDeltaSeverity = 'warning';
   }
-  const creditsDeltaSeverity: MetricSeverity =
-    creditsDelta != null && creditsDelta > THRESHOLD_PCT ? 'warning' : null;
+  const creditsPerRunDeltaSeverity: MetricSeverity =
+    creditsPerRunDelta != null && creditsPerRunDelta > THRESHOLD_PCT ? 'warning' : null;
 
   let severity: MetricSeverity = null;
   if (
@@ -106,7 +99,7 @@ export function computeWorkflowAnalysis(wf: WorkflowMetrics): WorkflowAnalysis {
     runtimeDeltaSeverity === 'error'
   ) {
     severity = 'error';
-  } else if (runtimeDeltaSeverity === 'warning' || creditsDeltaSeverity === 'warning') {
+  } else if (runtimeDeltaSeverity === 'warning' || creditsPerRunDeltaSeverity === 'warning') {
     severity = 'warning';
   }
 
@@ -119,9 +112,9 @@ export function computeWorkflowAnalysis(wf: WorkflowMetrics): WorkflowAnalysis {
     runtimeSecs: wf.week.avgSuccessDurationSecs,
     runtimeDelta,
     runtimeDeltaSeverity,
-    creditsPerDay: weekCreditsPerDay,
-    creditsDelta,
-    creditsDeltaSeverity,
+    creditsPerRun: weekCreditsPerRun,
+    creditsPerRunDelta,
+    creditsPerRunDeltaSeverity,
   };
 }
 
@@ -238,22 +231,22 @@ export default function CiWorkflowCard({ slug, workflow }: CiWorkflowCardProps) 
             deltaSeverity={analysis.runtimeDeltaSeverity}
             invert
           />
-          {analysis.creditsDelta != null && analysis.creditsPerDay != null ? (
+          {analysis.creditsPerRunDelta != null && analysis.creditsPerRun != null ? (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
               <MetricRow
-                label="Credits/day"
-                value={Math.round(analysis.creditsPerDay).toLocaleString()}
+                label="Credits/run"
+                value={Math.round(analysis.creditsPerRun).toLocaleString()}
                 valueSeverity={null}
-                valueTooltip={`Credits/day: ${Math.round(analysis.creditsPerDay).toLocaleString()}`}
-                delta={analysis.creditsDelta}
-                deltaSeverity={analysis.creditsDeltaSeverity}
+                valueTooltip={`Credits/run (master): ${Math.round(analysis.creditsPerRun).toLocaleString()}`}
+                delta={analysis.creditsPerRunDelta}
+                deltaSeverity={analysis.creditsPerRunDeltaSeverity}
                 invert
               />
             </Box>
           ) : (
             <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
               <Typography variant="body2" color="text.secondary" sx={{ minWidth: 100 }}>
-                Credits/day
+                Credits/run
               </Typography>
               <Typography variant="body2" color="text.disabled" sx={{ fontStyle: 'italic' }}>
                 Insufficient data


### PR DESCRIPTION
The per-workflow CI analytics card showed a "Credits/day" metric (all-branches credits ÷ a fixed day count). Credits/day on its own isn't very actionable, and the all-branches credit totals are already conveyed by the Credits Usage pie chart below the cards.

Replace it with a "Credits/run" metric scoped to the master branch: total master credits ÷ total master runs, for the 7d and 30d windows, with a delta between them. Severity and "Insufficient data" handling carry over from the old metric.

Display-only change in `CiSummaryTable.tsx`. The snapshot JSON structure is unchanged — the metric is derived from `totalCredits`/`totalRuns` already present on every snapshot, so it works for existing snapshots with no regeneration. `allBranchCredits` is still collected and still feeds the pie chart.

example of this week's [report](https://code-infra-dashboard-pr-1489.onrender.com/ci-analytics?source=https%3A%2F%2Fraw.githubusercontent.com%2Fmui%2Fmui-public%2Fci-data%2Fci-reports%2F2026-05-18T07-30-18Z.json) ([original](https://code-infra-dashboard.onrender.com/ci-analytics?source=https%3A%2F%2Fraw.githubusercontent.com%2Fmui%2Fmui-public%2Fci-data%2Fci-reports%2F2026-05-18T07-30-18Z.json))


Why credits/run and not credits/day: The latter is influenced by the amount of runs, it fluctuates depending on activity in the repo. We're interested in this in the global picture, as in "which repo uses the most credits". But as a metric to track across the weeks it's not interesting, we want something that can be influenced by improving the workflows themselves, which is credits/run