### PR TITLE
[code-infra] Split PR comment table into sections

### DIFF
--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -114,6 +114,109 @@ describe('buildBenchmarkMarkdownReport', () => {
     expect(markdown).toContain('🔺+2');
   });
 
+  it('splits regressions and improvements into separate sections', () => {
+    const report = compareBenchmarkReports(
+      makeReport({ Slow: 150, Fast: 50, Stable: 102 }),
+      makeReport({ Slow: 100, Fast: 100, Stable: 100 }),
+    );
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).toContain('#### 🔺 Regressions');
+    expect(markdown).toContain('#### ▼ Improvements');
+    // No-change entries only surface via the footer/details, never as rows.
+    expect(markdown).not.toContain('| Stable |');
+    expect(markdown).toContain('within noise');
+
+    const regressionIndex = markdown.indexOf('#### 🔺 Regressions');
+    const improvementIndex = markdown.indexOf('#### ▼ Improvements');
+    expect(regressionIndex).toBeLessThan(improvementIndex);
+    expect(markdown.indexOf('Slow')).toBeLessThan(improvementIndex);
+    expect(markdown.indexOf('Fast')).toBeGreaterThan(improvementIndex);
+  });
+
+  it('omits the regressions section when every change is an improvement', () => {
+    const report = compareBenchmarkReports(makeReport({ Fast: 50 }), makeReport({ Fast: 100 }));
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).not.toContain('#### 🔺 Regressions');
+    expect(markdown).toContain('#### ▼ Improvements');
+    expect(markdown).toContain('Fast');
+  });
+
+  it('places removed tests in the added & removed section', () => {
+    const report = compareBenchmarkReports(makeReport({}), makeReport({ Button: 100 }));
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).toContain('#### ➕ Added & removed');
+    expect(markdown).not.toContain('#### 🔺 Regressions');
+    const sectionIndex = markdown.indexOf('#### ➕ Added & removed');
+    expect(markdown.indexOf('~~Button~~')).toBeGreaterThan(sectionIndex);
+  });
+
+  it('lists added and removed tests together in one section', () => {
+    const report = compareBenchmarkReports(
+      makeReport({ Existing: 100, Fresh: 80 }),
+      makeReport({ Existing: 100, Gone: 100 }),
+    );
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).toContain('#### ➕ Added & removed');
+    const sectionIndex = markdown.indexOf('#### ➕ Added & removed');
+    expect(markdown.indexOf('Fresh')).toBeGreaterThan(sectionIndex);
+    expect(markdown.indexOf('~~Gone~~')).toBeGreaterThan(sectionIndex);
+    // Existing test is unchanged → no row, only the within-noise footer.
+    expect(markdown).not.toContain('| Existing |');
+  });
+
+  it('renders the exact markdown for a report exercising every mutation', () => {
+    // One entry per mutation the comment can show:
+    // - Slower: duration regression
+    // - Faster: duration improvement
+    // - Rerendered: within-noise duration but render-count regression
+    // - Stable: within noise → no row, only the footer
+    // - Fresh: added (no baseline)
+    // - Gone: removed (no current value)
+    const current = makeReportFromConfig({
+      Slower: { duration: 150, renders: 1 },
+      Faster: { duration: 50, renders: 1 },
+      Rerendered: { duration: 102, renders: 3 },
+      Stable: { duration: 102, renders: 1 },
+      Fresh: { duration: 80, renders: 1 },
+    });
+    const base = makeReportFromConfig({
+      Slower: { duration: 100, renders: 1 },
+      Faster: { duration: 100, renders: 1 },
+      Rerendered: { duration: 100, renders: 1 },
+      Stable: { duration: 100, renders: 1 },
+      Gone: { duration: 100, renders: 1 },
+    });
+    const report = compareBenchmarkReports(current, base);
+    const markdown = buildBenchmarkMarkdownReport(report, {
+      reportUrl: 'https://example.com/details',
+    });
+    expect(markdown).toMatchInlineSnapshot(`
+      "**Total duration:** 484.00 ms -16.00 ms<sup>(-3.2%)</sup> | **Renders:** 7 <sup>(🔺+2)</sup>
+
+      #### 🔺 Regressions
+
+      | Test | Duration | Renders |
+      |:-----|----------:|--------:|
+      | Rerendered | 102.00 ms +2.00 ms<sup>(+2.0%)</sup> | 3 <sup>(🔺+2)</sup> |
+      | Slower | 150.00 ms 🔺+50.00 ms<sup>(+50.0%)</sup> | 1 <sup>(+0)</sup> |
+
+      #### ▼ Improvements
+
+      | Test | Duration | Renders |
+      |:-----|----------:|--------:|
+      | Faster | 50.00 ms ▼-50.00 ms<sup>(-50.0%)</sup> | 1 <sup>(+0)</sup> |
+
+      #### ➕ Added & removed
+
+      | Test | Duration | Renders |
+      |:-----|----------:|--------:|
+      | ~~Gone~~ (removed) | — | — |
+      | Fresh | 80.00 ms | 1 |
+
+      *1 test within noise — [details](https://example.com/details)*"
+    `);
+  });
+
   it('does not emit the "No significant changes" branch when only render counts change', () => {
     const currentReport = makeReportFromConfig({
       Button: { duration: 105, renders: 2 },

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
@@ -1,5 +1,9 @@
 import { formatMs, formatDiffMs, percentFormatter } from '@/utils/formatters';
-import type { BenchmarkComparisonReport, DiffValue } from './compareBenchmarkReports';
+import type {
+  BenchmarkComparisonReport,
+  ComparisonItem,
+  DiffValue,
+} from './compareBenchmarkReports';
 
 export interface BuildMarkdownReportOptions {
   maxRows?: number;
@@ -10,6 +14,33 @@ const SEVERITY_PREFIX: Record<string, string> = {
   error: '🔺',
   success: '▼',
 };
+
+const TABLE_HEADER = ['| Test | Duration | Renders |', '|:-----|----------:|--------:|'];
+
+const REMOVED_CELL = '—';
+
+type EntryClass = 'regression' | 'improvement' | 'addedRemoved' | 'neutral';
+
+/**
+ * Buckets an entry into one of the report sections. Tests with no current
+ * value (removed) or no baseline (added) have no diff to compare, so they
+ * share an "added & removed" section; otherwise the worst severity across
+ * duration and render count decides. Everything else is "no change" and only
+ * surfaces via the details link.
+ */
+function classifyEntry(entry: ComparisonItem): EntryClass {
+  if (entry.duration.current === null || entry.duration.base === null) {
+    return 'addedRemoved';
+  }
+  const severities = [entry.duration.severity, entry.renderCount?.severity ?? 'neutral'];
+  if (severities.includes('error')) {
+    return 'regression';
+  }
+  if (severities.includes('success')) {
+    return 'improvement';
+  }
+  return 'neutral';
+}
 
 function formatDiff(diff: DiffValue, unit: 'ms' | 'count'): string {
   const prefix = SEVERITY_PREFIX[diff.severity] ?? '';
@@ -51,50 +82,87 @@ export function buildBenchmarkMarkdownReport(
     lines.push('');
   }
 
-  const significant = report.entries.filter(
-    (entry) =>
-      entry.duration.severity !== 'neutral' ||
-      (entry.renderCount?.severity ?? 'neutral') !== 'neutral' ||
-      entry.duration.current === null ||
-      entry.duration.base === null,
-  );
-
   const detailsLink = reportUrl ? `[details](${reportUrl})` : '';
   const suffix = detailsLink ? ` — ${detailsLink}` : '';
 
-  if (report.hasBase && significant.length === 0) {
-    lines.push(`*No significant changes${suffix}*`);
-    return lines.join('\n');
-  }
-
-  // Table header
-  lines.push('| Test | Duration | Renders |');
-  lines.push('|:-----|----------:|--------:|');
-
-  const visibleEntries = significant.slice(0, maxRows);
-  const hiddenSignificant = significant.length - visibleEntries.length;
-  const hiddenWithinNoise = report.entries.length - significant.length;
-
-  for (const entry of visibleEntries) {
-    const renderCount = entry.renders.filter((r) => !r.removed).length;
+  const renderRow = (entry: ComparisonItem): string => {
+    const renderCount = entry.renders.filter((render) => !render.removed).length;
 
     if (entry.duration.current === null) {
-      lines.push(`| ~~${entry.name}~~ (removed) | \u2014 | \u2014 |`);
-      continue;
+      return `| ~~${entry.name}~~ (removed) | ${REMOVED_CELL} | ${REMOVED_CELL} |`;
     }
 
     const duration = `${formatMs(entry.duration.current)}${report.hasBase ? formatDiff(entry.duration, 'ms') : ''}`;
     const renders = `${renderCount}${report.hasBase && entry.renderCount ? formatDiff(entry.renderCount, 'count') : ''}`;
-    lines.push(`| ${entry.name} | ${duration} | ${renders} |`);
+    return `| ${entry.name} | ${duration} | ${renders} |`;
+  };
+
+  // Without a baseline there is nothing to compare against — emit a single
+  // plain table of every entry, no sections and no diff columns.
+  if (!report.hasBase) {
+    lines.push(...TABLE_HEADER);
+    const visibleEntries = report.entries.slice(0, maxRows);
+    for (const entry of visibleEntries) {
+      lines.push(renderRow(entry));
+    }
+    const hidden = report.entries.length - visibleEntries.length;
+    lines.push('');
+    if (hidden > 0) {
+      lines.push(`*…and ${hidden} more${suffix}*`);
+    } else if (detailsLink) {
+      lines.push(detailsLink);
+    }
+    return lines.join('\n');
   }
 
-  lines.push('');
+  const regressions = report.entries.filter((entry) => classifyEntry(entry) === 'regression');
+  const improvements = report.entries.filter((entry) => classifyEntry(entry) === 'improvement');
+  const addedRemoved = report.entries.filter((entry) => classifyEntry(entry) === 'addedRemoved');
+  const significant = [...regressions, ...improvements, ...addedRemoved];
+  const noChange = report.entries.length - significant.length;
+
+  if (significant.length === 0) {
+    lines.push(`*No significant changes${suffix}*`);
+    return lines.join('\n');
+  }
+
+  // Shared row budget across both sections — regressions first since they
+  // matter most, improvements fill whatever budget is left.
+  const visibleEntries = significant.slice(0, maxRows);
+  const hiddenSignificant = significant.length - visibleEntries.length;
+  const visibleRegressions = visibleEntries.filter(
+    (entry) => classifyEntry(entry) === 'regression',
+  );
+  const visibleImprovements = visibleEntries.filter(
+    (entry) => classifyEntry(entry) === 'improvement',
+  );
+  const visibleAddedRemoved = visibleEntries.filter(
+    (entry) => classifyEntry(entry) === 'addedRemoved',
+  );
+
+  const renderSection = (title: string, entries: ComparisonItem[]) => {
+    if (entries.length === 0) {
+      return;
+    }
+    lines.push(`#### ${title}`);
+    lines.push('');
+    lines.push(...TABLE_HEADER);
+    for (const entry of entries) {
+      lines.push(renderRow(entry));
+    }
+    lines.push('');
+  };
+
+  renderSection('🔺 Regressions', visibleRegressions);
+  renderSection('▼ Improvements', visibleImprovements);
+  renderSection('➕ Added & removed', visibleAddedRemoved);
+
   if (hiddenSignificant > 0) {
-    const noiseSuffix = hiddenWithinNoise > 0 ? ` (+${hiddenWithinNoise} within noise)` : '';
+    const noiseSuffix = noChange > 0 ? ` (+${noChange} within noise)` : '';
     lines.push(`*…and ${hiddenSignificant} more${noiseSuffix}${suffix}*`);
-  } else if (hiddenWithinNoise > 0) {
-    const label = hiddenWithinNoise === 1 ? 'test' : 'tests';
-    lines.push(`*${hiddenWithinNoise} ${label} within noise${suffix}*`);
+  } else if (noChange > 0) {
+    const label = noChange === 1 ? 'test' : 'tests';
+    lines.push(`*${noChange} ${label} within noise${suffix}*`);
   } else if (detailsLink) {
     lines.push(detailsLink);
   }


### PR DESCRIPTION
## Summary

Reworks the performance benchmark PR comment table into clearly separated sections instead of one flat list.

Sections (rendered in this order, each omitted when empty):

- `#### 🔺 Regressions` — duration or render-count got worse
- `#### ▼ Improvements` — duration or render-count got better
- `#### ➕ Added & removed` — new tests (no baseline) and removed tests (`~~name~~ (removed)`), no diff columns
- No-change / within-noise entries get **no row** — they collapse into the footer count + `[details]` link

Regressions take priority in the shared `maxRows` budget so a wall of new/improved tests can't bury a regression. The no-baseline path (single plain table, no diffs) is unchanged.

## Test plan

- `pnpm test --run buildMarkdownReport compareBenchmarkReports` — 32 passing
- Added an inline-snapshot test pinning the **exact** comment markdown for a report exercising every mutation: duration regression, duration improvement, render-count regression, added, removed, within-noise, totals line, details link
- `pnpm typescript` + `pnpm eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)