### PR TITLE
[infra] Bump self-referential workflow pins to master

### DIFF
--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -45,6 +45,6 @@ jobs:
       - run: pnpm install
       - run: pnpm release:build
       - name: Publish packages to pkg.pr.new
-        uses: mui/mui-public/.github/actions/ci-publish@ee9f4577f6b5a1f15331f9c5aec332a514e2cb26 # master
+        uses: mui/mui-public/.github/actions/ci-publish@8097d2430a2237044d47b3cfca7c35a6f90c9f48 # master
         with:
           pr-comment: ${{ inputs.pr-comment }}

--- a/.github/workflows/issue-status-label-handler.yml
+++ b/.github/workflows/issue-status-label-handler.yml
@@ -18,4 +18,4 @@ jobs:
       issues: write
       actions: write
     name: Handle status labels
-    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@ee9f4577f6b5a1f15331f9c5aec332a514e2cb26 # master
+    uses: mui/mui-public/.github/workflows/issues_status-label-handler.yml@8097d2430a2237044d47b3cfca7c35a6f90c9f48 # master

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -16,4 +16,4 @@ jobs:
       issues: write
       pull-requests: write
     name: Handle stale issues and PRs
-    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@ee9f4577f6b5a1f15331f9c5aec332a514e2cb26 # master
+    uses: mui/mui-public/.github/workflows/general_handle-stale-issues-and-prs.yml@8097d2430a2237044d47b3cfca7c35a6f90c9f48 # master


### PR DESCRIPTION
## Problem

The `pkg.pr.new` publish step on consumer CIs (e.g. mui-x) fails with:

```
code-infra list-workspaces ... Invalid values:
  Argument: output, Given: "publish-dir", Choices: "json", "path", "name"
Publishing failed (400): {"message":"No packages"}
```

### Root cause — version skew

`ci-base.yml` pinned the `ci-publish` action at `ee9f4577`, where the step runs:

```sh
pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=publish-dir) ...
```

The `publish-dir` output choice was removed from `list-workspaces` in #1354 (revert of the pkg.pr.new#389 workaround). Since the action installs `@mui/internal-code-infra@canary` (floating latest), `--output=publish-dir` now errors → `$(...)` is empty → `pkg-pr-new` gets no packages → `400 No packages`.

The action source was reverted to `--output=path`, but the self-referential `# master` SHA pins were never bumped, so consumers kept resolving the stale action.

## Fix

Bump all `mui/mui-public/...@<sha> # master` pins from `ee9f4577` → `8097d2430` (current master, which uses `--output=path`):

- `.github/workflows/ci-base.yml` (`ci-publish` action — the actual break)
- `.github/workflows/issue-status-label-handler.yml`
- `.github/workflows/no-response.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)