### PR TITLE
Add material-ui nightly-cron workflow to CI report

### DIFF
--- a/apps/code-infra-dashboard/src/lib/collectCiMetrics.ts
+++ b/apps/code-infra-dashboard/src/lib/collectCiMetrics.ts
@@ -13,7 +13,7 @@ const PROJECTS: ProjectConfig[] = [
   { slug: 'gh/mui/base-ui', displayName: 'Base UI', workflows: ['pipeline', 'react-18'] },
   { slug: 'gh/mui/base-ui-charts', displayName: 'Base UI Charts', workflows: ['pipeline'] },
   { slug: 'gh/mui/base-ui-mosaic', displayName: 'Base UI Mosaic', workflows: ['pipeline'] },
-  { slug: 'gh/mui/material-ui', displayName: 'MUI Core', workflows: ['pipeline'] },
+  { slug: 'gh/mui/material-ui', displayName: 'MUI Core', workflows: ['pipeline', 'nightly-cron'] },
   { slug: 'gh/mui/mui-public', displayName: 'Code infra', workflows: ['pipeline'] },
   { slug: 'gh/mui/mui-private', displayName: 'MUI Private', workflows: ['pipeline'] },
 ];


### PR DESCRIPTION
## Summary

- Track the `nightly-cron` workflow for `gh/mui/material-ui` in the CI analytics report, alongside the existing `pipeline` workflow.
- Depends on mui/material-ui#48556 which introduces the `nightly-cron` workflow.