### PR TITLE
[code-infra] Fix pnpm dlx build-prompt hang in cross-version installs

### DIFF
--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -78,11 +78,17 @@ commands:
                     # `pnpm dlx` installs code-infra into an isolated temp dir
                     # outside the workspace, so it can't see this repo's
                     # pnpm-workspace.yaml and runs with pnpm 11's strict build
-                    # defaults, which hang on an interactive build-approval
-                    # prompt. Disable strict-dep-builds for the temp install;
-                    # code-infra only needs `pnpm info`/`pnpm dedupe`, so
-                    # skipped dependency build scripts are irrelevant.
-                    pnpm dlx --config.strict-dep-builds=false @mui/internal-code-infra@canary set-version-overrides --pkg $args
+                    # defaults. With a cold store it must build transitive deps
+                    # that have install scripts (e.g. sharp, unrs-resolver), and
+                    # because CircleCI runs steps under a TTY it drops into the
+                    # interactive "Choose which packages to build" picker and
+                    # hangs until the idle timeout. `--config.strict-dep-builds=false`
+                    # only downgrades the hard error to a warning; the picker is
+                    # gated on stdin being a TTY, so we also redirect stdin from
+                    # /dev/null to force non-interactive (warn + skip). code-infra
+                    # only needs `pnpm info`/`pnpm dedupe`, so skipped dependency
+                    # build scripts are irrelevant.
+                    pnpm dlx --config.strict-dep-builds=false @mui/internal-code-infra@canary set-version-overrides --pkg $args < /dev/null
                   else
                     pnpm install
                   fi


### PR DESCRIPTION
## Problem

`install-deps` applies non-stable package overrides by shelling out to `pnpm dlx @mui/internal-code-infra@canary set-version-overrides`. `pnpm dlx` installs code-infra into an isolated temp dir that cannot read the consuming repo's `pnpm-workspace.yaml`, so on a cold CI store it has to build code-infra's transitive deps that ship install scripts (e.g. `sharp`, `unrs-resolver`). Under pnpm 11 those unapproved builds, combined with CircleCI running steps under a TTY, drop pnpm into the interactive "Choose which packages to build" picker, which blocks the step until the 10-minute idle timeout kills the job. The `--config.strict-dep-builds=false` added in #1491 only downgrades the hard `ERR_PNPM_IGNORED_BUILDS` error to a warning; it does not suppress the picker.

## Fix

Redirect stdin from `/dev/null` for the `pnpm dlx` call. The picker is gated on stdin being a TTY, so detaching stdin forces pnpm non-interactive: it prints the "Ignored build scripts" warning and continues. code-infra only needs `pnpm info` / `pnpm dedupe` here, so skipping those throwaway temp-dir build scripts is harmless.

## Verification

Reproduced against `@mui/internal-code-infra@canary` with a cold store under a PTY (simulating CircleCI's TTY):

- `--config.strict-dep-builds=false` alone, stdin = TTY: hangs on the picker (reproduced on pnpm 11.1.0, 11.1.2 and 11.5.0).
- stdout piped through `cat`, stdin still TTY: still hangs (so the picker is not stdout-gated).
- stdin from `/dev/null`, stdout = TTY: completes, warns, skips, continues.

Surfaced by mui/mui-x#22403 (pnpm 11 bump), whose React 18 / MUI 6 jobs hang on this.

Generated with [Claude Code](https://claude.com/claude-code)