### PR TITLE
[code-infra] netlify-ignore: diff against origin/master merge-base on PRs

### DIFF
--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -5,7 +5,7 @@
   command = "echo 'building...'"
 
   # Decide when to build Netlify
-  ignore = "cd ../../ && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml"
+  ignore = """cd ../../ && if [ "$BRANCH" = "master" ]; then git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; else git fetch origin master --depth=500 -q && git diff --quiet origin/master...$COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; fi"""
 
 [dev]
   framework = "#custom"

--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -5,7 +5,7 @@
   command = "echo 'building...'"
 
   # Decide when to build Netlify
-  ignore = """cd ../../ && if [ "$BRANCH" = "master" ]; then git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; else git fetch origin master --depth=500 -q && git diff --quiet origin/master...$COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; fi"""
+  ignore = """cd ../../ && if [ "$BRANCH" = "master" ]; then git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; else git fetch origin master --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; fi"""
 
 [dev]
   framework = "#custom"

--- a/apps/code-infra-dashboard/netlify.toml
+++ b/apps/code-infra-dashboard/netlify.toml
@@ -5,7 +5,7 @@
   command = "echo 'building...'"
 
   # Decide when to build Netlify
-  ignore = """cd ../../ && if [ "$BRANCH" = "master" ]; then git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; else git fetch origin master --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml; fi"""
+  ignore = """cd ../../ && [ "$CONTEXT" != "production" ] && git fetch origin master --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- apps/code-infra-dashboard packages/benchmark pnpm-lock.yaml"""
 
 [dev]
   framework = "#custom"

--- a/packages/code-infra/src/cli/cmdNetlifyIgnore.mjs
+++ b/packages/code-infra/src/cli/cmdNetlifyIgnore.mjs
@@ -32,7 +32,7 @@ function generateIgnoreCommand(paths, packagePath, workspaceRoot) {
   const relFromBase = `${toPosixPath(path.relative(packagePath, workspaceRoot))}/`;
   const pathsStr = paths.join(' ');
   const masterCheck = `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ${pathsStr}`;
-  const prCheck = `git fetch origin master --depth=500 -q && git diff --quiet origin/master...$COMMIT_REF -- ${pathsStr}`;
+  const prCheck = `git fetch origin master --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- ${pathsStr}`;
   return `  ignore = """cd ${relFromBase} && if [ "$BRANCH" = "master" ]; then ${masterCheck}; else ${prCheck}; fi"""`;
 }
 

--- a/packages/code-infra/src/cli/cmdNetlifyIgnore.mjs
+++ b/packages/code-infra/src/cli/cmdNetlifyIgnore.mjs
@@ -15,7 +15,14 @@ import { toPosixPath } from '../utils/path.mjs';
 import { getTransitiveDependencies, getWorkspacePackages } from '../utils/pnpm.mjs';
 
 /**
- * Generate the ignore command string for netlify.toml
+ * Generate the ignore command string for netlify.toml.
+ *
+ * On master we keep the incremental check (build only when the watched paths
+ * changed since the last cached build). On PRs we diff against the merge-base
+ * with origin/master so a rebase whose head commit doesn't touch the watched
+ * paths still rebuilds when the PR as a whole introduces changes to them —
+ * otherwise downstream plugins (e.g. e2e triggers) silently never run.
+ *
  * @param {string[]} paths - Array of paths to include in the ignore command
  * @param {string} packagePath - Absolute path to the package directory
  * @param {string} workspaceRoot - Absolute path to the workspace root
@@ -24,7 +31,9 @@ import { getTransitiveDependencies, getWorkspacePackages } from '../utils/pnpm.m
 function generateIgnoreCommand(paths, packagePath, workspaceRoot) {
   const relFromBase = `${toPosixPath(path.relative(packagePath, workspaceRoot))}/`;
   const pathsStr = paths.join(' ');
-  return `  ignore = "cd ${relFromBase} && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ${pathsStr}"`;
+  const masterCheck = `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ${pathsStr}`;
+  const prCheck = `git fetch origin master --depth=500 -q && git diff --quiet origin/master...$COMMIT_REF -- ${pathsStr}`;
+  return `  ignore = """cd ${relFromBase} && if [ "$BRANCH" = "master" ]; then ${masterCheck}; else ${prCheck}; fi"""`;
 }
 
 /**

--- a/packages/code-infra/src/cli/cmdNetlifyIgnore.mjs
+++ b/packages/code-infra/src/cli/cmdNetlifyIgnore.mjs
@@ -6,6 +6,7 @@
  * @typedef {Object} Args
  * @property {string[]} workspaces - List of workspace names to process
  * @property {boolean} [check] - Check mode - error if the generated content differs from current
+ * @property {string} [baseBranch] - Branch to compare PRs against (default: master)
  */
 
 import * as fs from 'node:fs/promises';
@@ -17,23 +18,28 @@ import { getTransitiveDependencies, getWorkspacePackages } from '../utils/pnpm.m
 /**
  * Generate the ignore command string for netlify.toml.
  *
- * On master we keep the incremental check (build only when the watched paths
- * changed since the last cached build). On PRs we diff against the merge-base
- * with origin/master so a rebase whose head commit doesn't touch the watched
- * paths still rebuilds when the PR as a whole introduces changes to them —
- * otherwise downstream plugins (e.g. e2e triggers) silently never run.
+ * Production builds (Netlify's $CONTEXT === "production" — i.e. any branch
+ * configured as the site's production branch, whatever its name) always
+ * build, so downstream plugins (e.g. e2e triggers) run on every commit and
+ * catch regressions in external dependencies even when the commit doesn't
+ * touch the watched paths.
+ *
+ * Every other context (deploy-preview, branch-deploy) diffs against the
+ * merge-base with origin/<baseBranch>. This way a PR rebase whose head
+ * commit doesn't touch the watched paths still rebuilds when the PR as a
+ * whole introduces changes to them — otherwise downstream plugins silently
+ * never run.
  *
  * @param {string[]} paths - Array of paths to include in the ignore command
  * @param {string} packagePath - Absolute path to the package directory
  * @param {string} workspaceRoot - Absolute path to the workspace root
+ * @param {string} baseBranch - Branch to compare PRs against
  * @returns {string} The ignore command string
  */
-function generateIgnoreCommand(paths, packagePath, workspaceRoot) {
+function generateIgnoreCommand(paths, packagePath, workspaceRoot, baseBranch) {
   const relFromBase = `${toPosixPath(path.relative(packagePath, workspaceRoot))}/`;
   const pathsStr = paths.join(' ');
-  const masterCheck = `git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ${pathsStr}`;
-  const prCheck = `git fetch origin master --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- ${pathsStr}`;
-  return `  ignore = """cd ${relFromBase} && if [ "$BRANCH" = "master" ]; then ${masterCheck}; else ${prCheck}; fi"""`;
+  return `  ignore = """cd ${relFromBase} && [ "$CONTEXT" != "production" ] && git fetch origin ${baseBranch} --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- ${pathsStr}"""`;
 }
 
 /**
@@ -103,6 +109,12 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         default: false,
         describe: 'Check if the netlify.toml needs updating without modifying it',
       })
+      .option('base-branch', {
+        type: 'string',
+        default: 'master',
+        describe:
+          "Branch to compare PRs against (the site's production branch on Netlify). Production builds always rebuild regardless of this value.",
+      })
       .example('$0 netlify-ignore @mui/internal-docs-infra', 'Update netlify.toml for a workspace')
       .example(
         '$0 netlify-ignore @mui/internal-docs-infra @mui/internal-code-infra',
@@ -114,7 +126,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       );
   },
   handler: async (argv) => {
-    const { workspaces, check = false } = argv;
+    const { workspaces, check = false, baseBranch = 'master' } = argv;
 
     // Get the workspace root
     const workspaceRoot = await findWorkspaceDir(process.cwd());
@@ -166,7 +178,12 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         const allPaths = [...relativePaths, 'pnpm-lock.yaml'];
 
         // Generate the ignore command for this workspace
-        const newIgnoreCommand = generateIgnoreCommand(allPaths, workspacePath, workspaceRoot);
+        const newIgnoreCommand = generateIgnoreCommand(
+          allPaths,
+          workspacePath,
+          workspaceRoot,
+          baseBranch,
+        );
 
         // Update or check the netlify.toml file
         await updateNetlifyToml(tomlPath, newIgnoreCommand, check);


### PR DESCRIPTION
## Problem

The CLI currently emits an `ignore` of the form:

```sh
cd <relFromBase> && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF <paths>
```

Two failure modes fall out of that:

1. **PR rebases whose head commit doesn't touch the watched paths are silently skipped.** Netlify cache-skips the build, which also skips downstream plugins — including e2e triggers. The PR can end up green by omission.
2. **Commits on the production branch outside the watched paths never re-exercise downstream plugins.** For tests that depend on external services (e.g. the storefront e2e against a live WooCommerce/Stripe backend), we want them to run on every commit as a heartbeat.

We hit this concretely in mui/mui-private#1587, where a rebase commit cache-skipped the build, the e2e didn't run, and a master-side regression slipped through unnoticed.

## Fix

Generate this instead:

```sh
cd <relFromBase> && [ "$CONTEXT" != "production" ] && git fetch origin <baseBranch> --depth=500 -q && git diff --quiet FETCH_HEAD...$COMMIT_REF -- <paths>
```

- **`$CONTEXT != "production"`** — Netlify's `$CONTEXT` env var is `"production"` for whatever branch the site is configured to deploy as production. Using it instead of `$BRANCH = master` means a site whose production branch is `v6` (or `main`, or anything else) Just Works without a code change. Production always rebuilds, so downstream plugins fire on every commit.
- **Merge-base diff on every other context** — `FETCH_HEAD...$COMMIT_REF` compares to the merge-base with the just-fetched base branch, so a PR rebase whose head commit is unrelated still rebuilds when the PR as a whole introduces changes to the watched paths.
- **New `--base-branch` option** (default `master`). Netlify doesn't expose the PR's base branch in env vars, so this has to be configured. Each Netlify site has a single production branch — that's what consumers pass here.

## Notes

- `--depth=500` is a pragmatic shallow-fetch bound for the merge-base. PR branches older than that will fall through to "always build" (`git diff` exits non-zero on missing ref), which is the safe-fail direction.