### PR TITLE
[code-infra] Add MUI_VERSION to build-env env types

### DIFF
--- a/packages/code-infra/src/build-env.d.ts
+++ b/packages/code-infra/src/build-env.d.ts
@@ -3,6 +3,7 @@ export {};
 declare global {
   interface Env {
     NODE_ENV?: 'production' | undefined;
+    MUI_VERSION?: string;
   }
 
   interface Process {


### PR DESCRIPTION
Adds `MUI_VERSION?: string` to the `Env` interface in `build-env.d.ts`, so the existing `@mui/internal-code-infra/build-env` export covers everything consumer repos previously needed from a local `mui-env.d.ts`.

This lets repos like mui-x delete their hand-maintained `mui-env.d.ts` and replace `types: ['../../mui-env.d.ts']` with `types: ['@mui/internal-code-infra/build-env']` in their tsconfigs.

Note: `build-env` keeps its intentional `NODE_ENV?: 'production' | undefined` narrowing (from #1170) rather than mui-x's looser `NODE_ENV?: string`. Consumers comparing `NODE_ENV` against `'development'`/`'test'` may need to adjust when migrating.