### PR TITLE
[code-infra] Pause Renovate updates on PRs labeled "on hold"

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -17,6 +17,7 @@
   "dependencyDashboard": true,
   "rebaseWhen": "conflicted",
   "labels": ["dependencies"],
+  "stopUpdatingLabel": "on hold",
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary

Adds Renovate's [`stopUpdatingLabel`](https://docs.renovatebot.com/configuration-options/#stopupdatinglabel) option to the shared preset. When a Renovate PR receives the `on hold` label, Renovate stops pushing further commits to its branch — no rebases, no version bumps, no lockfile maintenance. The PR stays open as a reminder; CI stops running on it because no new commits arrive. Removing the label resumes normal updates.

## Why

Some Renovate PRs are deliberately blocked (waiting on an upstream fix, a peer-dep bump, a deprecation timeline, etc.) but we want to keep them around as visible reminders. Today Renovate keeps rebasing them every week, triggering full CI runs on PRs nobody intends to merge yet.

### Examples

- https://github.com/mui/mui-x/pull/22405
- https://github.com/mui/mui-x/pull/22400

## Scope

Lives in the shared preset (`renovate/default.json`), so every MUI repo extending `github>mui/mui-public//renovate/default` inherits the behavior. Repos without an `on hold` label are unaffected — the option is a no-op until the label exists and is applied to a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)