### PR TITLE
[docs] Simplify Claude instructions

### DIFF
--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -1,3 +1,5 @@
 import { createBaseConfig } from '@mui/internal-code-infra/markdownlint';
 
-export default createBaseConfig();
+export default createBaseConfig({
+  ignores: ['/CLAUDE.md'],
+});

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# Claude Instructions
-
-See @AGENTS.md for instructions.
+@AGENTS.md


### PR DESCRIPTION
Use a direct CLAUDE.md import because Claude Code documents @path imports as expanding referenced files into memory context: https://docs.anthropic.com/en/docs/claude-code/memory#claudemd-imports