### PR TITLE
[code-infra] Refresh CI Node pins to 22.22.3

### DIFF
--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -208,7 +208,7 @@ executors:
     parameters:
       node-version:
         type: string
-        default: '22.22'
+        default: '22.22.3'
     docker:
       - image: cimg/node:<< parameters.node-version >>
     environment:

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -208,7 +208,7 @@ executors:
     parameters:
       node-version:
         type: string
-        default: '22.21.1'
+        default: '22.22'
     docker:
       - image: cimg/node:<< parameters.node-version >>
     environment:

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version: '22.22'
+        node-version: '22.22.3'
         # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        node-version: 22.19.0
+        node-version: '22.22'
         # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.18.0'
+          node-version: '22.22'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
       - name: Cache Next.js build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22.22'
+          node-version: '22.22.3'
           cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
       - run: pnpm install
       - name: Cache Next.js build

--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -13,7 +13,7 @@
   targetPort = 3000
 
 [build.environment]
-  NODE_VERSION = "22.22"
+  NODE_VERSION = "22.22.3"
 
 [functions]
   directory = "functions"

--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -13,7 +13,7 @@
   targetPort = 3000
 
 [build.environment]
-  NODE_VERSION = "22.18"
+  NODE_VERSION = "22.22"
 
 [functions]
   directory = "functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "docs/export/"
 command = "pnpm docs:lib && pnpm docs:build"
 
 [build.environment]
-NODE_VERSION = "22.22"
+NODE_VERSION = "22.22.3"
 PNPM_FLAGS = "--frozen-lockfile"
 
 [[plugins]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@ publish = "docs/export/"
 command = "pnpm docs:lib && pnpm docs:build"
 
 [build.environment]
-NODE_VERSION = "22.18"
+NODE_VERSION = "22.22"
 PNPM_FLAGS = "--frozen-lockfile"
 
 [[plugins]]

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -125,18 +125,18 @@
       "groupName": "node",
       "description": "Restricts Node.js version bumps in Github Actions workflows.",
       "extends": ["group:nodeJs"],
-      "allowedVersions": "<=22.22"
+      "allowedVersions": "22"
     },
     {
       "groupName": "node",
       "matchDepTypes": ["uses-with"],
       "matchDepNames": ["node"],
-      "allowedVersions": "<=22.22"
+      "allowedVersions": "22"
     },
     {
       "groupName": "node",
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "<=22.22"
+      "allowedVersions": "22"
     },
     {
       "matchDepTypes": ["engines"],

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -125,18 +125,18 @@
       "groupName": "node",
       "description": "Restricts Node.js version bumps in Github Actions workflows.",
       "extends": ["group:nodeJs"],
-      "allowedVersions": "<=22.18"
+      "allowedVersions": "<=22.22"
     },
     {
       "groupName": "node",
       "matchDepTypes": ["uses-with"],
       "matchDepNames": ["node"],
-      "allowedVersions": "<=22.18"
+      "allowedVersions": "<=22.22"
     },
     {
       "groupName": "node",
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "<=22.18"
+      "allowedVersions": "<=22.22"
     },
     {
       "matchDepTypes": ["engines"],

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -62,6 +62,26 @@
       "depNameTemplate": "vale-cli/vale",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "description": "Custom manager for Node.js version in netlify.toml NODE_VERSION",
+      "customType": "regex",
+      "fileMatch": ["(^|/)netlify\\.toml$"],
+      "matchStrings": ["NODE_VERSION\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    },
+    {
+      "description": "Custom manager for Node.js version in code-infra mui-node executor default",
+      "customType": "regex",
+      "fileMatch": ["(^|/)\\.circleci/orbs/code-infra\\.yml$"],
+      "matchStrings": [
+        "node-version:\\s*\\n\\s*type:\\s*string\\s*\\n\\s*default:\\s*'(?<currentValue>[^']+)'"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Bumps all CI/build/deploy Node version pins to the current latest v22 LTS patch (`22.22.3`).

The original trigger was a failing `pnpm install` step in downstream repos: the freshly released `mute-stream@4.0.0` (transitive of `@mui/internal-code-infra` via `@inquirer/confirm`) declares `engines.node: "^22.22.2 || ^24.15.0 || >=26.0.0"`, but the `mui-node` orb defaulted to `22.21.1`. Reproduced on `mui/mui-x` master in the `test-react-18` CircleCI workflow ([example failing job](https://app.circleci.com/pipelines/github/mui/mui-x/130959/workflows/10593204-7651-4d49-ab17-ca5d7d4e5233/jobs/841359)):

    ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
    Your Node version is incompatible with "mute-stream@4.0.0".
    Expected version: ^22.22.2 || ^24.15.0 || >=26.0.0
    Got: v22.21.1

## What changes

| File | Before | After |
| --- | --- | --- |
| `.circleci/orbs/code-infra.yml` | `'22.21.1'` | `'22.22.3'` |
| `.github/actions/publish-prepare/action.yml` | `22.19.0` | `'22.22.3'` |
| `.github/workflows/ci.yml` | `'22.18.0'` | `'22.22.3'` |
| `apps/code-infra-dashboard/netlify.toml` | `"22.18"` | `"22.22.3"` |
| `netlify.toml` | `"22.18"` | `"22.22.3"` |
| `renovate/default.json` (x3 caps) | `"<=22.18"` | `"22"` |

Adopts [@Janpot's full proposal](https://github.com/mui/mui-public/pull/1501#pullrequestreview-4362717785):

- **Action pins exact** (`22.22.3`): every CI run is on a single deterministic Node version, so a freshly published patch can't show up in CI before the team has seen it.
- **Renovate cap major-only** (`22`): communicates which Node line we support without micro-managing each minor/patch bump.

## Renovate custom managers

Two new `customManagers` regex entries so Renovate actually picks up bumps on the files where it has no built-in coverage:

- `netlify.toml` (`NODE_VERSION = "..."`): covers the root `netlify.toml`, `apps/code-infra-dashboard/netlify.toml`, and downstream consumers like `mui/mui-x` via the shared preset.
- `.circleci/orbs/code-infra.yml` (`default:` under the `node-version` parameter of the `mui-node` executor).

Both use the `node-version` datasource with `node` versioning, so they respect the `allowedVersions: "22"` cap from the node group rules. They match either format (`22.22` or `22.22.3`), so they keep working regardless of how tight the pin is.

## Intentionally left alone

- `render.yaml` already uses `NODE_VERSION = 22` (looser than `22.22.3`).
- `package.json` `engines.node` (`>=22.18.0`) and `AGENTS.md` (`22.18.0+`) describe the supported floor, not the CI version, and are still satisfied by `22.22.3`.
- `@types/node` package versions are left to Renovate now that the cap is bumped.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui/mui-public/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).