### PR TITLE
[docs-infra] Fix Live Editing Bugs

### DIFF
--- a/docs/app/docs-infra/components/code-highlighter/types.md
+++ b/docs/app/docs-infra/components/code-highlighter/types.md
@@ -832,7 +832,7 @@ were deleted. Keyed by the line they collapsed onto; each entry records
 the original offset from the edit line so the collapse can be reversed.
 
 ```typescript
-type CollapseMap = { [key: number]: { offset: number; comments: string[] }[] };
+type CollapseMap = { [key: number]: { offset: number; comments: string[]; boundary?: true }[] };
 ```
 
 ### Components

--- a/docs/app/docs-infra/hooks/page.mdx
+++ b/docs/app/docs-infra/hooks/page.mdx
@@ -304,6 +304,7 @@ The `useCodeWindow` hook layers code-block-specific choreography on top of [`use
     - Collapsible Code Block
     - Collapse to Empty
     - Collapsible Code Block with Transform
+    - Collapsible Editor
     - Collapsible Demo
     - `@focus` with Multiple Regions
     - Indent Shifting

--- a/docs/app/docs-infra/hooks/page.mdx
+++ b/docs/app/docs-infra/hooks/page.mdx
@@ -298,6 +298,8 @@ The `useCodeWindow` hook layers code-block-specific choreography on top of [`use
     - `anchorSelector`
     - `collapsibleProbeSelector`
   - CSS contract
+  - Animating the frames
+    - Staggering the expand
   - Examples
     - Collapsible Code Block
     - Collapse to Empty

--- a/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.module.css
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.module.css
@@ -87,6 +87,16 @@ pre.codeBlock {
   margin: 0;
   --code-padding-bottom: 6px;
   --scrollbar-gutter-size: 15px;
+  /* Expand stagger: when the focused region opens, frames directly bordering it
+     grow at full speed while frames farther out wait out the first third — the
+     bordering frames push them off-screen — then cover their height in the
+     remaining two thirds. `--frame-expand-duration` is the single knob; the
+     delayed frames still finish on time (delay + stagger duration = total). */
+  --frame-expand-duration: 0.3s;
+  --frame-expand-stagger-delay: calc(var(--frame-expand-duration) / 3);
+  --frame-expand-stagger-duration: calc(
+    var(--frame-expand-duration) - var(--frame-expand-stagger-delay)
+  );
   padding: var(--code-padding-bottom) 0;
 }
 
@@ -428,7 +438,47 @@ pre.codeBlock[data-scrollbar-gutter='expand-to'] :global(code) {
     height: auto;
     overflow: clip;
     transition:
-      height 0.3s ease,
+      height var(--frame-expand-stagger-duration) ease var(--frame-expand-stagger-delay),
+      opacity 0.3s ease,
+      visibility 0s;
+  }
+
+  /* Frames directly bordering the focused region run at full speed with no delay.
+     `:has(+ visible)` catches the hidden frame above the region; `visible + frame`
+     catches the one below. "Visible" is any typed frame except the hidden
+     `-unfocused` overflow variants. These bordering frames push the delayed far
+     frames off-screen during the first third before those start growing. */
+  .container:has(.checkbox:checked)
+    .code
+    .codeBlock
+    :global(
+      .frame:is(
+          :not([data-frame-type]),
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        ):has(
+          + .frame[data-frame-type]:not(
+              [data-frame-type='highlighted-unfocused'],
+              [data-frame-type='focus-unfocused']
+            )
+        )
+    ),
+  .container:has(.checkbox:checked)
+    .code
+    .codeBlock
+    :global(
+      .frame[data-frame-type]:not(
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        )
+        + .frame:is(
+          :not([data-frame-type]),
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        )
+    ) {
+    transition:
+      height var(--frame-expand-duration) ease,
       opacity 0.3s ease,
       visibility 0s;
   }

--- a/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.module.css
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.module.css
@@ -42,8 +42,11 @@
   text-align: center;
 }
 
-/* Only show the toggle when the code block has collapsible frames */
-.code:has(> pre > code[data-collapsible]) ~ .toggle {
+/* Only show the toggle when the code block has collapsible frames.
+   Editable blocks wrap the `<pre>` in a `.editable-code-wrapper` focus trap, so
+   match the `<pre>` as a descendant (not a direct child) to cover both the plain
+   and the editable structure. */
+.code:has(pre > code[data-collapsible]) ~ .toggle {
   display: block;
 }
 

--- a/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.tsx
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.tsx
@@ -13,18 +13,21 @@ import '../../../components/code-highlighter/demos/syntax.css';
 
 export function CollapsibleContent(props: ContentProps<object>) {
   // @focus-start @padding 1
+  const { containerRef, toggleRef, anchorScroll } = useCodeWindow<HTMLLabelElement>();
+  const { containerRef: transformAnchorRef, anchorScroll: anchorTransformScroll } =
+    useScrollAnchor<HTMLDivElement>();
   const code = useCode(props, {
     preClassName: styles.codeBlock,
     transformDelay: 350,
     transformLayoutShift: 'focus',
     variantSwapDelay: 350,
     variantLayoutShift: 'focus',
+    // Keyboard-driven expansion (caret navigates past the visible top/bottom)
+    // anchors the scroll just like clicking the expand toggle does.
+    onExpand: () => anchorScroll('expand'),
   });
   const id = React.useId();
   const checkboxId = `${id}-expand`;
-  const { containerRef, toggleRef, anchorScroll } = useCodeWindow<HTMLLabelElement>();
-  const { containerRef: transformAnchorRef, anchorScroll: anchorTransformScroll } =
-    useScrollAnchor<HTMLDivElement>();
   const blurPointerFocus = React.useCallback((event: React.FocusEvent<HTMLInputElement>) => {
     if (!event.currentTarget.matches(':focus-visible')) {
       event.currentTarget.blur();

--- a/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.tsx
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleContent.tsx
@@ -78,15 +78,19 @@ export function CollapsibleContent(props: ContentProps<object>) {
         />
         <div className={styles.code}>{code.selectedFile}</div>
         {/* Visually hidden checkbox provides no-JS toggle state via CSS :checked.
-            `defaultChecked` seeds it from the resolved expand state (e.g. a demo
-            rendered with `initialExpanded`) so the block starts open. */}
+            It is *controlled* by `code.expanded` so JS-driven expansion — e.g.
+            arrow-key navigation past the visible region calling `code.expand()`
+            — reveals the frames too, not just a direct click. Without this the
+            checkbox and the engine's expand state drift apart: keyboard expand
+            would unlock caret bounds while the frames stayed hidden. */}
         <input
           type="checkbox"
           id={checkboxId}
           className={styles.checkbox}
-          defaultChecked={code.expanded}
+          checked={code.expanded}
           onFocus={blurPointerFocus}
           onChange={(event) => {
+            code.setExpanded(event.target.checked);
             anchorScroll(event.target.checked ? 'expand' : 'collapse');
           }}
         />

--- a/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleDemoContent.module.css
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/CollapsibleDemoContent.module.css
@@ -89,6 +89,16 @@ pre.codeBlock {
   margin: 0;
   --code-padding-bottom: 6px;
   --scrollbar-gutter-size: 15px;
+  /* Expand stagger: when the focused region opens, frames directly bordering it
+     grow at full speed while frames farther out wait out the first third — the
+     bordering frames push them off-screen — then cover their height in the
+     remaining two thirds. `--frame-expand-duration` is the single knob; the
+     delayed frames still finish on time (delay + stagger duration = total). */
+  --frame-expand-duration: 0.3s;
+  --frame-expand-stagger-delay: calc(var(--frame-expand-duration) / 3);
+  --frame-expand-stagger-duration: calc(
+    var(--frame-expand-duration) - var(--frame-expand-stagger-delay)
+  );
   padding: var(--code-padding-bottom) 0;
 }
 
@@ -438,7 +448,47 @@ pre.codeBlock[data-scrollbar-gutter='expand-to'] :global(code) {
     height: auto;
     overflow: clip;
     transition:
-      height 0.3s ease,
+      height var(--frame-expand-stagger-duration) ease var(--frame-expand-stagger-delay),
+      opacity 0.3s ease,
+      visibility 0s;
+  }
+
+  /* Frames directly bordering the focused region run at full speed with no delay.
+     `:has(+ visible)` catches the hidden frame above the region; `visible + frame`
+     catches the one below. "Visible" is any typed frame except the hidden
+     `-unfocused` overflow variants. These bordering frames push the delayed far
+     frames off-screen during the first third before those start growing. */
+  .codeSection:has(.checkbox:checked)
+    .code
+    .codeBlock
+    :global(
+      .frame:is(
+          :not([data-frame-type]),
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        ):has(
+          + .frame[data-frame-type]:not(
+              [data-frame-type='highlighted-unfocused'],
+              [data-frame-type='focus-unfocused']
+            )
+        )
+    ),
+  .codeSection:has(.checkbox:checked)
+    .code
+    .codeBlock
+    :global(
+      .frame[data-frame-type]:not(
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        )
+        + .frame:is(
+          :not([data-frame-type]),
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        )
+    ) {
+    transition:
+      height var(--frame-expand-duration) ease,
       opacity 0.3s ease,
       visibility 0s;
   }

--- a/docs/app/docs-infra/hooks/use-code-window/demos/IndentContent.module.css
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/IndentContent.module.css
@@ -41,6 +41,16 @@
 pre.codeBlock {
   tab-size: 2;
   margin: 0;
+  /* Expand stagger: when the focused region opens, frames directly bordering it
+     grow at full speed while frames farther out wait out the first third — the
+     bordering frames push them off-screen — then cover their height in the
+     remaining two thirds. `--frame-expand-duration` is the single knob; the
+     delayed frames still finish on time (delay + stagger duration = total). */
+  --frame-expand-duration: 0.3s;
+  --frame-expand-stagger-delay: calc(var(--frame-expand-duration) / 3);
+  --frame-expand-stagger-duration: calc(
+    var(--frame-expand-duration) - var(--frame-expand-stagger-delay)
+  );
   padding: 6px 0;
 }
 
@@ -276,7 +286,45 @@ pre.codeBlock:has(> code > :global(.frame[data-frame-truncated='visible'])) {
     height: auto;
     overflow: clip;
     transition:
-      height 0.3s ease,
+      height var(--frame-expand-stagger-duration) ease var(--frame-expand-stagger-delay),
+      opacity 0.3s ease,
+      visibility 0s;
+  }
+
+  /* Frames directly bordering the focused region run at full speed with no delay.
+     `:has(+ visible)` catches the hidden frame above the region; `visible + frame`
+     catches the one below. "Visible" is any typed frame except the hidden
+     `-unfocused` overflow variants. These bordering frames push the delayed far
+     frames off-screen during the first third before those start growing. */
+  .expanded
+    .codeBlock
+    :global(
+      .frame:is(
+          :not([data-frame-type]),
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        ):has(
+          + .frame[data-frame-type]:not(
+              [data-frame-type='highlighted-unfocused'],
+              [data-frame-type='focus-unfocused']
+            )
+        )
+    ),
+  .expanded
+    .codeBlock
+    :global(
+      .frame[data-frame-type]:not(
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        )
+        + .frame:is(
+          :not([data-frame-type]),
+          [data-frame-type='highlighted-unfocused'],
+          [data-frame-type='focus-unfocused']
+        )
+    ) {
+    transition:
+      height var(--frame-expand-duration) ease,
       opacity 0.3s ease,
       visibility 0s;
   }

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/CodeController.tsx
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/CodeController.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import * as React from 'react';
+import { CodeControllerContext } from '@mui/internal-docs-infra/CodeControllerContext';
+import type { ControlledCode } from '@mui/internal-docs-infra/CodeHighlighter/types';
+
+/**
+ * Minimal controlled-code provider so the collapsible block below becomes
+ * editable: `useCode` enables `setSource` whenever a `CodeControllerContext`
+ * with `setCode` is present.
+ */
+export function CodeController({ children }: { children: React.ReactNode }) {
+  // @focus-start @padding 1
+  const [code, setCode] = React.useState<ControlledCode | undefined>(undefined);
+  const contextValue = React.useMemo(() => ({ code, setCode }), [code, setCode]);
+  return (
+    <CodeControllerContext.Provider value={contextValue}>{children}</CodeControllerContext.Provider>
+  );
+  // @focus-end
+}

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/CollapsibleEditor.tsx
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/CollapsibleEditor.tsx
@@ -1,0 +1,96 @@
+import 'server-only';
+
+import * as React from 'react';
+import { CodeHighlighter } from '@mui/internal-docs-infra/CodeHighlighter';
+import type { Code as CodeType } from '@mui/internal-docs-infra/CodeHighlighter/types';
+import { createParseSource } from '@mui/internal-docs-infra/pipeline/parseSource';
+import {
+  createEnhanceCodeEmphasis,
+  EMPHASIS_COMMENT_PREFIX,
+} from '@mui/internal-docs-infra/pipeline/enhanceCodeEmphasis';
+import { parseImportsAndComments } from '@mui/internal-docs-infra/pipeline/loaderUtils';
+
+import { CollapsibleContentLazy } from '../CollapsibleContentLazy';
+import { CollapsibleContentLoading } from '../CollapsibleContentLoading';
+import { CodeController } from './CodeController';
+
+const sourceParser = createParseSource();
+const sourceEnhancers = [createEnhanceCodeEmphasis({ paddingFrameMaxSize: 3 })];
+
+// A source long enough (and indented) to collapse into a windowed view with a
+// clipped indent gutter. The `@highlight` block becomes the focused/visible
+// region while collapsed; the surrounding lines are clipped.
+const source = `import * as React from 'react';
+import { fetchUser } from './api';
+
+interface User {
+  name: string;
+  email: string;
+}
+
+export function UserProfile({ id }: { id: string }) {
+  const [user, setUser] = React.useState<User | null>(null);
+
+  // @highlight-start
+  React.useEffect(() => {
+    let cancelled = false;
+    fetchUser(id).then((data) => {
+      if (!cancelled) {
+        setUser(data);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+  // @highlight-end
+
+  if (!user) {
+    return <p>Loading…</p>;
+  }
+
+  return (
+    <div>
+      <h2>{user.name}</h2>
+      <p>{user.email}</p>
+    </div>
+  );
+}`;
+
+/**
+ * A collapsible code block that is ALSO editable — the combination needed to
+ * reproduce the collapsed-window editing bugs (last-indent erase jump, ArrowUp
+ * scroll anchor). It reuses the collapsible `CollapsibleContent` (which owns the
+ * `useCodeWindow` collapse + the expand checkbox) and turns on editing by
+ * wrapping it in a `CodeController` and passing `controlled` to the highlighter.
+ */
+export async function CollapsibleEditor() {
+  // @focus-start @padding 1
+  const { code: strippedSource, comments } = await parseImportsAndComments(source, '/demo.tsx', {
+    removeCommentsWithPrefix: [EMPHASIS_COMMENT_PREFIX],
+    notableCommentsPrefix: [EMPHASIS_COMMENT_PREFIX],
+  });
+
+  const code: CodeType = {
+    Default: {
+      fileName: 'UserProfile.tsx',
+      language: 'tsx',
+      source: strippedSource!,
+      comments,
+    },
+  };
+
+  return (
+    <CodeController>
+      <CodeHighlighter
+        code={code}
+        controlled
+        Content={CollapsibleContentLazy}
+        ContentLoading={CollapsibleContentLoading}
+        sourceParser={sourceParser}
+        sourceEnhancers={sourceEnhancers}
+      />
+    </CodeController>
+  );
+  // @focus-end
+}

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/CollapsibleEditor.tsx
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/CollapsibleEditor.tsx
@@ -15,7 +15,16 @@ import { CollapsibleContentLoading } from '../CollapsibleContentLoading';
 import { CodeController } from './CodeController';
 
 const sourceParser = createParseSource();
-const sourceEnhancers = [createEnhanceCodeEmphasis({ paddingFrameMaxSize: 3 })];
+// Must match the global `DemoCodeProvider` emphasis config (see
+// `docs/demo-data/code-provider/layout.tsx`). This block is EDITABLE: the
+// controlled view re-parses the source from its editable string (dropping the
+// precomputed frames and the `appliedEnhancers` marker) and re-enhances it with
+// the PROVIDER's enhancer. The server precompute here builds the loading
+// fallback, so it must window identically or the fallback won't match the live
+// editor (e.g. a missing `padding-top` frame).
+const sourceEnhancers = [
+  createEnhanceCodeEmphasis({ paddingFrameMaxSize: 2, focusFramesMaxSize: 18 }),
+];
 
 // A source long enough (and indented) to collapse into a windowed view with a
 // clipped indent gutter. The `@highlight` block becomes the focused/visible

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/index.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/index.ts
@@ -1,0 +1,7 @@
+import { createDemo } from '@/functions/createDemo';
+import { CollapsibleEditor } from './CollapsibleEditor';
+
+export const DemoCollapsibleEditor = createDemo(import.meta.url, CollapsibleEditor, {
+  name: 'Collapsible Editor',
+  slug: 'collapsible-editor',
+});

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/page.tsx
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/page.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { DemoCollapsibleEditor } from '.';
+
+export default function Page() {
+  return <DemoCollapsibleEditor />;
+}

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
@@ -1,0 +1,82 @@
+import path from 'node:path';
+import { test, expect, type Page } from '@playwright/test';
+
+// The standalone demo route, derived from this file's location under `app`.
+const route = path
+  .dirname(import.meta.filename)
+  .split('/app')
+  .pop()!;
+
+/**
+ * Caret state that doesn't depend on collapsed-mode line/column maths: the
+ * character immediately before the caret, plus whether the caret sits at the
+ * start of its line. The "x =" bug sends the caret to the line start, so the
+ * preceding character flips from `x` to a newline (or nothing).
+ */
+async function caret(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('[contenteditable]') as HTMLElement | null;
+    const sel = window.getSelection();
+    if (!el || !sel || sel.rangeCount === 0) {
+      return { position: -1, prevChar: null as string | null, atLineStart: true };
+    }
+    const range = sel.getRangeAt(0);
+    const until = document.createRange();
+    until.setStart(el, 0);
+    until.setEnd(range.startContainer, range.startOffset);
+    const text = until.toString();
+    const prevChar = text.length > 0 ? text[text.length - 1] : null;
+    return {
+      position: text.length,
+      prevChar,
+      atLineStart: prevChar === null || prevChar === '\n',
+    };
+  });
+}
+
+async function open(page: Page) {
+  const errors: Error[] = [];
+  page.on('pageerror', (error) => errors.push(error));
+  await page.goto(route);
+  const editable = page.locator('[contenteditable]').first();
+  await expect(editable).toBeVisible({ timeout: 15000 });
+  await editable.click();
+  await page.waitForTimeout(700); // warm the lazy editing engine
+  return { editable, errors };
+}
+
+test('the collapsible editor mounts and is editable', async ({ page }) => {
+  const { editable, errors } = await open(page);
+  // The visible (collapsed) region is the highlighted `useEffect` block.
+  await expect(editable).toContainText('fetchUser');
+  await expect(editable).toHaveAttribute('contenteditable');
+  expect(errors, 'demo should mount without uncaught errors').toEqual([]);
+});
+
+// Bug 3: typing `x`, then `=`, then Backspace must keep the caret right after the
+// `x`, not send it to the start of the line.
+test('Bug 3: x then = then Backspace keeps the caret after x', async ({ page }) => {
+  const { editable } = await open(page);
+  // Land the caret at the end of a visible line (the line/inter-line-gap
+  // boundary, where native plaintext typing used to flatten the spans).
+  await editable.locator('.line').first().click();
+  await page.keyboard.press('End');
+
+  await page.keyboard.type('x');
+  await page.waitForTimeout(300);
+  await page.keyboard.type('=');
+  await page.waitForTimeout(300);
+  const afterTyping = await caret(page);
+
+  await page.keyboard.press('Backspace');
+  await page.waitForTimeout(300);
+  const afterBackspace = await caret(page);
+
+  // Deleting the `=` should move the caret back exactly one position and leave
+  // it sitting right after the `x`. The bug sent it to the line start instead:
+  // the caret's preceding character became the newline, not `x`.
+  const ctx = `caret: ${JSON.stringify({ afterTyping, afterBackspace })}`;
+  expect(afterBackspace.position, ctx).toBe(afterTyping.position - 1);
+  expect(afterBackspace.prevChar, ctx).toBe('x');
+  expect(afterBackspace.atLineStart, ctx).toBe(false);
+});

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 
 // The standalone demo route, derived from this file's location under `app`.
 const route = path
@@ -8,17 +8,25 @@ const route = path
   .pop()!;
 
 /**
- * Caret state that doesn't depend on collapsed-mode line/column maths: the
- * character immediately before the caret, plus whether the caret sits at the
- * start of its line. The "x =" bug sends the caret to the line start, so the
- * preceding character flips from `x` to a newline (or nothing).
+ * Caret state read straight from the live Selection — the source of truth the
+ * user actually sees. `dataLn` is the `data-ln` of the `.line` the caret sits
+ * in; `inGap` is true when the caret is stranded in an inter-line gap text node
+ * (between `.line` spans) rather than inside a real line. `prevChar` /
+ * `atLineStart` describe the character immediately before the caret without
+ * depending on collapsed-mode column maths.
  */
 async function caret(page: Page) {
   return page.evaluate(() => {
     const el = document.querySelector('[contenteditable]') as HTMLElement | null;
     const sel = window.getSelection();
     if (!el || !sel || sel.rangeCount === 0) {
-      return { position: -1, prevChar: null as string | null, atLineStart: true };
+      return {
+        position: -1,
+        prevChar: null as string | null,
+        atLineStart: true,
+        dataLn: null as string | null,
+        inGap: true,
+      };
     }
     const range = sel.getRangeAt(0);
     const until = document.createRange();
@@ -26,57 +34,905 @@ async function caret(page: Page) {
     until.setEnd(range.startContainer, range.startOffset);
     const text = until.toString();
     const prevChar = text.length > 0 ? text[text.length - 1] : null;
+    const startNode = range.startContainer;
+    const startElement =
+      startNode.nodeType === 1 ? (startNode as Element) : startNode.parentElement;
+    const lineEl = startElement ? startElement.closest('.line') : null;
     return {
       position: text.length,
       prevChar,
       atLineStart: prevChar === null || prevChar === '\n',
+      dataLn: lineEl ? lineEl.getAttribute('data-ln') : null,
+      inGap: !lineEl,
     };
   });
 }
 
+/**
+ * The visible window of the editable: how many `.line`s are actually rendered
+ * (height > 0, not `visibility: hidden`) and which `data-ln` they span. Scoped
+ * to the editable's own collapsible container because the demo ALSO renders a
+ * separate collapsible source viewer with its own checkbox/toggle.
+ */
+async function visibleWindow(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('[contenteditable]') as HTMLElement | null;
+    if (!el) {
+      return {
+        count: 0,
+        firstLn: null as string | null,
+        lastLn: null as string | null,
+        expanded: false,
+      };
+    }
+    const container = el.closest('div[class*=container]');
+    const lines = Array.from(el.querySelectorAll('.line'));
+    const visible = lines.filter((line) => {
+      const rect = line.getBoundingClientRect();
+      return rect.height > 0 && getComputedStyle(line).visibility !== 'hidden';
+    });
+    const checkbox = container?.querySelector('input[type=checkbox]') as HTMLInputElement | null;
+    return {
+      count: visible.length,
+      firstLn: visible[0]?.getAttribute('data-ln') ?? null,
+      lastLn: visible[visible.length - 1]?.getAttribute('data-ln') ?? null,
+      expanded: checkbox?.checked ?? false,
+    };
+  });
+}
+
+/**
+ * Clicks the visible `.line` carrying `dataLn` to place the caret on it, then
+ * optionally normalizes the column with Home/End. Clicking (rather than a
+ * synthetic range) exercises the engine's real pointer → caret pipeline.
+ */
+async function placeCaretOnLine(
+  page: Page,
+  editable: Locator,
+  dataLn: number,
+  where: 'start' | 'end' | 'click' = 'click',
+) {
+  await editable.locator(`.line[data-ln="${dataLn}"]`).click();
+  await page.waitForTimeout(120);
+  if (where === 'start') {
+    await page.keyboard.press('Home');
+  } else if (where === 'end') {
+    await page.keyboard.press('End');
+  }
+  await page.waitForTimeout(80);
+}
+
+type Signature = { lineCount: number; visCount: number; empty: number; textLen: number };
+
+/**
+ * Records a structural signature of the editable on every DOM mutation while
+ * `action` runs, so transient "flash" states are captured. A flash is any
+ * intermediate frame whose structure is WORSE than both the stable before/after
+ * states — a momentary empty `.line` (the browser's default contentEditable
+ * behavior collapsing a line) or a dip in the visible line count — that then
+ * reconciles back. These are invisible to a plain before/after assertion but
+ * are exactly what the user sees flicker on screen.
+ */
+async function flashDuring(page: Page, action: () => Promise<void>) {
+  await page.evaluate(() => {
+    const el = document.querySelector('[contenteditable]') as HTMLElement;
+    const probe = window as unknown as {
+      flashSig: () => Signature;
+      flashRec: Signature[];
+      flashMo: MutationObserver;
+    };
+    probe.flashSig = () => {
+      const lines = Array.from(el.querySelectorAll('.line'));
+      const visible = lines.filter((line) => {
+        const rect = line.getBoundingClientRect();
+        return rect.height > 0 && getComputedStyle(line).visibility !== 'hidden';
+      });
+      return {
+        lineCount: lines.length,
+        visCount: visible.length,
+        empty: lines.filter((line) => (line.textContent || '') === '').length,
+        textLen: (el.textContent || '').length,
+      };
+    };
+    probe.flashRec = [probe.flashSig()];
+    probe.flashMo = new MutationObserver(() => probe.flashRec.push(probe.flashSig()));
+    probe.flashMo.observe(el, { childList: true, subtree: true, characterData: true });
+  });
+
+  await action();
+  await page.waitForTimeout(500);
+
+  const records = await page.evaluate(() => {
+    const probe = window as unknown as {
+      flashSig: () => Signature;
+      flashRec: Signature[];
+      flashMo: MutationObserver;
+    };
+    probe.flashMo.disconnect();
+    probe.flashRec.push(probe.flashSig());
+    return probe.flashRec;
+  });
+
+  const baseline = records[0];
+  const stable = records[records.length - 1];
+  // Only meaningful for edits that keep the line structure (so before ≈ after).
+  const stableVis = Math.min(baseline.visCount, stable.visCount);
+  const flashed = records.some((rec) => rec.empty > stable.empty || rec.visCount < stableVis);
+  return { records, baseline, stable, flashed };
+}
+
+/** Total character length of the editable's text content. */
+async function editableTextLength(page: Page) {
+  return page.evaluate(
+    () => (document.querySelector('[contenteditable]')?.textContent ?? '').length,
+  );
+}
+
+/** The current Selection's plain text. */
+async function selectionText(page: Page) {
+  return page.evaluate(() => window.getSelection()?.toString() ?? '');
+}
+
+/**
+ * Selects whole lines `fromLn`..`toLn` (inclusive) via a real Range and returns
+ * the browser's `Selection.toString()`. Used instead of keyboard Shift+Arrow
+ * for multi-line selections, which the browser extends unreliably across the
+ * non-selectable inter-line gap nodes in the framed structure.
+ */
+async function selectLines(page: Page, fromLn: number, toLn: number) {
+  return page.evaluate(
+    ({ from, to }) => {
+      const el = document.querySelector('[contenteditable]') as HTMLElement;
+      const lines = Array.from(el.querySelectorAll('.line'));
+      const first = lines.find((node) => node.getAttribute('data-ln') === String(from))!;
+      const last = lines.find((node) => node.getAttribute('data-ln') === String(to))!;
+      const range = document.createRange();
+      range.setStart(first, 0);
+      range.setEnd(last, last.childNodes.length);
+      const selection = window.getSelection()!;
+      selection.removeAllRanges();
+      selection.addRange(range);
+      return selection.toString();
+    },
+    { from: fromLn, to: toLn },
+  );
+}
+
+/**
+ * Dispatches a synthetic `copy`/`cut` ClipboardEvent (the same event a real
+ * Ctrl+C/Ctrl+X fires) and returns the `text/plain` the engine's handler wrote
+ * plus whether it intercepted the event. Avoids OS-clipboard/permission flake
+ * while exercising the exact handler logic.
+ */
+async function clipboardFromEvent(page: Page, type: 'copy' | 'cut') {
+  return page.evaluate((eventType) => {
+    const el = document.querySelector('[contenteditable]') as HTMLElement;
+    const data = new DataTransfer();
+    const event = new ClipboardEvent(eventType, {
+      clipboardData: data,
+      bubbles: true,
+      cancelable: true,
+    });
+    el.dispatchEvent(event);
+    return { text: data.getData('text/plain'), prevented: event.defaultPrevented };
+  }, type);
+}
+
+/** Dispatches a synthetic paste of `value` (the same event a real Ctrl+V fires). */
+async function pasteText(page: Page, value: string) {
+  await page.evaluate((text) => {
+    const el = document.querySelector('[contenteditable]') as HTMLElement;
+    const data = new DataTransfer();
+    data.setData('text/plain', text);
+    el.dispatchEvent(
+      new ClipboardEvent('paste', { clipboardData: data, bubbles: true, cancelable: true }),
+    );
+  }, value);
+}
+
+/** Opens the demo, warms the lazy editing engine, and tracks uncaught errors. */
 async function open(page: Page) {
   const errors: Error[] = [];
   page.on('pageerror', (error) => errors.push(error));
   await page.goto(route);
   const editable = page.locator('[contenteditable]').first();
   await expect(editable).toBeVisible({ timeout: 15000 });
-  await editable.click();
+  await editable.locator('.line').first().click();
   await page.waitForTimeout(700); // warm the lazy editing engine
   return { editable, errors };
 }
 
-test('the collapsible editor mounts and is editable', async ({ page }) => {
-  const { editable, errors } = await open(page);
-  // The visible (collapsed) region is the highlighted `useEffect` block.
-  await expect(editable).toContainText('fetchUser');
-  await expect(editable).toHaveAttribute('contenteditable');
-  expect(errors, 'demo should mount without uncaught errors').toEqual([]);
+test.describe('collapsible editor — mount', () => {
+  test('mounts, is editable, and renders the collapsed window', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    // The visible (collapsed) region is the highlighted `useEffect` block.
+    await expect(editable).toContainText('fetchUser');
+    await expect(editable).toHaveAttribute('contenteditable');
+    const view = await visibleWindow(page);
+    // Collapsed: only the focused window (padding + highlighted block) shows,
+    // far fewer than the ~33 total lines in the source.
+    expect(view.count).toBeGreaterThan(0);
+    expect(view.count).toBeLessThan(33);
+    expect(errors, 'demo should mount without uncaught errors').toEqual([]);
+  });
 });
 
-// Bug 3: typing `x`, then `=`, then Backspace must keep the caret right after the
-// `x`, not send it to the start of the line.
-test('Bug 3: x then = then Backspace keeps the caret after x', async ({ page }) => {
-  const { editable } = await open(page);
-  // Land the caret at the end of a visible line (the line/inter-line-gap
-  // boundary, where native plaintext typing used to flatten the spans).
-  await editable.locator('.line').first().click();
-  await page.keyboard.press('End');
+test.describe('cursor movement within the visible frame', () => {
+  test('Home and End stay on the same line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'click');
+    const start = await caret(page);
+    await page.keyboard.press('End');
+    const atEnd = await caret(page);
+    await page.keyboard.press('Home');
+    const atHome = await caret(page);
 
-  await page.keyboard.type('x');
-  await page.waitForTimeout(300);
-  await page.keyboard.type('=');
-  await page.waitForTimeout(300);
-  const afterTyping = await caret(page);
+    expect(atEnd.dataLn, 'End keeps the caret on its line').toBe(start.dataLn);
+    expect(atHome.dataLn, 'Home keeps the caret on its line').toBe(start.dataLn);
+    expect(atEnd.inGap).toBe(false);
+    expect(atHome.inGap).toBe(false);
+    expect(atHome.atLineStart).toBe(true);
+    expect(errors).toEqual([]);
+  });
 
-  await page.keyboard.press('Backspace');
-  await page.waitForTimeout(300);
-  const afterBackspace = await caret(page);
+  test('ArrowLeft at the start of a line wraps to the end of the previous line', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    const before = await caret(page);
+    await page.keyboard.press('ArrowLeft');
+    const after = await caret(page);
 
-  // Deleting the `=` should move the caret back exactly one position and leave
-  // it sitting right after the `x`. The bug sent it to the line start instead:
-  // the caret's preceding character became the newline, not `x`.
-  const ctx = `caret: ${JSON.stringify({ afterTyping, afterBackspace })}`;
-  expect(afterBackspace.position, ctx).toBe(afterTyping.position - 1);
-  expect(afterBackspace.prevChar, ctx).toBe('x');
-  expect(afterBackspace.atLineStart, ctx).toBe(false);
+    expect(before.dataLn).toBe('13');
+    expect(after.inGap, 'ArrowLeft must not strand the caret in an inter-line gap').toBe(false);
+    expect(after.dataLn, 'ArrowLeft at line start lands on the previous line').toBe('12');
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowRight at the end of a line wraps to the start of the next line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'end');
+    const before = await caret(page);
+    await page.keyboard.press('ArrowRight');
+    const after = await caret(page);
+
+    expect(before.dataLn).toBe('13');
+    expect(after.inGap, 'ArrowRight must not strand the caret in an inter-line gap').toBe(false);
+    expect(after.dataLn, 'ArrowRight at line end lands on the next line').toBe('14');
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowDown then ArrowUp moves one real line at a time', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 16, 'click');
+    const start = await caret(page);
+    await page.keyboard.press('ArrowDown');
+    const down = await caret(page);
+    await page.keyboard.press('ArrowUp');
+    const back = await caret(page);
+
+    expect(start.dataLn).toBe('16');
+    expect(down.inGap).toBe(false);
+    expect(down.dataLn).toBe('17');
+    expect(back.inGap).toBe(false);
+    expect(back.dataLn).toBe('16');
+    expect(errors).toEqual([]);
+  });
+
+  // Typing `x`, then `=`, then Backspace must keep the caret right after the
+  // `x`, not send it to the start of the line (a previously-fixed regression).
+  test('typing x, =, then Backspace keeps the caret after x', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await editable.locator('.line').first().click();
+    await page.keyboard.press('End');
+
+    await page.keyboard.type('x');
+    await page.waitForTimeout(300);
+    await page.keyboard.type('=');
+    await page.waitForTimeout(300);
+    const afterTyping = await caret(page);
+
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(300);
+    const afterBackspace = await caret(page);
+
+    const ctx = `caret: ${JSON.stringify({ afterTyping, afterBackspace })}`;
+    expect(afterBackspace.position, ctx).toBe(afterTyping.position - 1);
+    expect(afterBackspace.prevChar, ctx).toBe('x');
+    expect(afterBackspace.atLineStart, ctx).toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('clicking in the gap between two lines snaps the caret onto a line', async ({ page }) => {
+    const { errors } = await open(page);
+    // Click just below line 12 — the inter-line gap text node, where a naive
+    // contentEditable would strand the caret "between lines".
+    const point = await page.evaluate(() => {
+      const el = document.querySelector('[contenteditable]') as HTMLElement;
+      const line = Array.from(el.querySelectorAll('.line')).find(
+        (node) => node.getAttribute('data-ln') === '12',
+      )!;
+      const rect = line.getBoundingClientRect();
+      return { x: rect.right - 2, y: rect.bottom + 0.5 };
+    });
+    await page.mouse.click(point.x, point.y);
+    await page.waitForTimeout(150);
+    const after = await caret(page);
+
+    expect(after.inGap, 'a click in the gap must snap onto a real line').toBe(false);
+    expect(['12', '13'], `landed on ${after.dataLn}`).toContain(after.dataLn);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('navigating across empty lines', () => {
+  test('ArrowDown/ArrowUp step onto a blank line instead of skipping it', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    // data-ln 23 is a blank line between `}, [id]);` (22) and `if (!user) {` (24).
+    await placeCaretOnLine(page, editable, 22, 'end');
+    await page.keyboard.press('ArrowDown');
+    const onBlank = await caret(page);
+    await page.keyboard.press('ArrowDown');
+    const belowBlank = await caret(page);
+    await page.keyboard.press('ArrowUp');
+    const backOnBlank = await caret(page);
+
+    expect(onBlank.inGap, 'caret must land ON the blank line, not in a gap').toBe(false);
+    expect(onBlank.dataLn).toBe('23');
+    expect(belowBlank.dataLn).toBe('24');
+    expect(backOnBlank.inGap).toBe(false);
+    expect(backOnBlank.dataLn).toBe('23');
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowUp stops on each of two consecutive empty lines (does not skip both)', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    // Turn the single blank line 23 into TWO consecutive blank lines by pressing
+    // Enter on it (an empty line has no indent to preserve, so this inserts a
+    // truly-empty, zero-height line — the kind native vertical nav skips).
+    await placeCaretOnLine(page, editable, 23, 'start');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    const afterEnter = await caret(page);
+    // Caret is now on the lower of the two blank lines. Step up onto the other.
+    await page.keyboard.press('ArrowUp');
+    const up1 = await caret(page);
+    await page.keyboard.press('ArrowUp');
+    const up2 = await caret(page);
+
+    expect(afterEnter.inGap).toBe(false);
+    expect(up1.inGap, 'ArrowUp must stop on the first blank line, not skip it').toBe(false);
+    // up1 lands on a blank line one row above; up2 lands on the content line above.
+    expect(Number(up1.dataLn)).toBe(Number(afterEnter.dataLn) - 1);
+    expect(up2.inGap).toBe(false);
+    expect(Number(up2.dataLn)).toBe(Number(afterEnter.dataLn) - 2);
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowDown stops on each of two consecutive empty lines (does not skip both)', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    // Two consecutive blank lines (Enter on the blank line 23), then step DOWN
+    // through them starting from the content line above.
+    await placeCaretOnLine(page, editable, 23, 'start');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(300);
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
+    const top = await caret(page);
+    await page.keyboard.press('ArrowDown');
+    const down1 = await caret(page);
+    await page.keyboard.press('ArrowDown');
+    const down2 = await caret(page);
+
+    expect(down1.inGap).toBe(false);
+    expect(Number(down1.dataLn)).toBe(Number(top.dataLn) + 1);
+    expect(down2.inGap, 'ArrowDown must stop on the second blank line, not skip it').toBe(false);
+    expect(Number(down2.dataLn)).toBe(Number(top.dataLn) + 2);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('frame edges', () => {
+  test('ArrowUp at the top of the window keeps the caret on a real line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const view = await visibleWindow(page);
+    // Click the topmost visible line, then press ArrowUp at the frame edge.
+    await placeCaretOnLine(page, editable, Number(view.firstLn), 'click');
+    const before = await caret(page);
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(600);
+    const after = await caret(page);
+
+    expect(before.dataLn).toBe(view.firstLn);
+    expect(
+      after.inGap,
+      `ArrowUp at the top edge must not strand the caret in a gap (got ${JSON.stringify(after)})`,
+    ).toBe(false);
+    // It should step up onto the previously-hidden line above the window.
+    expect(Number(after.dataLn)).toBe(Number(view.firstLn) - 1);
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowUp at the top of the window expands the collapsed region', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const before = await visibleWindow(page);
+    await placeCaretOnLine(page, editable, Number(before.firstLn), 'click');
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(800);
+    const after = await visibleWindow(page);
+
+    expect(
+      after.count,
+      `ArrowUp at the top edge should reveal more lines (before ${before.count}, after ${after.count})`,
+    ).toBeGreaterThan(before.count);
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowDown at the bottom of the window keeps the caret on a real line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const view = await visibleWindow(page);
+    await placeCaretOnLine(page, editable, Number(view.lastLn), 'click');
+    const before = await caret(page);
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(600);
+    const after = await caret(page);
+
+    expect(before.dataLn).toBe(view.lastLn);
+    expect(
+      after.inGap,
+      `ArrowDown at the bottom edge must not strand the caret in a gap (got ${JSON.stringify(after)})`,
+    ).toBe(false);
+    expect(Number(after.dataLn)).toBe(Number(view.lastLn) + 1);
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowDown at the bottom of the window expands the collapsed region', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const before = await visibleWindow(page);
+    await placeCaretOnLine(page, editable, Number(before.lastLn), 'click');
+    await page.keyboard.press('ArrowDown');
+    await page.waitForTimeout(800);
+    const after = await visibleWindow(page);
+
+    expect(
+      after.count,
+      `ArrowDown at the bottom edge should reveal more lines (before ${before.count}, after ${after.count})`,
+    ).toBeGreaterThan(before.count);
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowLeft at the very start of the top line wraps to the previous line and expands', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const view = await visibleWindow(page);
+    // Caret at column 0 of the topmost visible line, then ArrowLeft at the edge.
+    await placeCaretOnLine(page, editable, Number(view.firstLn), 'start');
+    const before = await caret(page);
+    await page.keyboard.press('ArrowLeft');
+    await page.waitForTimeout(800);
+    const after = await caret(page);
+    const afterView = await visibleWindow(page);
+
+    expect(before.dataLn).toBe(view.firstLn);
+    expect(
+      after.inGap,
+      `ArrowLeft at the top edge must not strand the caret in a gap (got ${JSON.stringify(after)})`,
+    ).toBe(false);
+    // It lands on the (now revealed) previous line — not stuck on the edge line.
+    expect(after.dataLn, 'ArrowLeft at the top edge lands on the previous line').toBe(
+      String(Number(view.firstLn) - 1),
+    );
+    expect(afterView.count, 'and the region expands').toBeGreaterThan(view.count);
+    expect(errors).toEqual([]);
+  });
+
+  test('ArrowRight at the very end of the bottom line wraps to the next line and expands', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const view = await visibleWindow(page);
+    await placeCaretOnLine(page, editable, Number(view.lastLn), 'end');
+    const before = await caret(page);
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(800);
+    const after = await caret(page);
+    const afterView = await visibleWindow(page);
+
+    expect(before.dataLn).toBe(view.lastLn);
+    expect(
+      after.inGap,
+      `ArrowRight at the bottom edge must not strand the caret in a gap (got ${JSON.stringify(after)})`,
+    ).toBe(false);
+    expect(after.dataLn, 'ArrowRight at the bottom edge lands on the next line').toBe(
+      String(Number(view.lastLn) + 1),
+    );
+    expect(afterView.count, 'and the region expands').toBeGreaterThan(view.count);
+    expect(errors).toEqual([]);
+  });
+
+  test('the Expand toggle reveals the hidden lines', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const before = await visibleWindow(page);
+    const toggle = editable
+      .locator('xpath=ancestor::div[contains(@class,"container")][1]')
+      .locator('label')
+      .first();
+    await expect(toggle, 'the Expand/Collapse toggle should be visible').toBeVisible({
+      timeout: 6000,
+    });
+    await toggle.click();
+    await page.waitForTimeout(1500);
+    const after = await visibleWindow(page);
+
+    expect(
+      after.count,
+      `Expand should reveal the full source (before ${before.count}, after ${after.count})`,
+    ).toBeGreaterThan(before.count);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('expanding and collapsing', () => {
+  test('after expanding via ArrowUp, the caret keeps moving up into the revealed lines', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const view = await visibleWindow(page);
+    await placeCaretOnLine(page, editable, Number(view.firstLn), 'click');
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(800);
+    const up1 = await caret(page);
+    // Now expanded: a second ArrowUp must keep stepping up through real lines.
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(200);
+    const up2 = await caret(page);
+
+    expect(up1.inGap).toBe(false);
+    expect(up1.dataLn).toBe(String(Number(view.firstLn) - 1));
+    expect(up2.inGap, 'the caret keeps moving up into revealed content').toBe(false);
+    expect(Number(up2.dataLn)).toBe(Number(view.firstLn) - 2);
+    expect(errors).toEqual([]);
+  });
+
+  test('the toggle expands and then collapses back to the original window', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const collapsed = await visibleWindow(page);
+    const toggle = editable
+      .locator('xpath=ancestor::div[contains(@class,"container")][1]')
+      .locator('label')
+      .first();
+
+    await toggle.click();
+    await page.waitForTimeout(1500);
+    const expanded = await visibleWindow(page);
+
+    await toggle.click();
+    await page.waitForTimeout(1500);
+    const recollapsed = await visibleWindow(page);
+
+    expect(expanded.count, 'expands').toBeGreaterThan(collapsed.count);
+    expect(recollapsed.count, 'collapses back to the original window').toBe(collapsed.count);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('editing operations', () => {
+  test('the first keystroke is inserted and keeps focus', async ({ page }) => {
+    // Bug 4: the first keystroke after engaging the editor used to lose focus.
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    await page.keyboard.type('Q');
+    await page.waitForTimeout(300);
+    const after = await caret(page);
+    const focused = await page.evaluate(
+      () => document.activeElement === document.querySelector('[contenteditable]'),
+    );
+
+    expect(focused, 'the editable keeps focus after the first keystroke').toBe(true);
+    expect(after.prevChar, 'the character is inserted at the caret').toBe('Q');
+    expect(after.dataLn).toBe('12');
+    expect(errors).toEqual([]);
+  });
+
+  test('Tab indents and Shift+Tab dedents', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    const base = await editableTextLength(page);
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(300);
+    const indented = await editableTextLength(page);
+    await page.keyboard.press('Shift+Tab');
+    await page.waitForTimeout(300);
+    const dedented = await editableTextLength(page);
+
+    expect(indented, 'Tab adds one indent unit').toBe(base + 2);
+    expect(dedented, 'Shift+Tab removes it again').toBe(base);
+    expect(errors).toEqual([]);
+  });
+
+  test('forward Delete at the end of a line merges the next line up', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    const base = await editableTextLength(page);
+    const before = await caret(page);
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(400);
+    const after = await caret(page);
+    const merged = await editableTextLength(page);
+
+    expect(before.dataLn).toBe('12');
+    // The line break is removed, so the document loses exactly one character and
+    // the caret stays put at the join (not stranded, not jumped).
+    expect(merged, 'the line break is deleted').toBe(base - 1);
+    expect(after.inGap).toBe(false);
+    expect(after.dataLn).toBe('12');
+    expect(errors).toEqual([]);
+  });
+
+  test('pasting multi-line text inserts every line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    await pasteText(page, 'AAA\nBBB');
+    await page.waitForTimeout(500);
+    const after = await caret(page);
+
+    await expect(editable).toContainText('AAA');
+    await expect(editable).toContainText('BBB');
+    expect(after.inGap, 'caret lands inside a real line after paste').toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('Ctrl+Z undoes and Ctrl+Shift+Z redoes a typed edit', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    const base = await editableTextLength(page);
+    await page.keyboard.type('Q');
+    // Wait past the 500ms undo-coalescing window so the edit is its own step.
+    await page.waitForTimeout(700);
+    const typed = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(500);
+    const undone = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await page.waitForTimeout(500);
+    const redone = await editableTextLength(page);
+
+    expect(typed, 'the character is typed').toBe(base + 1);
+    expect(undone, 'Ctrl+Z removes it').toBe(base);
+    expect(redone, 'Ctrl+Shift+Z restores it').toBe(base + 1);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('no flash on edits (synchronous reconciliation)', () => {
+  test('typing a character does not flash', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    const { flashed, records } = await flashDuring(page, async () => {
+      await page.keyboard.type('z');
+    });
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('backspacing trailing whitespace keeps the caret on the same line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    // Make the blank line 23 a whitespace-only line (one indent unit), then
+    // erase it. A single Backspace clears the whole unit and empties the line —
+    // "removing the last part of a line full of spaces".
+    await placeCaretOnLine(page, editable, 23, 'start');
+    await page.keyboard.type('  ');
+    await page.waitForTimeout(300);
+    const filled = await caret(page);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(300);
+    const after = await caret(page);
+
+    expect(filled.dataLn).toBe('23');
+    expect(after.dataLn, 'Backspace on a space-only line must keep the caret on that line').toBe(
+      '23',
+    );
+    expect(after.inGap).toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('backspacing trailing whitespace does not flash the line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    // One indent unit of whitespace, so the single Backspace below empties the
+    // line — the exact moment the browser's default behavior collapses it.
+    await placeCaretOnLine(page, editable, 23, 'start');
+    await page.keyboard.type('  ');
+    await page.waitForTimeout(300);
+    const { flashed, records } = await flashDuring(page, async () => {
+      await page.keyboard.press('Backspace');
+    });
+    // The browser's default behavior momentarily collapses the line to empty;
+    // the engine must reconcile to the final state synchronously so the user
+    // never sees the line blink out and back.
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('backspacing at the start of a line merges into the previous line without flashing', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    const before = await caret(page);
+    const { flashed, records } = await flashDuring(page, async () => {
+      await page.keyboard.press('Backspace');
+    });
+    const after = await caret(page);
+
+    expect(before.dataLn).toBe('13');
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(after.inGap).toBe(false);
+    expect(after.dataLn, 'the caret joins the end of the previous line').toBe('12');
+    expect(errors).toEqual([]);
+  });
+
+  test('pressing Enter splits a line onto a new line without flashing', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'click');
+    const before = await caret(page);
+    const { flashed, records } = await flashDuring(page, async () => {
+      await page.keyboard.press('Enter');
+    });
+    const after = await caret(page);
+
+    expect(before.dataLn).toBe('13');
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(after.inGap).toBe(false);
+    expect(Number(after.dataLn), 'the caret moves onto the new line').toBe(
+      Number(before.dataLn) + 1,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test('forward Delete that empties a line does not flash', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    // Whitespace-only line (one indent unit); forward Delete from its start
+    // empties it — the same zero-height collapse as the Backspace case, but via
+    // the forward-delete path.
+    await placeCaretOnLine(page, editable, 23, 'start');
+    await page.keyboard.type('  ');
+    await page.waitForTimeout(300);
+    await page.keyboard.press('Home');
+    await page.waitForTimeout(80);
+    const { flashed, records } = await flashDuring(page, async () => {
+      await page.keyboard.press('Delete');
+      await page.keyboard.press('Delete');
+    });
+    const after = await caret(page);
+
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(after.inGap).toBe(false);
+    expect(after.dataLn, 'the caret stays on the emptied line').toBe('23');
+    expect(errors).toEqual([]);
+  });
+
+  test('pasting multi-line text does not flash', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    const { flashed, records } = await flashDuring(page, async () => {
+      await pasteText(page, 'AAA\nBBB');
+    });
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('selection and clipboard', () => {
+  test('Shift+ArrowRight extends the selection within a line', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'start');
+    await page.keyboard.press('Shift+ArrowRight');
+    await page.keyboard.press('Shift+ArrowRight');
+    await page.keyboard.press('Shift+ArrowRight');
+    const selected = await selectionText(page);
+    expect(selected.length, 'three characters are selected').toBe(3);
+    expect(errors).toEqual([]);
+  });
+
+  test('Ctrl+A selects the editable content across multiple lines', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'click');
+    await page.keyboard.press('ControlOrMeta+a');
+    const selected = await selectionText(page);
+    expect(selected.length, 'selects a large multi-line span').toBeGreaterThan(50);
+    expect(selected, 'spans multiple lines').toContain('\n');
+    expect(errors).toEqual([]);
+  });
+
+  test('copying a selection writes it to the system clipboard (real Ctrl+C)', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    await page.keyboard.press('Shift+End');
+    const selected = await selectionText(page);
+    await page.keyboard.press('ControlOrMeta+c');
+    await page.waitForTimeout(200);
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+
+    expect(selected.length).toBeGreaterThan(0);
+    expect(clip, 'the clipboard holds exactly the selected text').toBe(selected);
+    expect(errors).toEqual([]);
+  });
+
+  test('copying across lines collapses the browser-duplicated block newline', async ({ page }) => {
+    const { errors } = await open(page);
+    // The browser serializes each `.line` block with an EXTRA newline; the engine
+    // overrides copy to use the range text so each line break appears once.
+    const selected = await selectLines(page, 12, 13);
+    const copied = await clipboardFromEvent(page, 'copy');
+
+    expect(copied.prevented, 'the engine intercepts copy').toBe(true);
+    expect(
+      (selected.match(/\n/g) || []).length,
+      'the browser selection has a doubled newline',
+    ).toBeGreaterThan(1);
+    expect(
+      (copied.text.match(/\n/g) || []).length,
+      'the clipboard has one newline per line break',
+    ).toBe(1);
+    expect(errors).toEqual([]);
+  });
+
+  test('cutting removes the selection and writes it to the clipboard', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    await page.keyboard.press('Shift+End');
+    const selected = await selectionText(page);
+    const before = await editableTextLength(page);
+
+    const cut = await clipboardFromEvent(page, 'cut');
+    await page.waitForTimeout(300);
+    const after = await editableTextLength(page);
+
+    expect(cut.prevented, 'the engine intercepts cut').toBe(true);
+    expect(cut.text, 'the clipboard holds the cut text').toBe(selected);
+    expect(after, 'the selected text is removed from the document').toBe(before - selected.length);
+    expect(errors).toEqual([]);
+  });
+
+  test('pasting over a selection replaces it', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    await page.keyboard.press('Shift+End');
+    const selected = await selectionText(page);
+    const before = await editableTextLength(page);
+
+    await pasteText(page, 'XYZ');
+    await page.waitForTimeout(400);
+    const after = await editableTextLength(page);
+
+    await expect(editable).toContainText('XYZ');
+    expect(after, 'the selection is replaced by the pasted text').toBe(
+      before - selected.length + 'XYZ'.length,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test('Backspace deletes a whole multi-line selection', async ({ page }) => {
+    const { errors } = await open(page);
+    await selectLines(page, 12, 13);
+    const before = await editableTextLength(page);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(400);
+    const after = await caret(page);
+    const remaining = await editableTextLength(page);
+
+    // Both selected lines (~50 chars) are removed in one keystroke.
+    expect(remaining, 'the whole selection is deleted').toBeLessThan(before - 40);
+    expect(after.inGap, 'the caret lands on a real line after the delete').toBe(false);
+    expect(errors).toEqual([]);
+  });
 });

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
@@ -200,6 +200,81 @@ async function selectionText(page: Page) {
 }
 
 /**
+ * The Selection's two ends, by `data-ln`. `anchorLn` is the fixed end, `focusLn`
+ * the moving end (extended by Shift+arrow). `focusInGap` is true when the focus
+ * landed in an inter-line gap node rather than inside a real `.line` — the
+ * "between lines" trap the framed structure is prone to.
+ */
+async function selectionEnds(page: Page) {
+  return page.evaluate(() => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) {
+      return { anchorLn: null, focusLn: null, focusInGap: true, collapsed: true };
+    }
+    const lineOf = (node: Node | null) => {
+      const el = node?.nodeType === 1 ? (node as Element) : (node?.parentElement ?? null);
+      const line = el?.closest('.line');
+      return line ? line.getAttribute('data-ln') : null;
+    };
+    const inLine = (node: Node | null) => {
+      const el = node?.nodeType === 1 ? (node as Element) : (node?.parentElement ?? null);
+      return !!el?.closest('.line');
+    };
+    return {
+      anchorLn: lineOf(sel.anchorNode),
+      focusLn: lineOf(sel.focusNode),
+      focusInGap: !inLine(sel.focusNode),
+      collapsed: sel.isCollapsed,
+    };
+  });
+}
+
+/**
+ * Whether the current Selection range intersects any zero-height (`h===0`)
+ * frame — the collapsed/clipped regions above and below the window. A selection
+ * that reaches into one paints a stray highlight on lines the user can't see.
+ */
+async function selectionTouchesHiddenFrame(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('[contenteditable]');
+    const sel = window.getSelection();
+    if (!el || !sel || sel.rangeCount === 0) {
+      return false;
+    }
+    const range = sel.getRangeAt(0);
+    for (const frame of el.querySelectorAll('.frame')) {
+      if (frame.getBoundingClientRect().height === 0 && range.intersectsNode(frame)) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+/**
+ * A compact signature of the rendered frame structure — each frame's type and
+ * its `.line` contents. Used to detect a transient "flash" where the live DOM
+ * deviates from React's eventual render (the two snapshots must match).
+ */
+async function frameStructure(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('[contenteditable]');
+    if (!el) {
+      return '';
+    }
+    return Array.from(el.querySelectorAll('.frame'))
+      .map((frame) => {
+        const type = frame.getAttribute('data-frame-type') ?? 'null';
+        const lines = Array.from(frame.querySelectorAll('.line')).map((line) =>
+          (line.textContent || '').trim().slice(0, 16),
+        );
+        return `${type}[${lines.join('|')}]`;
+      })
+      .join(' ');
+  });
+}
+
+/**
  * Selects whole lines `fromLn`..`toLn` (inclusive) via a real Range and returns
  * the browser's `Selection.toString()`. Used instead of keyboard Shift+Arrow
  * for multi-line selections, which the browser extends unreliably across the
@@ -1025,6 +1100,29 @@ test.describe('selection and clipboard', () => {
     expect(after.inGap, 'the caret lands on a real line after the delete').toBe(false);
     expect(errors).toEqual([]);
   });
+
+  test('deleting a selection that spans a whole frame keeps the editor mounted and undoable', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const initialLen = await editableTextLength(page);
+    // Select the entire highlighted frame plus its blank `@highlight-end` line
+    // (12..23). A native delete of this range removes a whole `.frame` wrapper
+    // element, which used to crash React (`removeChild` on a detached node) and
+    // unmount the editor. The controlled delete + synchronous reconcile must keep
+    // the editor alive and the code undoable.
+    await selectLines(page, 12, 23);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(500);
+    await expect(editable, 'the editor stays mounted (no crash)').toBeVisible();
+    expect(await editableTextLength(page), 'the selection was deleted').toBeLessThan(initialLen);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    await expect(editable).toBeVisible();
+    expect(await editableTextLength(page), 'undo restores the code').toBe(initialLen);
+    expect(errors, 'no uncaught errors (no React reconciliation crash)').toEqual([]);
+  });
 });
 
 test.describe('undo and redo restore the emphasis frames', () => {
@@ -1268,6 +1366,279 @@ test.describe('undo/redo restores the highlight after a structural deletion', ()
 
     expect(undone, 'undo rebuilds the highlighted region').toEqual(initial);
     expect(after.inGap, 'the caret is resolvable again').toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('deleting the highlight from its first line through the end marker restores on undo', async ({
+    page,
+  }) => {
+    // Selecting from the @highlight-start line (12) THROUGH the blank
+    // @highlight-end line (23) and deleting starts the selection exactly on the
+    // start-marker line. The post-delete caret then sits on the line that
+    // shifted up from below, so the comment-shift anchor must drop one line or
+    // the start marker is left stranded and undo rebuilds the wrong region.
+    const { errors } = await open(page);
+    const initial = await highlightSignature(page);
+    expect(initial?.first, 'the useEffect block is highlighted to start').toBe(
+      'React.useEffect(() => {',
+    );
+    const initialLen = await editableTextLength(page);
+    await selectLines(page, 12, 23);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+
+    expect(undone, 'undo rebuilds the exact highlighted region').toEqual(initial);
+    expect(await editableTextLength(page), 'undo restores the code').toBe(initialLen);
+    expect(errors).toEqual([]);
+  });
+
+  test('deleting exactly the visible highlight (its first line through its last) restores on undo', async ({
+    page,
+  }) => {
+    // The realistic "select the highlighted region" case: lines 12..22 (the
+    // start marker line through the last highlighted line, NOT the end marker).
+    // Only the start marker line is deleted; the end marker survives. Must still
+    // round-trip through the same anchor adjustment.
+    const { errors } = await open(page);
+    const initial = await highlightSignature(page);
+    const initialLen = await editableTextLength(page);
+    await selectLines(page, 12, 22);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+
+    expect(undone, 'undo rebuilds the exact highlighted region').toEqual(initial);
+    expect(await editableTextLength(page), 'undo restores the code').toBe(initialLen);
+    expect(errors).toEqual([]);
+  });
+
+  test('deleting only the highlight tail (end marker, start survives) restores exactly on undo', async ({
+    page,
+  }) => {
+    // Partial-range deletion: select from the SECOND highlighted line (13)
+    // through the @highlight-end line (23). The @highlight-start line (12)
+    // survives, so the region SHRINKS in the live view (the end marker collapses
+    // to the boundary) instead of vanishing. The collapsed end is stashed at its
+    // true offset so undo rebuilds the region EXACTLY — not one line short or
+    // long, which a plain boundary shrink+re-shift would produce. Redo→undo must
+    // stay stable too.
+    const { errors } = await open(page);
+    const initial = await highlightSignature(page);
+    const initialLen = await editableTextLength(page);
+    await selectLines(page, 13, 23);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await page.waitForTimeout(500);
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const redoUndone = await highlightSignature(page);
+
+    expect(undone, 'undo rebuilds the exact highlighted region').toEqual(initial);
+    expect(redoUndone, 'redo then undo also rebuilds it exactly').toEqual(initial);
+    expect(await editableTextLength(page), 'undo restores the code').toBe(initialLen);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('Shift+arrow extends the selection one line at a time', () => {
+  // Native vertical selection-extension in the framed editor skips zero-height
+  // blank `.line` spans (a two-line jump) and parks the focus in the
+  // non-selectable inter-line `\n` gap nodes. The engine must step the focus
+  // exactly one logical line, keep it inside a real `.line`, and leave the
+  // anchor put.
+
+  test('Shift+ArrowUp extends onto the blank line above instead of skipping it', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'start'); // line 11 above is blank
+    await page.keyboard.press('Shift+ArrowUp');
+    await page.waitForTimeout(150);
+    const first = await selectionEnds(page);
+    expect(first.anchorLn, 'the anchor stays put on line 12').toBe('12');
+    expect(first.focusLn, 'the focus lands on the blank line 11, not skipping to 10').toBe('11');
+    expect(first.focusInGap, 'the focus is inside a real line, not between lines').toBe(false);
+
+    await page.keyboard.press('Shift+ArrowUp');
+    await page.waitForTimeout(150);
+    const second = await selectionEnds(page);
+    expect(second.anchorLn).toBe('12');
+    expect(second.focusLn, 'a second Shift+ArrowUp reaches line 10').toBe('10');
+    expect(second.focusInGap).toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('Shift+ArrowDown extends onto the blank line below instead of skipping it', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 22, 'start'); // last highlighted line; 23 below is blank
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.waitForTimeout(150);
+    const sel = await selectionEnds(page);
+    expect(sel.anchorLn).toBe('22');
+    expect(sel.focusLn, 'the focus lands on the blank line 23, not skipping to 24').toBe('23');
+    expect(sel.focusInGap).toBe(false);
+    expect(errors).toEqual([]);
+  });
+
+  test('Shift+ArrowDown between non-blank lines keeps the focus inside a line, not a gap', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'start');
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.waitForTimeout(150);
+    const sel = await selectionEnds(page);
+    expect(sel.focusInGap, 'the focus never lands in an inter-line gap node').toBe(false);
+    expect(sel.focusLn, 'the focus steps one line down to 13').toBe('13');
+    expect(errors).toEqual([]);
+  });
+
+  test('Shift+ArrowUp then Shift+ArrowDown returns the focus to where it started', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 13, 'start');
+    await page.keyboard.press('Shift+ArrowUp');
+    await page.waitForTimeout(120);
+    expect((await selectionEnds(page)).focusLn).toBe('12');
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.waitForTimeout(120);
+    const back = await selectionEnds(page);
+    expect(back.focusLn, 'the focus comes back to line 13').toBe('13');
+    expect(back.focusInGap).toBe(false);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('selection never extends into the collapsed (zero-height) region', () => {
+  // Above and below the visible window the clipped lines render inside h=0
+  // frames. Extending a selection into them paints a stray highlight on lines
+  // the user can't see (and parks the focus in a non-selectable node). Keyboard
+  // extension must stop at the window edge; a mouse drag past the edge must be
+  // pulled back on mouse up.
+
+  test('Shift+ArrowDown stops at the window bottom instead of entering the clipped frame', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 22, 'start');
+    // Walk down to and past the last visible line; the focus must never reach a
+    // zero-height frame and must stay inside a real line. Each press depends on
+    // the previous one, so the awaits are intentionally sequential.
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < 5; i += 1) {
+      await page.keyboard.press('Shift+ArrowDown');
+      await page.waitForTimeout(120);
+      expect(
+        await selectionTouchesHiddenFrame(page),
+        `Shift+ArrowDown #${i + 1} must not reach the clipped region`,
+      ).toBe(false);
+      const sel = await selectionEnds(page);
+      expect(sel.focusInGap, `focus stays in a real line on press #${i + 1}`).toBe(false);
+    }
+    /* eslint-enable no-await-in-loop */
+    expect(errors).toEqual([]);
+  });
+
+  test('Shift+ArrowUp stops at the window top instead of entering the clipped frame', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'start');
+    /* eslint-disable no-await-in-loop */
+    for (let i = 0; i < 5; i += 1) {
+      await page.keyboard.press('Shift+ArrowUp');
+      await page.waitForTimeout(120);
+      expect(
+        await selectionTouchesHiddenFrame(page),
+        `Shift+ArrowUp #${i + 1} must not reach the clipped region`,
+      ).toBe(false);
+      const sel = await selectionEnds(page);
+      expect(sel.focusInGap, `focus stays in a real line on press #${i + 1}`).toBe(false);
+    }
+    /* eslint-enable no-await-in-loop */
+    expect(errors).toEqual([]);
+  });
+
+  test('a selection reaching into the clipped region is pulled back on mouse up', async ({
+    page,
+  }) => {
+    // A headless drag clamps to visible content on its own, but a real-browser
+    // drag can autoscroll the focus past the fold into the zero-height clipped
+    // frame. Reproduce that end state directly (a Range from a visible line to
+    // the very end of the document), then fire `mouseup` — the engine must pull
+    // the focus back to the window edge.
+    const { errors } = await open(page);
+    const reached = await page.evaluate(() => {
+      const el = document.querySelector('[contenteditable]') as HTMLElement;
+      const from = Array.from(el.querySelectorAll('.line')).find(
+        (line) => line.getAttribute('data-ln') === '20',
+      )!;
+      const range = document.createRange();
+      range.setStart(from, 0);
+      range.setEnd(el, el.childNodes.length); // end of the document, deep in the bottom clipped frame
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      // Confirm the buggy precondition: the selection touches a zero-height frame.
+      const r = sel.getRangeAt(0);
+      return Array.from(el.querySelectorAll('.frame')).some(
+        (frame) => frame.getBoundingClientRect().height === 0 && r.intersectsNode(frame),
+      );
+    });
+    expect(reached, 'precondition: the forced selection reaches the clipped region').toBe(true);
+
+    await page.evaluate(() => {
+      const el = document.querySelector('[contenteditable]') as HTMLElement;
+      el.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+    await page.waitForTimeout(150);
+
+    expect(
+      await selectionTouchesHiddenFrame(page),
+      'mouse up pulls the selection back out of the clipped region',
+    ).toBe(false);
+    const sel = await selectionEnds(page);
+    expect(sel.focusInGap, 'the clamped focus rests inside a real line').toBe(false);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('Enter after a window-shifting edit does not flash', () => {
+  // Backspace at the top of a frame merges the line up and scrolls the collapsed
+  // window; pressing Enter splits it back and scrolls the window down again. The
+  // split must reconcile React's frame structure synchronously — otherwise the
+  // live DOM shows the pre-reconcile window position until the keyup flush, a
+  // visible flash.
+
+  test('pressing Enter reconciles the frame structure in the same task (no flash)', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'start');
+    await page.keyboard.press('Backspace'); // merge line 12 up; window scrolls up
+    await page.waitForTimeout(500);
+
+    // Press Enter as two halves so we can read the DOM between keydown and keyup.
+    await page.keyboard.down('Enter');
+    const afterKeydown = await frameStructure(page);
+    await page.keyboard.up('Enter');
+    await page.waitForTimeout(600);
+    const settled = await frameStructure(page);
+
+    expect(afterKeydown, 'the keydown reconciles to the final frame structure').toBe(settled);
     expect(errors).toEqual([]);
   });
 });

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
@@ -1520,6 +1520,51 @@ test.describe('Shift+arrow extends the selection one line at a time', () => {
     expect(back.focusInGap).toBe(false);
     expect(errors).toEqual([]);
   });
+
+  test('Shift+ArrowDown advances one line per press across a zero-height empty line (no stall)', async ({
+    page,
+  }) => {
+    // In production CSS an empty line collapses to ZERO height (no inline content
+    // to form a line box). Headless renders it at 18px, so force the zero-height
+    // condition to match a real (headed) browser. Native Shift+Arrow works in
+    // visual space, so it STALLS on a zero-height line: a second Shift+Down lands
+    // on the same line instead of advancing ("expected line 4, still on line 3").
+    // The engine steps in LOGICAL line space, so each press advances exactly one
+    // line — landing on the empty line, then moving past it.
+    const { editable, errors } = await open(page);
+    await page.addStyleTag({
+      content: '.line.__zh{height:0!important;line-height:0!important;overflow:hidden!important;}',
+    });
+    await page.evaluate(() => {
+      for (const line of document.querySelectorAll('.line')) {
+        if ((line.textContent || '').replace(/\n/g, '').trim() === '') {
+          line.classList.add('__zh');
+        }
+      }
+    });
+    // Line 11 (below line 10) is the now-zero-height empty line.
+    await placeCaretOnLine(page, editable, 10, 'end');
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.waitForTimeout(150);
+    expect((await selectionEnds(page)).focusLn, 'first press lands on the empty line 11').toBe(
+      '11',
+    );
+
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.waitForTimeout(150);
+    const past = await selectionEnds(page);
+    expect(past.focusLn, 'second press advances PAST it to 12 (not stuck on 11)').toBe('12');
+    expect(past.focusInGap).toBe(false);
+
+    // And it comes back one line per press.
+    await page.keyboard.press('Shift+ArrowUp');
+    await page.waitForTimeout(150);
+    expect((await selectionEnds(page)).focusLn, 'Shift+Up steps back onto 11').toBe('11');
+    await page.keyboard.press('Shift+ArrowUp');
+    await page.waitForTimeout(150);
+    expect((await selectionEnds(page)).focusLn, 'and back to 10').toBe('10');
+    expect(errors).toEqual([]);
+  });
 });
 
 test.describe('selection never extends into the collapsed (zero-height) region', () => {

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
@@ -161,11 +161,37 @@ async function flashDuring(page: Page, action: () => Promise<void>) {
   return { records, baseline, stable, flashed };
 }
 
-/** Total character length of the editable's text content. */
+/**
+ * Content length of the editable, ignoring a single trailing newline. The
+ * contentEditable serializes with a trailing newline (and the rendered fallback
+ * reflects it once the source carries one), so measuring length without it makes
+ * deltas reflect real edits rather than the line terminator.
+ */
 async function editableTextLength(page: Page) {
-  return page.evaluate(
-    () => (document.querySelector('[contenteditable]')?.textContent ?? '').length,
-  );
+  return page.evaluate(() => {
+    const text = document.querySelector('[contenteditable]')?.textContent ?? '';
+    return (text.endsWith('\n') ? text.slice(0, -1) : text).length;
+  });
+}
+
+/**
+ * A content-based signature of the emphasis (`@highlight`) frame: the trimmed
+ * text of its first and last line, plus its line count. Content-based (not line
+ * numbers) so it survives the collapsed windowing — it answers "is the SAME
+ * code still highlighted?" across edits and undo/redo.
+ */
+async function highlightSignature(page: Page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('[contenteditable]');
+    const frame = el?.querySelector('.frame[data-frame-type="highlighted"]') ?? null;
+    if (!frame) {
+      return null;
+    }
+    const lines = Array.from(frame.querySelectorAll('.line')).map((line) =>
+      (line.textContent || '').trim(),
+    );
+    return { first: lines[0] ?? null, last: lines[lines.length - 1] ?? null, count: lines.length };
+  });
 }
 
 /** The current Selection's plain text. */
@@ -712,6 +738,48 @@ test.describe('editing operations', () => {
   });
 });
 
+test.describe('word- and line-granular deletion', () => {
+  // The indentation editor routes every plain Backspace through a single-character
+  // delete (to tame the Firefox/plaintext-only quirks). A MODIFIED Backspace
+  // (Ctrl/Meta/Alt) must instead fall through to the browser's native word/line
+  // deletion — mirroring the forward-Delete branch — so a held modifier keeps its
+  // OS deletion granularity.
+  test('Ctrl+Backspace deletes the whole word before the caret, not one character', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    // Type a known word at the end of a line, then word-delete it.
+    await placeCaretOnLine(page, editable, 12, 'end');
+    await page.keyboard.type(' hello');
+    await page.waitForTimeout(600);
+    const typed = await editableTextLength(page);
+    await page.keyboard.press('ControlOrMeta+Backspace');
+    await page.waitForTimeout(400);
+    const after = await editableTextLength(page);
+
+    expect(typed - after, 'a whole word is removed in one press').toBeGreaterThanOrEqual(5);
+    await expect(
+      editable.locator('.line[data-ln="12"]'),
+      'the word is gone, not just its last character',
+    ).not.toContainText('hello');
+    expect(errors).toEqual([]);
+  });
+
+  test('plain Backspace still deletes a single character', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'end');
+    await page.keyboard.type(' hello');
+    await page.waitForTimeout(600);
+    const typed = await editableTextLength(page);
+    await page.keyboard.press('Backspace');
+    await page.waitForTimeout(400);
+
+    expect(typed - (await editableTextLength(page)), 'one character is removed').toBe(1);
+    await expect(editable.locator('.line[data-ln="12"]')).toContainText('hell');
+    expect(errors).toEqual([]);
+  });
+});
+
 test.describe('no flash on edits (synchronous reconciliation)', () => {
   test('typing a character does not flash', async ({ page }) => {
     const { editable, errors } = await open(page);
@@ -776,6 +844,28 @@ test.describe('no flash on edits (synchronous reconciliation)', () => {
     expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
     expect(after.inGap).toBe(false);
     expect(after.dataLn, 'the caret joins the end of the previous line').toBe('12');
+    expect(errors).toEqual([]);
+  });
+
+  test('backspacing a line up into a BLANK line above does not flash', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    // Line 11 is the blank padding line directly above the highlight. Backspacing
+    // at the start of line 12 merges the highlighted line up into that empty line.
+    // The merge momentarily collapses a `.line` until the async re-highlight
+    // commits — unless the engine reconciles the merge synchronously. (Distinct
+    // from the merge-into-a-non-blank-line case above, which absorbs the text
+    // without leaving an extra empty line transiently.)
+    await placeCaretOnLine(page, editable, 12, 'start');
+    const before = await caret(page);
+    const { flashed, records } = await flashDuring(page, async () => {
+      await page.keyboard.press('Backspace');
+    });
+    const after = await caret(page);
+
+    expect(before.dataLn).toBe('12');
+    expect(flashed, `transient flash detected: ${JSON.stringify(records)}`).toBe(false);
+    expect(after.inGap).toBe(false);
+    expect(after.dataLn, 'the caret joins the previously-blank line above').toBe('11');
     expect(errors).toEqual([]);
   });
 
@@ -933,6 +1023,251 @@ test.describe('selection and clipboard', () => {
     // Both selected lines (~50 chars) are removed in one keystroke.
     expect(remaining, 'the whole selection is deleted').toBeLessThan(before - 40);
     expect(after.inGap, 'the caret lands on a real line after the delete').toBe(false);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('undo and redo restore the emphasis frames', () => {
+  // The `@highlight` region is driven by the comment map, which must travel with
+  // the code: an edit that moves the region must move it, and undo/redo must put
+  // BOTH the code and the highlighted region back exactly where they were.
+
+  test('inserting a line above the highlight, then undo/redo restores code and highlight', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const initial = await highlightSignature(page);
+    const initialLen = await editableTextLength(page);
+    expect(initial?.first, 'the useEffect block is highlighted to start').toBe(
+      'React.useEffect(() => {',
+    );
+
+    // Add a blank line in the padding region above the highlight.
+    await placeCaretOnLine(page, editable, 11, 'end');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(600);
+    const edited = await highlightSignature(page);
+    const editedLen = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+    const undoneLen = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await page.waitForTimeout(600);
+    const redone = await highlightSignature(page);
+    const redoneLen = await editableTextLength(page);
+
+    // The same code stays highlighted across the insert (it just moves down).
+    expect(edited, 'the highlight still wraps the useEffect block').toMatchObject({
+      first: 'React.useEffect(() => {',
+      last: '}, [id]);',
+    });
+    // Undo restores both the code and the highlighted region exactly.
+    expect(undoneLen, 'undo restores the code').toBe(initialLen);
+    expect(undone, 'undo restores the highlighted region').toEqual(initial);
+    // Redo re-applies both.
+    expect(redoneLen, 'redo restores the code').toBe(editedLen);
+    expect(redone, 'redo restores the highlighted region').toEqual(edited);
+    expect(errors).toEqual([]);
+  });
+
+  test('cutting a line above the highlight, then undo/redo restores code and highlight', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const initial = await highlightSignature(page);
+    const initialLen = await editableTextLength(page);
+
+    // Select and cut the padding line directly above the highlight.
+    await placeCaretOnLine(page, editable, 10, 'start');
+    await page.keyboard.press('Shift+ArrowDown');
+    await page.keyboard.press('ControlOrMeta+x');
+    await page.waitForTimeout(600);
+    const edited = await highlightSignature(page);
+    const editedLen = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+    const undoneLen = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await page.waitForTimeout(600);
+    const redone = await highlightSignature(page);
+    const redoneLen = await editableTextLength(page);
+
+    // Cutting above moves the code up but the SAME block stays highlighted.
+    expect(edited, 'the highlight still wraps the useEffect block after the cut').toMatchObject({
+      first: 'React.useEffect(() => {',
+      last: '}, [id]);',
+    });
+    expect(undoneLen, 'undo restores the cut code').toBe(initialLen);
+    expect(undone, 'undo restores the highlighted region').toEqual(initial);
+    expect(redoneLen, 'redo re-applies the cut').toBe(editedLen);
+    expect(redone, 'redo restores the highlighted region').toEqual(edited);
+    expect(errors).toEqual([]);
+  });
+
+  test('editing inside the highlight, then undo/redo restores code and highlight', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const initial = await highlightSignature(page);
+    const initialLen = await editableTextLength(page);
+
+    // Add a line inside the highlighted block — it should grow the region.
+    await placeCaretOnLine(page, editable, 15, 'end');
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(600);
+    const edited = await highlightSignature(page);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+    const undoneLen = await editableTextLength(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await page.waitForTimeout(600);
+    const redone = await highlightSignature(page);
+
+    // The region grew by the inserted line but still starts/ends on the block.
+    expect(edited?.count, 'the highlight grows by the inserted line').toBe(
+      (initial?.count ?? 0) + 1,
+    );
+    expect(undoneLen, 'undo restores the code').toBe(initialLen);
+    expect(undone, 'undo restores the highlighted region').toEqual(initial);
+    expect(redone, 'redo restores the highlighted region').toEqual(edited);
+    expect(errors).toEqual([]);
+  });
+
+  test('a no-op-line edit above the highlight does not drift the region', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    const initial = await highlightSignature(page);
+
+    // Typing a character above the highlight changes no line count, so the
+    // highlighted region must stay on exactly the same code.
+    await placeCaretOnLine(page, editable, 10, 'end');
+    await page.keyboard.type('x');
+    await page.waitForTimeout(600);
+    const edited = await highlightSignature(page);
+
+    expect(edited, 'the highlight must not drift when no line is added or removed').toEqual(
+      initial,
+    );
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('crossing the window fold with non-arrow keys', () => {
+  // Arrow keys at the visible edge expand the collapsed window (see "frame
+  // edges"). Enter that pushes a new line past the fold, and PageUp/PageDown,
+  // must behave the same — never strand the caret in the non-editable padding
+  // filler that has no host `.line`.
+
+  test('pressing Enter on the last visible line expands and keeps the caret on a real line', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 24, 'end'); // bottom visible line
+    const before = await caret(page);
+    await page.keyboard.press('Enter');
+    await page.waitForTimeout(500);
+    const after = await caret(page);
+    const window = await visibleWindow(page);
+
+    expect(before.dataLn).toBe('24');
+    expect(after.inGap, 'the caret is not stranded below the fold').toBe(false);
+    expect(Number(after.dataLn), 'the caret moves onto the newly inserted line').toBe(25);
+    expect(window.expanded, 'the window expands to reveal the new line').toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  test('PageDown moves the caret to the bottom edge and expands', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 12, 'start');
+    await page.keyboard.press('PageDown');
+    await page.waitForTimeout(400);
+    const after = await caret(page);
+    const window = await visibleWindow(page);
+
+    expect(after.inGap, 'PageDown keeps the caret on a real line').toBe(false);
+    expect(after.dataLn, 'the caret lands on the last visible line').toBe('24');
+    expect(window.expanded).toBe(true);
+    expect(errors).toEqual([]);
+  });
+
+  test('PageUp moves the caret to the top edge and expands', async ({ page }) => {
+    const { editable, errors } = await open(page);
+    await placeCaretOnLine(page, editable, 20, 'start');
+    await page.keyboard.press('PageUp');
+    await page.waitForTimeout(400);
+    const after = await caret(page);
+    const window = await visibleWindow(page);
+
+    expect(after.inGap).toBe(false);
+    expect(after.dataLn, 'the caret lands on the first visible line').toBe('10');
+    expect(window.expanded).toBe(true);
+    expect(errors).toEqual([]);
+  });
+});
+
+test.describe('undo/redo restores the highlight after a structural deletion', () => {
+  // Undo/redo reverse the comment-map transform: the engine tags the restored
+  // position with its navigation direction so `shiftComments` re-inserts deleted
+  // lines after the pre-edit caret (a plain delta can't tell an undo-of-a-merge
+  // from forward typing — same caret, same delta — and would drift the region).
+
+  test('forward Delete that merges a highlighted line, then undo/redo, restores the region', async ({
+    page,
+  }) => {
+    const { editable, errors } = await open(page);
+    const initial = await highlightSignature(page);
+    expect(initial?.first, 'the useEffect block is highlighted to start').toBe(
+      'React.useEffect(() => {',
+    );
+    await placeCaretOnLine(page, editable, 12, 'end');
+    await page.keyboard.press('Delete'); // merge the next line up into the first highlighted line
+    await page.waitForTimeout(600);
+    const edited = await highlightSignature(page);
+
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(600);
+    const undone = await highlightSignature(page);
+
+    await page.keyboard.press('ControlOrMeta+Shift+z');
+    await page.waitForTimeout(600);
+    const redone = await highlightSignature(page);
+
+    expect(undone, 'undo restores both code and the highlighted region').toEqual(initial);
+    expect(redone, 'redo re-applies the merge to the region').toEqual(edited);
+    expect(errors).toEqual([]);
+  });
+
+  test('select-all, delete, retype, then undo rebuilds the highlight', async ({ page }) => {
+    // Deleting a select-all that spans the whole frame REMOVES it (both ends are
+    // stashed in the collapseMap), and undo reopens it: the restored caret can
+    // land on a different line than the deletion's collapse point, so the engine
+    // passes the forward edit's anchor (`historyPivotLine`) to reverse at the
+    // right line.
+    const { editable, errors } = await open(page);
+    const initial = await highlightSignature(page);
+    await placeCaretOnLine(page, editable, 12, 'start');
+    await page.keyboard.press('ControlOrMeta+a');
+    await page.keyboard.press('Delete');
+    await page.waitForTimeout(300);
+    await page.keyboard.type('x');
+    await page.waitForTimeout(600);
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.keyboard.press('ControlOrMeta+z');
+    await page.waitForTimeout(800);
+    const undone = await highlightSignature(page);
+    const after = await caret(page);
+
+    expect(undone, 'undo rebuilds the highlighted region').toEqual(initial);
+    expect(after.inGap, 'the caret is resolvable again').toBe(false);
     expect(errors).toEqual([]);
   });
 });

--- a/docs/app/docs-infra/hooks/use-code-window/page.mdx
+++ b/docs/app/docs-infra/hooks/use-code-window/page.mdx
@@ -139,6 +139,55 @@ pre[data-scrollbar-gutter='expand-to'] {
 
 Without these rules the attribute is harmless — it just toggles silently. If you change `expandDuration` / `collapseDuration`, update the `0.35s` values above to match.
 
+## Animating the frames
+
+The hook choreographs the scroll and the gutter — **growing and shrinking the frames is your CSS**. Each frame outside the focused region collapses to `height: 0` and animates back to `height: auto` (via [`interpolate-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size)) when the toggle expands the block:
+
+```css
+@supports (interpolate-size: allow-keywords) {
+  /* Collapsed: frames outside the focused region have no height */
+  .frame:not([data-frame-type]) {
+    interpolate-size: allow-keywords;
+    height: 0;
+    overflow: clip;
+    transition: height 0.3s ease;
+  }
+
+  /* Expanded */
+  :checked ~ .code .frame:not([data-frame-type]) {
+    height: auto;
+  }
+}
+```
+
+### Staggering the expand
+
+A long block opens best when the frames nearest the focused region move first and shove the rest off-screen, rather than every frame growing in lock-step. Drive the whole effect from one custom property: frames **directly bordering** the focused region grow at full speed, while frames farther out wait out the first third — the bordering frames push them off-screen — then cover their height in the remaining two thirds, so every frame still lands on time.
+
+```css
+pre {
+  --frame-expand-duration: 0.3s;
+  --frame-expand-stagger-delay: calc(var(--frame-expand-duration) / 3);
+  --frame-expand-stagger-duration: calc(
+    var(--frame-expand-duration) - var(--frame-expand-stagger-delay)
+  );
+}
+
+/* Far frames are delayed by a third, then run for the rest of the duration */
+:checked ~ .code .frame:not([data-frame-type]) {
+  transition: height var(--frame-expand-stagger-duration) ease var(--frame-expand-stagger-delay);
+}
+
+/* Frames directly bordering the focused region run at full speed with no delay.
+   `:has(+ focus)` is the frame above the region; `focus + .frame` is the one below. */
+:checked ~ .code .frame:not([data-frame-type]):has(+ .frame[data-frame-type='focus']),
+:checked ~ .code .frame[data-frame-type='focus'] + .frame:not([data-frame-type]) {
+  transition: height var(--frame-expand-duration) ease;
+}
+```
+
+The example above borders a single `focus` region; the demos generalize the "visible" side to any focused frame type (`padding-top`, `padding-bottom`, `highlighted`) and treat the hidden `-unfocused` overflow frames as bordering too — see the [`CollapsibleContent.module.css`](./demos/CollapsibleContent.module.css) source for the full selector.
+
 ## Examples
 
 These demos all use [`enhanceCodeEmphasis`](../../pipeline/enhance-code-emphasis/page.mdx) directives (`@highlight`, `@focus`, `@padding`) to mark which lines belong to the focus area. `useCodeWindow` then handles the choreography — picking the anchor, animating the gutter, and keeping your scroll position pinned.

--- a/docs/app/docs-infra/hooks/use-code-window/page.mdx
+++ b/docs/app/docs-infra/hooks/use-code-window/page.mdx
@@ -186,7 +186,7 @@ pre {
 }
 ```
 
-The example above borders a single `focus` region; the demos generalize the "visible" side to any focused frame type (`padding-top`, `padding-bottom`, `highlighted`) and treat the hidden `-unfocused` overflow frames as bordering too — see the [`CollapsibleContent.module.css`](./demos/CollapsibleContent.module.css) source for the full selector.
+The example above borders a single `focus` region; the demos generalize the "visible" side to any focused frame type (`padding-top`, `padding-bottom`, `highlighted`) and treat the hidden `-unfocused` overflow frames as bordering too — see the [`CollapsibleContent.module.css`](#collapsible-code-block:collapsible-content.module.css) source for the full selector.
 
 ## Examples
 

--- a/docs/app/docs-infra/hooks/use-code-window/page.mdx
+++ b/docs/app/docs-infra/hooks/use-code-window/page.mdx
@@ -228,6 +228,18 @@ import { DemoCollapsibleTransform } from './demos/collapsible-transform';
 
 [See Demo](./demos/collapsible-transform/)
 
+### Collapsible Editor
+
+A collapsible code block that is also **editable**. Combining collapse with live editing is what surfaces the trickiest caret behaviors: navigating the cursor past the visible top or bottom expands the window, the clipped indent gutter is respected, and edits re-highlight in place. Use this to verify cursor movement, frame-edge navigation, and flash-free structural edits inside a collapsed window.
+
+import { DemoCollapsibleEditor } from './demos/collapsible-editor';
+
+<DemoCollapsibleEditor.Title />
+
+<DemoCollapsibleEditor />
+
+[See Demo](./demos/collapsible-editor/)
+
 ### Collapsible Demo
 
 A full demo component with a live preview, file tabs, and collapsible code. The code section starts collapsed, showing only the focused region.

--- a/docs/app/docs-infra/hooks/use-code/types.md
+++ b/docs/app/docs-infra/hooks/use-code/types.md
@@ -66,6 +66,17 @@ type UseCodeOpts = {
   /** Disables editing of the code block even when a CodeControllerContext is present. */
   disabled?: boolean;
   /**
+   * Called when the code block is asked to expand its collapsed window — most
+   * importantly from the editor itself, when the caret navigates past the
+   * visible region (e.g. `ArrowUp` at the top of a collapsed block). Fires
+   * synchronously, *before* the expansion re-renders, so a host can capture the
+   * still-collapsed layout and engage a scroll anchor (e.g. `useCodeWindow`'s
+   * `anchorScroll('expand')`) — matching the timing of a click on the expand
+   * toggle. Without this, keyboard-driven expansion would jump the viewport
+   * instead of smoothly anchoring it.
+   */
+  onExpand?: () => void;
+  /**
    * Delay in milliseconds between a transform change and the actual swap
    * of the rendered file tree to the new transform. `selectedTransform`
    * still updates synchronously so UI controls reflect the change

--- a/docs/app/docs-infra/hooks/use-demo/types.md
+++ b/docs/app/docs-infra/hooks/use-demo/types.md
@@ -348,12 +348,19 @@ type ExportConfig = {
     config: ExportConfig,
   ) => { exported: VariantCode; rootFile: string };
   /**
-   * Transform function that runs at the very start of the export process
-   * Can modify the variant code and metadata before any other processing happens
+   * Transform function that runs at the very start of the export process.
+   * Can modify the variant code and metadata before any other processing happens.
+   *
+   * Every source handed to this hook — `variant.source`, each
+   * `variant.extraFiles[*].source`, and each `globals[*].source` — is decoded to
+   * either a plain string or a live HAST tree (`HastRoot`); the serialized
+   * `hastCompressed` / `hastJson` shapes never reach it. Read a source as text
+   * with `stringOrHastToString`, or inspect / transform the HAST directly.
+   * Decoded trees are clones you own, so mutating them is safe.
    * @example
-   * transformVariant: (variant, globals, variantName) => ({
-   *   variant: { ...variant, source: modifiedSource },
-   *   globals: { ...globals, extraFiles: { ...globals.extraFiles, 'theme.css': { source: '.new {}', metadata: true } } }
+   * transformVariant: (variant, variantName, globals) => ({
+   *   variant: { ...variant, source: `// ${variantName}\n${stringOrHastToString(variant.source)}` },
+   *   globals: { ...globals, 'theme.css': { source: '.new {}', metadata: true } },
    * })
    */
   transformVariant?: (

--- a/docs/app/docs-infra/pipeline/lint-javascript-demo-focus/page.mdx
+++ b/docs/app/docs-infra/pipeline/lint-javascript-demo-focus/page.mdx
@@ -54,7 +54,7 @@ The rule identifies the main component export of a demo file and inserts comment
 
 When the return contains a wrapper (`div`, `Box`, `Stack`, or `React.Fragment`), JSX comments are inserted inside the wrapper around its children:
 
-```tsx
+```tsx displayComments
 // Before
 export default function Demo() {
   return (
@@ -80,7 +80,7 @@ export default function Demo() {
 
 For a single child inside a wrapper:
 
-```tsx
+```tsx displayComments
 // After fix
 export default function Demo() {
   return (
@@ -96,7 +96,7 @@ export default function Demo() {
 
 When the return is a bare element (not wrapped in `div`, `Box`, `Stack`, or a fragment), JS comments are inserted before the return line:
 
-```tsx
+```tsx displayComments
 // Before
 export default function Demo() {
   return <Button>Click me</Button>;
@@ -111,7 +111,7 @@ export default function Demo() {
 
 When the return already has parentheses, the comment is placed inside them:
 
-```tsx
+```tsx displayComments
 // Before
 export default function Demo() {
   return <Button>Click me</Button>;
@@ -128,7 +128,7 @@ export default function Demo() {
 
 With `wrapReturn: true`, bare returns without parentheses are wrapped so the comment appears inside:
 
-```tsx
+```tsx displayComments
 // Before
 export default function Demo() {
   return <Button>Click me</Button>;
@@ -147,7 +147,7 @@ export default function Demo() {
 
 When the component has setup code (hooks, variables, etc.) before the return, the entire function body is wrapped:
 
-```tsx
+```tsx displayComments
 // Before
 export default function Demo() {
   const code = useCode();
@@ -172,7 +172,7 @@ Not all demos use `export default`. The rule handles named exports with two stra
 
 All common export forms are recognized: `export function`, `export const` with arrow or function expressions, and call-wrapped patterns like `React.forwardRef` or `React.memo`.
 
-```tsx
+```tsx displayComments
 // CodeEditor.tsx — filename match
 export function CodeEditor() {
   return <Editor />;
@@ -186,7 +186,7 @@ export function getEditorConfig() {
 
 Call-wrapped components work the same way:
 
-```tsx
+```tsx displayComments
 // DialogTrigger.tsx — React.forwardRef with filename match
 export const DialogTrigger = React.forwardRef(function DialogTrigger(props, ref) {
   return <button ref={ref} {...props} />;

--- a/packages/docs-infra/src/CodeHighlighter/fallbackCompression.test.ts
+++ b/packages/docs-infra/src/CodeHighlighter/fallbackCompression.test.ts
@@ -382,30 +382,38 @@ describe('fallbackCollapsed (visibility split)', () => {
   });
 });
 
-describe('hoisted fallback never clobbers the compression dictionary (trailing-newline regression)', () => {
-  // Real-world crash: an un-highlighted initial load hoists a *raw-string* fallback
-  // (`[rawSource]`) whose text keeps the source's trailing newline. `buildRootFallback`
-  // — the dictionary the encoder used to compress the `hastCompressed` source — drops
-  // that trailing newline, so the two texts differ by exactly one '\n'. When the full
-  // load's compressed source arrives carrying its own structured `fallback`, the hoisted
-  // scatter must NOT overwrite it, or `decodeHastSource` decodes with the wrong dictionary
-  // and throws a dictionary mismatch. This pins the `preserveExisting` guard end-to-end.
-  it('preserves the structured dictionary so a trailing-newline source still decodes', async () => {
+describe('compression dictionary matches the raw source for trailing-newline sources', () => {
+  // Regression history: an un-highlighted initial load hoists a *raw-string*
+  // fallback (`[rawSource]`) whose text keeps the source's trailing newline.
+  // The encoder's dictionary comes from `buildRootFallback`, which previously
+  // DROPPED that trailing newline (the final frame's fallback omitted it), so
+  // the two texts differed by exactly one '\n'. A hoisted scatter overwriting
+  // the structured fallback then made `decodeHastSource` decode with the wrong
+  // dictionary and throw — worked around by the `preserveExisting` guard.
+  //
+  // Root fix (`starryNightGutter`): the final frame's fallback now keeps the
+  // trailing newline when the source ends with one, so `buildRootFallback`
+  // matches the raw source EXACTLY. A hoisted raw fallback can no longer differ
+  // from the dictionary the `hastCompressed` source was compressed with, so
+  // decoding succeeds whether or not it clobbers the structured fallback. The
+  // `preserveExisting` guard is retained as defense and still keeps the
+  // structured fallback in place.
+  it('decodes a trailing-newline source whether the dictionary is clobbered or preserved', async () => {
     const parse = await createParseSource(['App.js']);
     const rawSource = 'const value = compute();\nexport default value;\n'; // ends in a newline
     const root = parse(rawSource, 'App.js');
 
-    // The encoder's dictionary drops the trailing newline...
     const structuredFallback = buildRootFallback(root);
     const dictionary = fallbackToText(structuredFallback);
-    // ...while the raw-string hoisted fallback keeps it — differing by exactly '\n'.
+    // The structured dictionary now matches the raw source exactly — the final
+    // frame keeps the trailing newline — so the raw-string hoisted fallback
+    // produces the same dictionary text.
     const rawHoisted: FallbackNode[] = [rawSource];
-    expect(fallbackToText(rawHoisted)).toBe(`${dictionary}\n`);
-    expect(fallbackToText(rawHoisted)).not.toBe(dictionary);
+    expect(fallbackToText(rawHoisted)).toBe(dictionary);
 
     const compressedBytes = compressHast(JSON.stringify(root), dictionary);
     // Distinct source objects so `decodeHastSource`'s identity cache never bridges the
-    // two cases (a cached success would mask the mismatch on the other).
+    // two cases.
     const sourceForClobber = { hastCompressed: compressedBytes };
     const sourceForRestore = { hastCompressed: compressedBytes };
     const wireCode: Code = {
@@ -413,14 +421,14 @@ describe('hoisted fallback never clobbers the compression dictionary (trailing-n
     };
     const hoisted: ResidualFallbacks = { javascript: { 'App.js': rawHoisted } };
 
-    // Without the guard, the hoisted scatter overwrites the structured dictionary with
-    // the raw string, and the compressed source can no longer be decoded.
+    // Even when the hoisted scatter overwrites the structured dictionary with the
+    // raw string, the dictionary text is identical, so decoding still succeeds.
     const clobbered = scatterResidualFallbacks(wireCode, hoisted);
     const clobberedFallback = (clobbered.javascript as { fallback?: FallbackNode[] }).fallback;
     expect(clobberedFallback).toEqual(rawHoisted);
-    expect(() => decodeHastSource(sourceForClobber, clobberedFallback)).toThrow(/dictionary/i);
+    expect(() => decodeHastSource(sourceForClobber, clobberedFallback)).not.toThrow();
 
-    // With `preserveExisting`, the source-paired structured dictionary survives and decodes.
+    // `preserveExisting` still keeps the source-paired structured dictionary in place.
     const restored = scatterResidualFallbacks(wireCode, hoisted, true);
     const restoredFallback = (restored.javascript as { fallback?: FallbackNode[] }).fallback;
     expect(restoredFallback).toBe(structuredFallback);

--- a/packages/docs-infra/src/CodeHighlighter/types.ts
+++ b/packages/docs-infra/src/CodeHighlighter/types.ts
@@ -210,7 +210,10 @@ export type Code = { [key: string]: undefined | string | VariantCode }; // TODO:
  * were deleted. Keyed by the line they collapsed onto; each entry records
  * the original offset from the edit line so the collapse can be reversed.
  */
-export type CollapseMap = Record<number, Array<{ offset: number; comments: string[] }>>;
+export type CollapseMap = Record<
+  number,
+  Array<{ offset: number; comments: string[]; boundary?: true }>
+>;
 
 export type ControlledVariantExtraFiles = {
   [fileName: string]: {

--- a/packages/docs-infra/src/pipeline/hastUtils/hastCompression.test.ts
+++ b/packages/docs-infra/src/pipeline/hastUtils/hastCompression.test.ts
@@ -485,6 +485,13 @@ describe('hastCompression', () => {
         expect(result).not.toBe(SAMPLE_HAST_JSON);
       });
 
+      it('throws a descriptive dictionary error (not a raw fflate code) when compressed with a dictionary but decompressed without', () => {
+        const compressed = compressHast(SAMPLE_HAST_JSON, TEXT_CONTENT);
+        // Previously this surfaced as `{"code":0}` once stringified; now it names
+        // the missing fallback dictionary as the likely cause.
+        expect(() => decompressHast(compressed)).toThrow(/fallback dictionary/i);
+      });
+
       it('rejects when textContent differs', async () => {
         const compressed = compressHast(SAMPLE_HAST_JSON, TEXT_CONTENT);
         await expect(decompressHastAsync(compressed, 'wrong text')).rejects.toThrow(

--- a/packages/docs-infra/src/pipeline/hastUtils/hastDecompress.ts
+++ b/packages/docs-infra/src/pipeline/hastUtils/hastDecompress.ts
@@ -25,10 +25,24 @@ export function decompressHast(base64: string, textContent?: string): string {
 
   if (textContent != null) {
     verifyChecksum(raw, dictionary);
-    return strFromU8(inflateSync(raw.subarray(CHECKSUM_BYTES), { dictionary }));
   }
 
-  return strFromU8(inflateSync(raw, { dictionary }));
+  try {
+    const deflated = textContent != null ? raw.subarray(CHECKSUM_BYTES) : raw;
+    return strFromU8(inflateSync(deflated, { dictionary }));
+  } catch (error) {
+    // A raw inflate failure (e.g. fflate's "unexpected EOF") is almost always a
+    // payload that was compressed with a fallback dictionary being decoded
+    // without one — the checksum prefix is then read as deflate data. Surface
+    // that cause instead of the cryptic `{code:0}` the raw error stringifies to.
+    throw new Error(
+      `Failed to decompress payload${
+        textContent == null
+          ? ' — if it was compressed with a fallback dictionary, that dictionary must be provided'
+          : ''
+      }: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
 }
 
 /**

--- a/packages/docs-infra/src/pipeline/hastUtils/hastUtils.tsx
+++ b/packages/docs-infra/src/pipeline/hastUtils/hastUtils.tsx
@@ -33,13 +33,17 @@ export function hastOrJsonToJsx(
     try {
       hast = JSON.parse(hastOrJson.hastJson);
     } catch (error) {
-      throw new Error(`Failed to parse hastJson: ${JSON.stringify(error)}`);
+      throw new Error(
+        `Failed to parse hastJson: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   } else if ('hastCompressed' in hastOrJson) {
     try {
       hast = JSON.parse(decompressHast(hastOrJson.hastCompressed, fallbackDictionary(fallback)));
     } catch (error) {
-      throw new Error(`Failed to parse hastCompressed: ${JSON.stringify(error)}`);
+      throw new Error(
+        `Failed to parse hastCompressed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   } else {
     hast = hastOrJson;
@@ -61,13 +65,17 @@ export function stringOrHastToString(
     try {
       hast = JSON.parse(source.hastJson);
     } catch (error) {
-      throw new Error(`Failed to parse hastJson: ${JSON.stringify(error)}`);
+      throw new Error(
+        `Failed to parse hastJson: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   } else if ('hastCompressed' in source) {
     try {
       hast = JSON.parse(decompressHast(source.hastCompressed, fallbackDictionary(fallback)));
     } catch (error) {
-      throw new Error(`Failed to parse hastCompressed: ${JSON.stringify(error)}`);
+      throw new Error(
+        `Failed to parse hastCompressed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   } else {
     hast = source;
@@ -91,13 +99,17 @@ export function stringOrHastToJsx(
     try {
       hast = JSON.parse(source.hastJson);
     } catch (error) {
-      throw new Error(`Failed to parse hastJson: ${JSON.stringify(error)}`);
+      throw new Error(
+        `Failed to parse hastJson: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   } else if ('hastCompressed' in source) {
     try {
       hast = JSON.parse(decompressHast(source.hastCompressed, fallbackDictionary(fallback)));
     } catch (error) {
-      throw new Error(`Failed to parse hastCompressed: ${JSON.stringify(error)}`);
+      throw new Error(
+        `Failed to parse hastCompressed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   } else {
     hast = source;

--- a/packages/docs-infra/src/pipeline/lintJavascriptDemoFocus/lintJavascriptDemoFocus.test.ts
+++ b/packages/docs-infra/src/pipeline/lintJavascriptDemoFocus/lintJavascriptDemoFocus.test.ts
@@ -494,7 +494,7 @@ export function Primary() {
 }`,
           output: `export default function Demo() {
   return (
-    // @focus
+    // @focus @padding 2
     <Button>Click me</Button>
   );
 }`,
@@ -510,7 +510,7 @@ export function Primary() {
 }`,
           output: `export default function Demo() {
   return (
-    // @focus
+    // @focus @padding 2
     <Checkbox defaultChecked />
   );
 }`,
@@ -526,7 +526,7 @@ export function Primary() {
 }`,
           output: `export default function Demo() {
   return (
-    // @focus-start
+    // @focus-start @padding 2
     <Card>
     <Button>Click</Button>
   </Card>
@@ -564,7 +564,7 @@ export function Primary() {
 }`,
           output: `export function CheckboxRed() {
   return (
-    // @focus
+    // @focus @padding 2
     <Checkbox defaultChecked />
   );
 }`,
@@ -575,7 +575,7 @@ export function Primary() {
           options: [{ wrapReturn: true }],
           code: `export default () => <Button>Click</Button>`,
           output: `export default () => (
-  // @focus
+  // @focus @padding 2
   <Button>Click</Button>
 )`,
           errors: [{ messageId: 'missingDemoFocusJsSingle' }],
@@ -586,7 +586,7 @@ export function Primary() {
           filename: 'CheckboxRed.tsx',
           code: `export const CheckboxRed = () => <Checkbox defaultChecked />;`,
           output: `export const CheckboxRed = () => (
-  // @focus
+  // @focus @padding 2
   <Checkbox defaultChecked />
 );`,
           errors: [{ messageId: 'missingDemoFocusJsSingle' }],

--- a/packages/docs-infra/src/pipeline/lintJavascriptDemoFocus/lintJavascriptDemoFocus.ts
+++ b/packages/docs-infra/src/pipeline/lintJavascriptDemoFocus/lintJavascriptDemoFocus.ts
@@ -352,7 +352,10 @@ function reportPreview(
         const hasParens = hasReturnParens(sourceCode, returnStatement);
 
         if (hasParens) {
-          // Already `return (...)` — just insert the comment inside
+          // Already `return (...)` — just insert the comment inside. The focus
+          // sits one level deeper than the function body, so `@padding 2` keeps
+          // the `return (` line and the function signature/closing brace visible
+          // as context when collapsed.
           const lineStartOffset = sourceCode.getIndexFromLoc({
             line: firstNode.loc.start.line,
             column: 0,
@@ -360,7 +363,7 @@ function reportPreview(
           if (isSingleLine) {
             return fixer.insertTextBeforeRange(
               [lineStartOffset, lineStartOffset],
-              `${indentation}// @focus\n`,
+              `${indentation}// @focus @padding 2\n`,
             );
           }
           const lastLineStartOffset = sourceCode.getIndexFromLoc({
@@ -372,7 +375,7 @@ function reportPreview(
           return [
             fixer.insertTextBeforeRange(
               [lineStartOffset, lineStartOffset],
-              `${indentation}// @focus-start\n`,
+              `${indentation}// @focus-start @padding 2\n`,
             ),
             fixer.insertTextAfterRange(
               [lastLineStartOffset, lastLineStartOffset + lastLine.length],
@@ -391,7 +394,7 @@ function reportPreview(
           return [
             fixer.replaceTextRange(
               [returnKeywordEnd, firstNode.range[0]],
-              ` (\n${innerIndentation}// @focus\n${innerIndentation}`,
+              ` (\n${innerIndentation}// @focus @padding 2\n${innerIndentation}`,
             ),
             fixer.insertTextAfterRange(lastNode.range, `\n${returnIndentation})`),
           ];
@@ -399,7 +402,7 @@ function reportPreview(
         return [
           fixer.replaceTextRange(
             [returnKeywordEnd, firstNode.range[0]],
-            ` (\n${innerIndentation}// @focus-start\n${innerIndentation}`,
+            ` (\n${innerIndentation}// @focus-start @padding 2\n${innerIndentation}`,
           ),
           fixer.insertTextAfterRange(
             lastNode.range,
@@ -420,7 +423,7 @@ function reportPreview(
             return [
               fixer.replaceTextRange(
                 [arrowToken.range[1], firstNode.range[0]],
-                ` (\n${innerIndentation}// @focus\n${innerIndentation}`,
+                ` (\n${innerIndentation}// @focus @padding 2\n${innerIndentation}`,
               ),
               fixer.insertTextAfterRange(lastNode.range, `\n${arrowIndentation})`),
             ];
@@ -428,7 +431,7 @@ function reportPreview(
           return [
             fixer.replaceTextRange(
               [arrowToken.range[1], firstNode.range[0]],
-              ` (\n${innerIndentation}// @focus-start\n${innerIndentation}`,
+              ` (\n${innerIndentation}// @focus-start @padding 2\n${innerIndentation}`,
             ),
             fixer.insertTextAfterRange(
               lastNode.range,

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSource.test.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSource.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { compressHast } from '../hastUtils';
+import { fallbackToText, type FallbackNode } from '../../CodeHighlighter/fallbackFormat';
+import type { HastRoot } from '../../CodeHighlighter/types';
+import { decodeHastSource } from './decodeHastSource';
+import { decodeSource } from './decodeSource';
+
+const sampleRoot: HastRoot = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'pre',
+      properties: {},
+      children: [{ type: 'text', value: ':root {\n  color: red;\n}\n' }],
+    },
+  ],
+};
+
+// The DEFLATE dictionary for a compressed source is the file's fallback text.
+const sampleFallback: FallbackNode[] = [':root {\n  color: red;\n}\n'];
+
+describe('decodeSource', () => {
+  it('returns a string source unchanged without needing a fallback', () => {
+    expect(decodeSource('export const value = 1;\n')).toBe('export const value = 1;\n');
+  });
+
+  it('decodes a hastJson source to a live HastRoot (not a serialized payload)', () => {
+    const decoded = decodeSource({ hastJson: JSON.stringify(sampleRoot) });
+    expect(decoded).toMatchObject({ type: 'root' });
+    expect(decoded).not.toHaveProperty('hastJson');
+    expect(decoded).toEqual(sampleRoot);
+  });
+
+  it('decodes a hastCompressed source to a live HastRoot using its fallback dictionary', () => {
+    const source = {
+      hastCompressed: compressHast(JSON.stringify(sampleRoot), fallbackToText(sampleFallback)),
+    };
+    const decoded = decodeSource(source, sampleFallback);
+    expect(decoded).toMatchObject({ type: 'root' });
+    expect(decoded).not.toHaveProperty('hastCompressed');
+    expect(decoded).toEqual(sampleRoot);
+  });
+
+  it('throws a descriptive dictionary error when a hastCompressed source is decoded without its fallback', () => {
+    const source = {
+      hastCompressed: compressHast(JSON.stringify(sampleRoot), fallbackToText(sampleFallback)),
+    };
+    expect(() => decodeSource(source)).toThrow(/fallback dictionary/i);
+  });
+
+  it('returns an owned clone, not the shared read-only cache tree', () => {
+    const source = { hastJson: JSON.stringify(sampleRoot) };
+    const shared = decodeHastSource(source);
+    const owned = decodeSource(source);
+    // Same content, but a distinct object the caller can safely mutate.
+    expect(owned).toEqual(shared);
+    expect(owned).not.toBe(shared);
+
+    if (owned && typeof owned === 'object' && 'children' in owned) {
+      owned.children = [];
+    }
+    // Mutating the clone leaves the shared cache tree intact.
+    expect(decodeHastSource(source)).toBe(shared);
+    expect(shared).toEqual(sampleRoot);
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSource.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSource.ts
@@ -1,0 +1,28 @@
+import type { VariantSource } from '../../CodeHighlighter/types';
+import type { FallbackNode } from '../../CodeHighlighter/fallbackFormat';
+import { decodeHastSource } from './decodeHastSource';
+
+/**
+ * Decode a `VariantSource` into a form that carries no serialization: a plain
+ * string stays a string, while a serialized `hastCompressed` / `hastJson`
+ * payload (or a live `HastRoot`) resolves to a live `HastRoot`. The
+ * `{ hastJson }` / `{ hastCompressed }` shapes never leak out, so consumers can
+ * read the source as text (`stringOrHastToString`) or inspect / transform the
+ * HAST tree directly without handling a DEFLATE dictionary.
+ *
+ * Decoding reuses the shared `decodeHastSource` cache — so a source already
+ * decoded for rendering is not inflated again — then returns a
+ * `structuredClone` of the tree. The clone matters: `decodeHastSource` hands
+ * back a read-only tree shared with the live render, and the result here is
+ * handed to user code (the `transformVariant` hook), which must be able to
+ * mutate it without corrupting that shared tree. `fallback` is the DEFLATE
+ * dictionary for a `hastCompressed` source.
+ */
+export function decodeSource(source: VariantSource, fallback?: FallbackNode[]): VariantSource {
+  if (typeof source === 'string') {
+    return source;
+  }
+
+  const root = decodeHastSource(source, fallback);
+  return root ? structuredClone(root) : source;
+}

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSourceToText.test.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSourceToText.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { compressHast } from '../hastUtils';
+import { fallbackToText, type FallbackNode } from '../../CodeHighlighter/fallbackFormat';
+import type { HastRoot } from '../../CodeHighlighter/types';
+import { decodeSourceToText } from './decodeSourceToText';
+
+const sampleRoot: HastRoot = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'pre',
+      properties: {},
+      children: [{ type: 'text', value: ':root {\n  color: red;\n}\n' }],
+    },
+  ],
+};
+
+// The DEFLATE dictionary for a compressed source is the file's fallback text.
+const sampleFallback: FallbackNode[] = [':root {\n  color: red;\n}\n'];
+const sampleText = ':root {\n  color: red;\n}\n';
+
+describe('decodeSourceToText', () => {
+  it('returns a string source unchanged without needing a fallback', () => {
+    expect(decodeSourceToText('export const value = 1;\n')).toBe('export const value = 1;\n');
+  });
+
+  it('resolves null / undefined sources to an empty string', () => {
+    expect(decodeSourceToText(null)).toBe('');
+    expect(decodeSourceToText(undefined)).toBe('');
+  });
+
+  it('decodes a hastJson source to its text', () => {
+    expect(decodeSourceToText({ hastJson: JSON.stringify(sampleRoot) })).toBe(sampleText);
+  });
+
+  it('decodes a hastCompressed source using its co-located fallback dictionary', () => {
+    const source = {
+      hastCompressed: compressHast(JSON.stringify(sampleRoot), fallbackToText(sampleFallback)),
+    };
+    expect(decodeSourceToText(source, sampleFallback)).toBe(sampleText);
+  });
+
+  it('returns the text of a live HastRoot', () => {
+    expect(decodeSourceToText(sampleRoot)).toBe(sampleText);
+  });
+
+  it('throws a descriptive dictionary error when a hastCompressed source is decoded without its fallback', () => {
+    const source = {
+      hastCompressed: compressHast(JSON.stringify(sampleRoot), fallbackToText(sampleFallback)),
+    };
+    // No `{"code":0}` — the message names the missing dictionary as the cause.
+    expect(() => decodeSourceToText(source)).toThrow(/fallback dictionary/i);
+  });
+
+  it('reuses the shared decode cache for repeated calls on the same payload object', () => {
+    const source = { hastJson: JSON.stringify(sampleRoot) };
+    expect(decodeSourceToText(source)).toBe(sampleText);
+    // A second call hits the WeakMap in `decodeHastSource` and yields the same text.
+    expect(decodeSourceToText(source)).toBe(sampleText);
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSourceToText.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/decodeSourceToText.ts
@@ -1,0 +1,30 @@
+import { toText } from 'hast-util-to-text';
+import type { VariantSource } from '../../CodeHighlighter/types';
+import type { FallbackNode } from '../../CodeHighlighter/fallbackFormat';
+import { decodeHastSource } from './decodeHastSource';
+
+/**
+ * Decode a `VariantSource` to its plain text, reusing the shared
+ * `decodeHastSource` cache so a `hastCompressed` / `hastJson` payload that was
+ * already decoded for rendering is not inflated and parsed a second time.
+ *
+ * String sources are returned unchanged and need no `fallback`. For an encoded
+ * source, `fallback` supplies the DEFLATE dictionary required to decode a
+ * `hastCompressed` payload (the file's compact fallback text); omitting it for
+ * such a payload surfaces a descriptive error from `decodeHastSource` rather
+ * than a cryptic inflate failure.
+ *
+ * `null` / `undefined` sources resolve to an empty string so callers can treat
+ * a missing source the same as an empty file.
+ */
+export function decodeSourceToText(
+  source: VariantSource | null | undefined,
+  fallback?: FallbackNode[],
+): string {
+  if (source == null || typeof source === 'string') {
+    return source ?? '';
+  }
+
+  const root = decodeHastSource(source, fallback);
+  return root ? toText(root, { whitespace: 'pre' }) : '';
+}

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/flattenCodeVariant.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/flattenCodeVariant.ts
@@ -5,7 +5,7 @@
  */
 
 import type { VariantCode } from '../../CodeHighlighter/types';
-import { stringOrHastToString } from '../hastUtils';
+import { decodeSourceToText } from './decodeSourceToText';
 import { addPathsToVariant } from './addCodeVariantPaths';
 
 export interface FlatFile {
@@ -32,8 +32,9 @@ export function flattenCodeVariant(variant: VariantCode): FlattenedFiles {
   if (variantWithPaths.path && variantWithPaths.source !== undefined) {
     result[variantWithPaths.path] = {
       // The source may be `hastCompressed`; its `fallback` is the DEFLATE
-      // dictionary needed to decode it back to text.
-      source: stringOrHastToString(variantWithPaths.source, variantWithPaths.fallback),
+      // dictionary needed to decode it back to text. `decodeSourceToText` reuses
+      // the shared decode cache rather than re-inflating on every export.
+      source: decodeSourceToText(variantWithPaths.source, variantWithPaths.fallback),
     };
   }
 
@@ -51,7 +52,7 @@ export function flattenCodeVariant(variant: VariantCode): FlattenedFiles {
       }
 
       result[fileWithPath.path] = {
-        source: stringOrHastToString(fileWithPath.source || '', fileWithPath.fallback),
+        source: decodeSourceToText(fileWithPath.source, fileWithPath.fallback),
         ...(fileWithPath.metadata && { metadata: fileWithPath.metadata }),
       };
     }

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.test.ts
@@ -605,6 +605,51 @@ describe('starryNightGutter', () => {
     }
   });
 
+  // The per-frame fallback must match the highlighted render's text exactly, or
+  // the frame jumps height when it swaps from plain text to highlighted spans.
+  // Non-final frames always end with the line separator; the final frame ends
+  // with one only when the source itself does.
+  it('omits the trailing newline on the final frame when the source has none', () => {
+    const lines = ['a', 'b', 'c', 'd', 'e'];
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'text', value: lines.join('\n') }],
+    };
+
+    starryNightGutter(tree, lines, 3);
+
+    expect(tree.children).toHaveLength(2);
+    const [firstFrame, secondFrame] = tree.children;
+    if (firstFrame.type === 'element') {
+      expect(firstFrame.data?.fallback).toEqual([{ type: 'text', value: 'a\nb\nc\n' }]);
+    }
+    if (secondFrame.type === 'element') {
+      expect(secondFrame.data?.fallback).toEqual([{ type: 'text', value: 'd\ne' }]);
+    }
+  });
+
+  it('keeps the trailing newline on the final frame when the source ends with one', () => {
+    // `['a','b','c','d',''].join('\n')` === `'a\nb\nc\nd\n'` — a source that ends
+    // with a newline. The final frame (line `d`) is followed by that newline in
+    // the render, so its fallback must keep the trailing `\n`.
+    const lines = ['a', 'b', 'c', 'd', ''];
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'text', value: lines.join('\n') }],
+    };
+
+    starryNightGutter(tree, lines, 3);
+
+    expect(tree.children).toHaveLength(2);
+    const [firstFrame, secondFrame] = tree.children;
+    if (firstFrame.type === 'element') {
+      expect(firstFrame.data?.fallback).toEqual([{ type: 'text', value: 'a\nb\nc\n' }]);
+    }
+    if (secondFrame.type === 'element') {
+      expect(secondFrame.data?.fallback).toEqual([{ type: 'text', value: 'd\n' }]);
+    }
+  });
+
   // Test that totalLines is correctly set
   it('should set totalLines in root data', () => {
     const tree: Root = {

--- a/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/addLineGutters.ts
@@ -174,7 +174,17 @@ export function starryNightGutter(
           const startLine = Number(lineChildren[0].properties.dataLn) - 1;
           const endLine = Number(lineChildren[lineChildren.length - 1].properties.dataLn);
           const joined = sourceLines.slice(startLine, endLine).join('\n');
-          const text = frameIndex < lastIndex ? `${joined}\n` : joined;
+          // Non-final frames are always followed by more content, so their text
+          // ends with the line separator. The final frame's text ends with a
+          // newline only when the source itself does — mirroring the highlighted
+          // render, whose last `.line` span is then followed by a trailing `\n`
+          // text node. `sourceLines` has one more entry than `lineNumber` exactly
+          // when the source ended with a newline (the empty segment after it
+          // never became a line). This keeps the plain-text fallback the same
+          // height as the highlighted render (no hydration jump) AND makes the
+          // root fallback dictionary an exact match for the raw source text.
+          const sourceEndsWithNewline = sourceLines.length > lineNumber;
+          const text = frameIndex < lastIndex || sourceEndsWithNewline ? `${joined}\n` : joined;
           // Cast to `ElementData` because `hast-util-from-parse5` augments
           // it with a required `position` field (upstream bug — should be
           // optional). We're not running through that parser here, so the

--- a/packages/docs-infra/src/useCode/EditableEngine.ts
+++ b/packages/docs-infra/src/useCode/EditableEngine.ts
@@ -1613,7 +1613,14 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           });
         }
       } else if (
-        boundsRef.current.caretSelector !== undefined &&
+        // Gate on the rendered structure (`.line` spans carry `data-ln`), NOT on
+        // `boundsRef.current.caretSelector`: the host drops `caretSelector` to
+        // undefined whenever `shouldHighlight` is false (an EXPANDED block, or a
+        // post-edit re-highlight in flight), yet the `.line`/frame structure
+        // persists. The old live-`caretSelector` check silently disabled this
+        // whole branch in those states, leaving native Shift+Arrow to stall on
+        // the zero-height empty lines this branch exists to step over.
+        element.querySelector('[data-ln]') !== null &&
         event.shiftKey &&
         !event.metaKey &&
         !event.ctrlKey &&
@@ -1638,7 +1645,7 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           const beforeFocus = focusProbe.toString();
           const focusRow = beforeFocus.split('\n').length - 1;
           const focusColumn = beforeFocus.length - (beforeFocus.lastIndexOf('\n') + 1);
-          const { prevLine, nextLine, hasNextLine } = getLineInfo(element, focusRow);
+          const { hasNextLine } = getLineInfo(element, focusRow);
           const goingUp = event.key === 'ArrowUp';
           const { minColumn, minRow, maxRow } = boundsRef.current;
           // Don't extend the selection past the collapsed window into the
@@ -1655,8 +1662,17 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           if (atWindowEdge) {
             event.preventDefault();
           } else if (goingUp ? focusRow > 0 : hasNextLine) {
+            event.preventDefault();
+            // Step the focus exactly ONE logical line. Crucially this is row-based
+            // (text newline count), so it advances correctly even across a line
+            // the browser renders at ZERO height — an empty line the CSS collapses
+            // to 0px. Native Shift+Arrow stalls there (it works in visual space and
+            // a zero-height line has none), which is the "two Shift+Downs land on
+            // the same line / can't get past the empty line" bug. We step in
+            // logical space and `extend` to a real offset, so each press advances
+            // one line, empty or not.
             const targetRow = goingUp ? focusRow - 1 : focusRow + 1;
-            const targetLine = goingUp ? prevLine : nextLine;
+            const targetLine = getLineInfo(element, targetRow).currentLine;
             let targetColumn = Math.min(focusColumn, targetLine.length);
             if (
               minColumn !== undefined &&
@@ -1666,10 +1682,11 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             ) {
               targetColumn = minColumn;
             }
-            const targetOffset = getOffsetAtLineColumn(element, targetRow, targetColumn);
-            const targetRange = makeRange(element, targetOffset);
+            const targetRange = makeRange(
+              element,
+              getOffsetAtLineColumn(element, targetRow, targetColumn),
+            );
             adjustCursorAtNewlineBoundary(targetRange);
-            event.preventDefault();
             sel.extend(targetRange.startContainer, targetRange.startOffset);
             // Keep the tracked selection in sync so a host re-render's restore
             // preserves the extended range instead of snapping it back.

--- a/packages/docs-infra/src/useCode/EditableEngine.ts
+++ b/packages/docs-infra/src/useCode/EditableEngine.ts
@@ -35,7 +35,7 @@ SOFTWARE.
 // - Repeat-key flush debouncing so syntax re-highlight fires once on key release
 // - Resync (instead of block) on stale-DOM arrow keys so navigation isn't eaten after a pending edit
 // - adjustCursorAtNewlineBoundary applied to all programmatic caret placements; getState() returns an empty snapshot pre-mount
-// - New `minColumn` option: skip clipped indent gutter via arrow navigation, click, and tab-focus; Backspace on a fully-clipped blank line collapses the line
+// - New `minColumn` option: skip clipped indent gutter via arrow navigation, click, and tab-focus; Backspace on a fully-clipped blank line clears the whole hidden indent (caret stays on the line at column 0)
 // - New `minRow`/`maxRow`/`onBoundary` options: arrow navigation past the visible region invokes the callback (and falls through natively when provided so hosts can expand collapsed regions)
 // - New `caretSelector` option: synchronous horizontal line-wrap and post-arrow rAF snap to lift the caret out of inter-line gap text nodes (e.g. `\n` between `.line` spans)
 // - Override copy/cut: write `Range.toString()` for `text/plain` (avoids duplicated newlines from block-level line wrappers) and an inline-styled `<pre>` clone for `text/html`; strip the clipped indent gutter from both payloads when `minColumn` is set
@@ -978,6 +978,30 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
       edit.move({ row: position.line, column: minColumn });
     };
 
+    // The most recent non-empty `caretSelector`. The host may briefly drop it
+    // (e.g. `shouldHighlight` flips false while the post-edit re-highlight is in
+    // flight), but the rendered `.line` structure persists across that window,
+    // so we latch the selector to keep framed-line handling stable mid-edit.
+    let latchedCaretSelector: string | undefined = boundsRef.current.caretSelector;
+
+    // True when this is a framed (`caretSelector`) editor — i.e. the content is
+    // rendered as `.line` spans inside `.frame` wrappers separated by inter-line
+    // gap text nodes. Native plaintext-only typing at a `.line`/gap boundary
+    // lands the character in the `.frame` wrapper instead, flattening the line
+    // spans and splitting input across rows (which then strands the caret at the
+    // line start on Backspace). Routing every printable key through the
+    // controlled `edit.insert` keeps the character inside its line span. We key
+    // off the *latched* selector (not the live caret position) because the caret
+    // can momentarily sit in a gap node mid-edit and the host briefly drops
+    // `caretSelector` while a post-edit re-highlight is in flight.
+    const framedEditorActive = (): boolean => {
+      const configured = boundsRef.current.caretSelector;
+      if (configured !== undefined) {
+        latchedCaretSelector = configured;
+      }
+      return latchedCaretSelector !== undefined;
+    };
+
     const onKeyDown = (event: HTMLElementEventMap['keydown']) => {
       if (event.defaultPrevented || event.target !== element) {
         return;
@@ -1088,10 +1112,22 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         const index = match ? match.index : position.content.length;
         const text = `\n${position.content.slice(0, index)}`;
         edit.insert(text);
-      } else if (!hasPlaintextSupport && !event.isComposing && isPlaintextInputKey(event)) {
+      } else if (
+        !event.isComposing &&
+        isPlaintextInputKey(event) &&
+        (!hasPlaintextSupport || framedEditorActive())
+      ) {
         // Firefox Quirk: native typing in contentEditable="true" can insert
         // directly into the frame wrapper before the current line span.
-        // Route plain text input through the controlled insert path instead.
+        //
+        // Chromium/WebKit (plaintext-only) Quirk: native typing at the END of a
+        // framed `.line` (the boundary with the inter-line gap text node)
+        // likewise lands the character in the `.frame` wrapper, flattening the
+        // line spans and splitting subsequent input onto the next row — which
+        // then strands the caret at the line start on the next Backspace.
+        //
+        // Route plain text input through the controlled insert path in both
+        // cases so the character lands inside the current line span.
         event.preventDefault();
         edit.insert(event.key);
       } else if ((!hasPlaintextSupport || config.indentation) && event.key === 'Backspace') {
@@ -1105,29 +1141,30 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           const position = getPosition(element);
           const { minColumn } = boundsRef.current;
           // When the caret sits at `minColumn` on a blank (whitespace-only)
-          // line inside a clipped indent gutter, a normal Backspace would
-          // step into `[0, minColumn)` — visually invisible to the user
-          // since that range is hidden by the host. The user has nothing
-          // useful to delete on this line, so collapse the entire blank
-          // line and land the caret at the end of the previous line. This
-          // matches the mental model: "Backspace from an empty indented
-          // line removes the line."
+          // line inside a clipped indent gutter, a single-character Backspace
+          // would step into `[0, minColumn)` — visually invisible to the user
+          // since that range is hidden by the host. Clearing one indent unit
+          // at a time would leave the caret stranded in that hidden gutter.
+          // Instead, clear the WHOLE clipped indent in one Backspace so the
+          // line becomes truly empty and the caret lands at its visible
+          // column 0 — keeping the caret on the same line rather than
+          // collapsing the line and jumping it up to the previous one.
           //
           // Walk only enough text nodes to read the current line — we
           // don't need the rest of the document on every Backspace.
-          const couldCollapse =
+          const clearsClippedIndent =
             minColumn !== undefined &&
             minColumn > 0 &&
             position.line > 0 &&
             position.content.length === minColumn &&
             /^\s*$/.test(position.content);
-          if (couldCollapse && minColumn !== undefined) {
+          if (clearsClippedIndent && minColumn !== undefined) {
             // The redundant `minColumn !== undefined` check pins TS's
             // narrowing across the boundary so we can use `minColumn`
             // as a number directly without an assertion.
             const fullLine = getLineInfo(element, position.line).currentLine;
             if (fullLine.length === minColumn && /^\s*$/.test(fullLine)) {
-              edit.insert('', -(minColumn + 1));
+              edit.insert('', -minColumn);
               return;
             }
           }
@@ -1228,6 +1265,13 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
               targetColumn = minColumn;
             }
             edit.move({ row: targetRow, column: targetColumn });
+            // Refresh the tracked caret to the new position. Arrow navigation
+            // otherwise never updates `state.position` (it is only seeded on
+            // click/focus and edits), so a host re-render triggered by
+            // `onBoundary` (e.g. expanding a collapsed block) would restore the
+            // stale pre-navigation position — snapping the caret back to where
+            // the user last clicked instead of where the arrow key left it.
+            state.position = getPosition(element);
           };
 
           if (event.key === 'ArrowUp') {
@@ -1252,6 +1296,25 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
               } else {
                 event.preventDefault();
               }
+            } else if (
+              caretSelector !== undefined &&
+              position.line > 0 &&
+              (prevLine.length === 0 || lineText.length === 0)
+            ) {
+              // Zero-height blank lines (`.line` blocks with no content) are
+              // skipped by the browser's native vertical navigation, so a
+              // single ArrowUp can jump over one or more blank rows. Step
+              // exactly one logical line up synchronously — preventing the
+              // native skip so the user never sees the caret land on the wrong
+              // line first — whenever the row we leave or the row we enter is
+              // blank. Gated on `caretSelector` (not `caretInLine`) because a
+              // caret sitting *on* a blank line lives in the inter-line gap
+              // text node, not inside a `.line`, so `caretInLine` is false
+              // there; the logical row from `getPosition` stays accurate.
+              // Non-blank rows fall through to native handling so wrapped
+              // visual lines keep behaving natively.
+              event.preventDefault();
+              moveToLine(position.line - 1, prevLine, column);
             }
           } else if (event.key === 'ArrowDown') {
             if (atVisibleEnd) {
@@ -1268,6 +1331,15 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
               } else {
                 event.preventDefault();
               }
+            } else if (
+              caretSelector !== undefined &&
+              hasNextLine &&
+              (nextLine.length === 0 || lineText.length === 0)
+            ) {
+              // Mirror of ArrowUp: step onto the blank row the browser would
+              // otherwise skip. See the ArrowUp branch above.
+              event.preventDefault();
+              moveToLine(position.line + 1, nextLine, column);
             }
           } else if (event.key === 'ArrowLeft') {
             if (atVisibleStart && atLineStart) {

--- a/packages/docs-infra/src/useCode/EditableEngine.ts
+++ b/packages/docs-infra/src/useCode/EditableEngine.ts
@@ -695,10 +695,20 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
       state.disconnected = true;
     };
 
-    const flushChanges = (ignoreTimestamp?: boolean, bypassPreParse?: boolean) => {
+    const flushChanges = (
+      ignoreTimestamp?: boolean,
+      bypassPreParse?: boolean,
+      positionFlags?: Partial<Position>,
+    ) => {
       const records = observerRef.current?.takeRecords() ?? [];
       state.queue.push(...records);
       const position = getPosition(element);
+      // Caller-supplied metadata that the post-edit caret can't carry on its own
+      // (e.g. that a selection delete started at column 0). Rides on the reported
+      // position into `onChange`/history so derived state and undo can use it.
+      if (positionFlags) {
+        Object.assign(position, positionFlags);
+      }
       if (state.queue.length) {
         // We DO NOT revert the queued mutations yet — letting them stay in
         // the live DOM means the user's keystroke remains visible while
@@ -1102,7 +1112,15 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           state.onChange(history[1], {
             ...history[0],
             history: event.shiftKey ? 'redo' : 'undo',
-            ...(leavingPosition ? { historyPivotLine: leavingPosition.line } : {}),
+            ...(leavingPosition
+              ? {
+                  historyPivotLine: leavingPosition.line,
+                  // Carry the reversed edit's column-0 flag so the reversal drops
+                  // its anchor by the same line the forward edit did, keeping the
+                  // collapseMap keys aligned across delete↔undo.
+                  deletedFromLineStart: leavingPosition.deletedFromLineStart,
+                }
+              : {}),
           });
         }
         return;
@@ -1142,6 +1160,19 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           state.position = getPosition(element);
           state.skipNextRestore = true;
           onBoundary();
+        } else if (!event.repeat) {
+          // Reconcile synchronously (revert the raw newline, re-render React's
+          // frame structure in one `flushSync`) so an Enter that MOVES an
+          // emphasis frame — e.g. re-splitting a line whose earlier Backspace
+          // merge had scrolled the collapsed window — repositions the window in
+          // the same task as the native insert. Without this the live DOM keeps
+          // the pre-reconcile window position until the keyup flush, a visible
+          // flash. Mirrors the synchronous Backspace-merge path; the keyup flush
+          // then no-ops (content unchanged → `trackState` dedups). Held Enter
+          // (`event.repeat`) keeps the debounced keyup flush so the highlight
+          // re-runs once on release instead of once per repeat.
+          flushChanges(true, true);
+          return;
         }
       } else if (
         !event.isComposing &&
@@ -1180,43 +1211,54 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         const beforePosition = getPosition(element);
         const range = getCurrentRange();
         if (!range.collapsed) {
+          // Whether the selection started at column 0 — i.e. the deletion removes
+          // whole lines from the first line down, so its comment-map anchor sits
+          // one line higher than the post-delete caret (see `deletedFromLineStart`).
+          const deletedFromLineStart = beforePosition.content.length === 0;
           edit.insert('', 0);
-        } else {
-          const position = beforePosition;
-          const { minColumn } = boundsRef.current;
-          // When the caret sits at `minColumn` on a blank (whitespace-only)
-          // line inside a clipped indent gutter, a single-character Backspace
-          // would step into `[0, minColumn)` — visually invisible to the user
-          // since that range is hidden by the host. Clearing one indent unit
-          // at a time would leave the caret stranded in that hidden gutter.
-          // Instead, clear the WHOLE clipped indent in one Backspace so the
-          // line becomes truly empty and the caret lands at its visible
-          // column 0 — keeping the caret on the same line rather than
-          // collapsing the line and jumping it up to the previous one.
-          //
-          // Walk only enough text nodes to read the current line — we
-          // don't need the rest of the document on every Backspace.
-          const clearsClippedIndent =
-            minColumn !== undefined &&
-            minColumn > 0 &&
-            position.line > 0 &&
-            position.content.length === minColumn &&
-            /^\s*$/.test(position.content);
-          let handled = false;
-          if (clearsClippedIndent && minColumn !== undefined) {
-            // The redundant `minColumn !== undefined` check pins TS's
-            // narrowing across the boundary so we can use `minColumn`
-            // as a number directly without an assertion.
-            const fullLine = getLineInfo(element, position.line).currentLine;
-            if (fullLine.length === minColumn && /^\s*$/.test(fullLine)) {
-              edit.insert('', -minColumn);
-              handled = true;
-            }
+          // A multi-line selection delete can natively remove whole `.frame`
+          // wrapper elements (e.g. selecting exactly one emphasis frame). That
+          // detaches nodes React still holds, so its next reconcile throws
+          // `removeChild`/`NotFoundError` and unmounts the whole editor. Reconcile
+          // synchronously (revert the raw mutation, re-render from the new source
+          // in one `flushSync`) so React owns the structural change consistently.
+          flushChanges(true, true, { deletedFromLineStart });
+          return;
+        }
+        // Collapsed caret (the non-collapsed range case returned above).
+        const { minColumn } = boundsRef.current;
+        // When the caret sits at `minColumn` on a blank (whitespace-only)
+        // line inside a clipped indent gutter, a single-character Backspace
+        // would step into `[0, minColumn)` — visually invisible to the user
+        // since that range is hidden by the host. Clearing one indent unit
+        // at a time would leave the caret stranded in that hidden gutter.
+        // Instead, clear the WHOLE clipped indent in one Backspace so the
+        // line becomes truly empty and the caret lands at its visible
+        // column 0 — keeping the caret on the same line rather than
+        // collapsing the line and jumping it up to the previous one.
+        //
+        // Walk only enough text nodes to read the current line — we
+        // don't need the rest of the document on every Backspace.
+        const clearsClippedIndent =
+          minColumn !== undefined &&
+          minColumn > 0 &&
+          beforePosition.line > 0 &&
+          beforePosition.content.length === minColumn &&
+          /^\s*$/.test(beforePosition.content);
+        let handled = false;
+        if (clearsClippedIndent && minColumn !== undefined) {
+          // The redundant `minColumn !== undefined` check pins TS's
+          // narrowing across the boundary so we can use `minColumn`
+          // as a number directly without an assertion.
+          const fullLine = getLineInfo(element, beforePosition.line).currentLine;
+          if (fullLine.length === minColumn && /^\s*$/.test(fullLine)) {
+            edit.insert('', -minColumn);
+            handled = true;
           }
-          if (!handled) {
-            const match = blanklineRe.exec(position.content);
-            edit.insert('', match ? -match[1].length : -1);
-          }
+        }
+        if (!handled) {
+          const match = blanklineRe.exec(beforePosition.content);
+          edit.insert('', match ? -match[1].length : -1);
         }
         // If the deletion left the current line empty, OR merged this line up
         // into the previous one (a Backspace at column 0 deletes the preceding
@@ -1252,10 +1294,15 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         event.preventDefault();
         const range = getCurrentRange();
         if (!range.collapsed) {
+          const deletedFromLineStart = getPosition(element).content.length === 0;
           edit.insert('', 0);
-        } else {
-          edit.insert('', 1);
+          // Same frame-wrapper detach crash as the Backspace branch above: a
+          // multi-line selection delete must reconcile synchronously so React
+          // commits the structural change instead of crashing on a detached node.
+          flushChanges(true, true, { deletedFromLineStart });
+          return;
         }
+        edit.insert('', 1);
         const afterForwardDelete = getPosition(element);
         if (getLineInfo(element, afterForwardDelete.line).currentLine.length === 0) {
           flushChanges(true, true);
@@ -1565,6 +1612,70 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             snapCaretOutOfGapNode(direction, isVertical, preferredColumn);
           });
         }
+      } else if (
+        boundsRef.current.caretSelector !== undefined &&
+        event.shiftKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        (event.key === 'ArrowUp' || event.key === 'ArrowDown')
+      ) {
+        // Shift+Up/Down selection extension in a framed editor (`caretSelector`
+        // set, with non-selectable inter-line gap `\n` text nodes between
+        // `.line` spans). The browser's native vertical selection-extension
+        // skips zero-height blank `.line` spans (a two-line jump) and parks the
+        // focus in a gap node. Step the FOCUS exactly one logical `.line`
+        // synchronously — preserving the anchor — so the selection grows one
+        // line at a time and the focus always lands inside a `.line`.
+        const sel = element.ownerDocument.defaultView?.getSelection();
+        if (sel && sel.rangeCount > 0 && sel.focusNode && element.contains(sel.focusNode)) {
+          // The focus is the moving end; `getPosition` reads the range start
+          // (the anchor on a forward selection), so derive the focus row/column
+          // straight from the live selection's focus.
+          const focusProbe = element.ownerDocument.createRange();
+          focusProbe.setStart(element, 0);
+          focusProbe.setEnd(sel.focusNode, sel.focusOffset);
+          const beforeFocus = focusProbe.toString();
+          const focusRow = beforeFocus.split('\n').length - 1;
+          const focusColumn = beforeFocus.length - (beforeFocus.lastIndexOf('\n') + 1);
+          const { prevLine, nextLine, hasNextLine } = getLineInfo(element, focusRow);
+          const goingUp = event.key === 'ArrowUp';
+          const { minColumn, minRow, maxRow } = boundsRef.current;
+          // Don't extend the selection past the collapsed window into the
+          // zero-height clipped frames above `minRow` / below `maxRow`: the
+          // focus would land in an h=0 region and paint a stray highlight on a
+          // hidden line (and strand the focus in a non-selectable node).
+          // `preventDefault` blocks the native extension too; the user can
+          // expand the window to reach the hidden lines. Mirrors the non-shift
+          // arrow boundary handling, minus the `onBoundary` expand (which would
+          // collapse the in-progress selection on the restore).
+          const atWindowEdge = goingUp
+            ? minRow !== undefined && focusRow <= minRow
+            : maxRow !== undefined && focusRow >= maxRow;
+          if (atWindowEdge) {
+            event.preventDefault();
+          } else if (goingUp ? focusRow > 0 : hasNextLine) {
+            const targetRow = goingUp ? focusRow - 1 : focusRow + 1;
+            const targetLine = goingUp ? prevLine : nextLine;
+            let targetColumn = Math.min(focusColumn, targetLine.length);
+            if (
+              minColumn !== undefined &&
+              targetLine.length >= minColumn &&
+              /^\s*$/.test(targetLine.slice(0, minColumn)) &&
+              targetColumn < minColumn
+            ) {
+              targetColumn = minColumn;
+            }
+            const targetOffset = getOffsetAtLineColumn(element, targetRow, targetColumn);
+            const targetRange = makeRange(element, targetOffset);
+            adjustCursorAtNewlineBoundary(targetRange);
+            event.preventDefault();
+            sel.extend(targetRange.startContainer, targetRange.startOffset);
+            // Keep the tracked selection in sync so a host re-render's restore
+            // preserves the extended range instead of snapping it back.
+            state.position = getPosition(element);
+          }
+        }
       }
 
       // After a controlled edit in plaintext-only contentEditable, the DOM is
@@ -1763,9 +1874,56 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
       state.position = getPosition(element);
     };
 
+    // Pull a non-collapsed selection's focus back inside the collapsed window
+    // when a drag carried it past `minRow`/`maxRow` into a zero-height clipped
+    // frame (the hidden lines above/below the fold). Leaving it there paints a
+    // stray highlight on a line the user can't see. Browsers usually clamp a
+    // drag to the visible content on their own, but autoscroll past the fold can
+    // defeat that — this is the requested fix-on-mouse-up safety net. A no-op
+    // when the focus already rests inside the window.
+    const clampSelectionToWindow = () => {
+      const { minRow, maxRow } = boundsRef.current;
+      if (minRow === undefined && maxRow === undefined) {
+        return;
+      }
+      const sel = element.ownerDocument.defaultView?.getSelection();
+      if (
+        !sel ||
+        sel.rangeCount === 0 ||
+        sel.isCollapsed ||
+        !sel.focusNode ||
+        !element.contains(sel.focusNode)
+      ) {
+        return;
+      }
+      const focusProbe = element.ownerDocument.createRange();
+      focusProbe.setStart(element, 0);
+      focusProbe.setEnd(sel.focusNode, sel.focusOffset);
+      const focusRow = focusProbe.toString().split('\n').length - 1;
+      let targetRow: number | undefined;
+      let targetColumn = 0;
+      if (maxRow !== undefined && focusRow > maxRow) {
+        targetRow = maxRow;
+        targetColumn = getLineInfo(element, maxRow).currentLine.length;
+      } else if (minRow !== undefined && focusRow < minRow) {
+        targetRow = minRow;
+        targetColumn = 0;
+      }
+      if (targetRow === undefined) {
+        return;
+      }
+      const targetOffset = getOffsetAtLineColumn(element, targetRow, targetColumn);
+      const targetRange = makeRange(element, targetOffset);
+      adjustCursorAtNewlineBoundary(targetRange);
+      // `extend` moves only the focus, leaving the drag's anchor put.
+      sel.extend(targetRange.startContainer, targetRange.startOffset);
+    };
+
     const onMouseUp = () => {
-      // First lift the caret out of any inter-line gap node so the
-      // gutter check below can see a real line position.
+      // First pull a drag-selection focus out of the clipped region, then lift
+      // a collapsed caret out of any inter-line gap node so the gutter check
+      // below can see a real line position.
+      clampSelectionToWindow();
       snapCaretOutOfGapNode('forward', false, 0);
       snapCaretOutOfGutter();
       capturePosition();

--- a/packages/docs-infra/src/useCode/EditableEngine.ts
+++ b/packages/docs-infra/src/useCode/EditableEngine.ts
@@ -1158,6 +1158,7 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             position.line > 0 &&
             position.content.length === minColumn &&
             /^\s*$/.test(position.content);
+          let handled = false;
           if (clearsClippedIndent && minColumn !== undefined) {
             // The redundant `minColumn !== undefined` check pins TS's
             // narrowing across the boundary so we can use `minColumn`
@@ -1165,11 +1166,52 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             const fullLine = getLineInfo(element, position.line).currentLine;
             if (fullLine.length === minColumn && /^\s*$/.test(fullLine)) {
               edit.insert('', -minColumn);
-              return;
+              handled = true;
             }
           }
-          const match = blanklineRe.exec(position.content);
-          edit.insert('', match ? -match[1].length : -1);
+          if (!handled) {
+            const match = blanklineRe.exec(position.content);
+            edit.insert('', match ? -match[1].length : -1);
+          }
+        }
+        // If the deletion left the current line empty, the browser has a
+        // zero-height empty `.line` span in the DOM that only disappears once
+        // the change commits and React re-renders the proper blank line. Left
+        // to the keyup flush (or an async re-highlight) the line blinks out and
+        // back — the visible flash when "removing the last part of a line full
+        // of spaces". Reconcile synchronously (bypassing preParse) so the final
+        // structure is in place before the next paint.
+        const afterDelete = getPosition(element);
+        if (getLineInfo(element, afterDelete.line).currentLine.length === 0) {
+          flushChanges(true, true);
+          return;
+        }
+      } else if (
+        (!hasPlaintextSupport || framedEditorActive()) &&
+        event.key === 'Delete' &&
+        !event.shiftKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        // Forward delete, mirroring the Backspace handling. Native plaintext-only
+        // forward-delete is unreliable in framed editors: at a `.line`/gap
+        // boundary it can no-op instead of merging the next line, and when it
+        // empties a line it leaves a zero-height empty `.line` that flashes
+        // before the async re-highlight commits. Route it through the controlled
+        // `edit.insert` so the deletion is predictable, then reconcile
+        // synchronously when the line empties (same flash fix as Backspace).
+        event.preventDefault();
+        const range = getCurrentRange();
+        if (!range.collapsed) {
+          edit.insert('', 0);
+        } else {
+          edit.insert('', 1);
+        }
+        const afterForwardDelete = getPosition(element);
+        if (getLineInfo(element, afterForwardDelete.line).currentLine.length === 0) {
+          flushChanges(true, true);
+          return;
         }
       } else if (config.indentation && event.key === 'Tab') {
         event.preventDefault();
@@ -1345,7 +1387,13 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             if (atVisibleStart && atLineStart) {
               if (caretInLine && position.line > 0) {
                 event.preventDefault();
-                edit.move({ row: position.line - 1, column: prevLine.length });
+                // Use `moveToLine` (not a bare `edit.move`) so `state.position`
+                // is updated to the end of the previous line. Like the ArrowUp /
+                // ArrowDown / ArrowRight boundary branches, `onBoundary` triggers
+                // a host re-render (expand); the per-render caret restore reads
+                // `state.position`, so a stale value would snap the caret back to
+                // the boundary line instead of landing it on the revealed line.
+                moveToLine(position.line - 1, prevLine, prevLine.length);
                 if (onBoundary) {
                   state.skipNextRestore = true;
                   onBoundary();

--- a/packages/docs-infra/src/useCode/EditableEngine.ts
+++ b/packages/docs-infra/src/useCode/EditableEngine.ts
@@ -54,6 +54,7 @@ import {
   isUndoRedoKey,
   makeRange,
   repairUnexpectedLineMerge,
+  restoreSelection,
   setCurrentRange,
   toString,
 } from './useEditableUtils';
@@ -542,10 +543,7 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
     if (state.skipNextRestore) {
       state.skipNextRestore = false;
     } else if (state.position && state.repeatFlushId === null) {
-      const { position, extent } = state.position;
-      const cursorRange = makeRange(elementRef.current, position, position + extent);
-      adjustCursorAtNewlineBoundary(cursorRange);
-      setCurrentRange(cursorRange);
+      restoreSelection(elementRef.current, state.position);
     }
 
     return () => {
@@ -590,10 +588,7 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
     }
     if (state.position) {
       element.focus();
-      const { position, extent } = state.position;
-      const cursorRange = makeRange(element, position, position + extent);
-      adjustCursorAtNewlineBoundary(cursorRange);
-      setCurrentRange(cursorRange);
+      restoreSelection(element, state.position);
     }
 
     const prevWhiteSpace = element.style.whiteSpace;
@@ -1049,10 +1044,7 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           return;
         }
         if (state.position && state.repeatFlushId === null) {
-          const { position, extent } = state.position;
-          const cursorRange = makeRange(element, position, position + extent);
-          adjustCursorAtNewlineBoundary(cursorRange);
-          setCurrentRange(cursorRange);
+          restoreSelection(element, state.position);
         }
         observerRef.current?.observe(element, observerSettings);
         state.disconnected = false;
@@ -1322,8 +1314,8 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             content.slice(start);
         edit.update(newContent);
       } else if (
-        (boundsRef.current.minRow !== undefined || boundsRef.current.maxRow !== undefined) &&
-        (event.key === 'PageDown' || event.key === 'PageUp') &&
+        ((event.key === 'PageDown' && boundsRef.current.maxRow !== undefined) ||
+          (event.key === 'PageUp' && boundsRef.current.minRow !== undefined)) &&
         !event.shiftKey &&
         !event.metaKey &&
         !event.ctrlKey &&
@@ -1334,9 +1326,13 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         // caret into the non-editable padding filler beyond the fold. Instead,
         // move the caret to the far visible edge in the paging direction and ask
         // the host to expand — landing it on a real, now-revealed line. Mirrors
-        // the arrow-at-edge handling; bounded cost (one `getLineInfo` for the
-        // edge line). Only acts on a collapsed selection so Shift-paging
-        // (range extension) stays native.
+        // the arrow-at-edge handling: PageDown engages only when `maxRow` is set
+        // (a bottom fold to protect, like `ArrowDown` at `maxRow`) and PageUp
+        // only when `minRow` is set. With no bound in the press direction there
+        // is no fold to strand into, so the key falls through to native handling
+        // instead of half-engaging. Bounded cost (one `getLineInfo` for the edge
+        // line). Only acts on a collapsed selection so Shift-paging (range
+        // extension) stays native.
         const range = getCurrentRange();
         const { minRow, maxRow, onBoundary } = boundsRef.current;
         if (range.collapsed && onBoundary) {
@@ -1690,7 +1686,23 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             sel.extend(targetRange.startContainer, targetRange.startOffset);
             // Keep the tracked selection in sync so a host re-render's restore
             // preserves the extended range instead of snapping it back.
-            state.position = getPosition(element);
+            const trackedPosition = getPosition(element);
+            // `getPosition` reads the forward-normalized range start and so loses
+            // which end is the focus. Record the direction explicitly: a backward
+            // selection (focus above the anchor) must be rebuilt focus-at-top on
+            // restore, or `addRange` would flip the focus to the bottom and the
+            // next Shift+Arrow would extend from the wrong end. The focus we just
+            // moved sits at the range start exactly when the selection is backward.
+            if (sel.anchorNode && element.contains(sel.anchorNode)) {
+              const anchorProbe = element.ownerDocument.createRange();
+              anchorProbe.setStart(element, 0);
+              anchorProbe.setEnd(sel.anchorNode, sel.anchorOffset);
+              const anchorOffset = anchorProbe.toString().length;
+              if (anchorOffset > trackedPosition.position) {
+                trackedPosition.backward = true;
+              }
+            }
+            state.position = trackedPosition;
           }
         }
       }

--- a/packages/docs-infra/src/useCode/EditableEngine.ts
+++ b/packages/docs-infra/src/useCode/EditableEngine.ts
@@ -1064,12 +1064,19 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         event.preventDefault();
 
         let history: History;
+        // The state we are leaving — its position is the POST-edit caret of the
+        // edit being undone, which the host needs as the reversal pivot (it can
+        // differ from the destination's PRE-edit caret after a selection edit).
+        let leavingPosition: Position | undefined;
         if (!event.shiftKey) {
+          const leavingAt = state.historyAt;
           state.historyAt -= 1;
           const at = state.historyAt;
           history = state.history[at];
           if (!history) {
             state.historyAt = 0;
+          } else {
+            leavingPosition = state.history[leavingAt]?.[0];
           }
         } else {
           state.historyAt += 1;
@@ -1084,7 +1091,19 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
           disconnect();
           state.position = history[0];
           state.lastCommittedContent = history[1];
-          state.onChange(history[1], history[0]);
+          // Tag the reported position with the navigation direction so the host
+          // can reverse the edit's derived state (e.g. the comment/highlight map)
+          // relative to this PRE-edit caret instead of assuming a forward-edit
+          // (post-edit) caret. On undo, also pass the reversed edit's anchor line
+          // (the leaving state's caret) so the reversal pivots on the same line
+          // the forward edit did — they diverge after a selection edit (e.g.
+          // Select All). A fresh object keeps the stored history entry clean for
+          // re-navigation.
+          state.onChange(history[1], {
+            ...history[0],
+            history: event.shiftKey ? 'redo' : 'undo',
+            ...(leavingPosition ? { historyPivotLine: leavingPosition.line } : {}),
+          });
         }
         return;
       }
@@ -1112,6 +1131,18 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         const index = match ? match.index : position.content.length;
         const text = `\n${position.content.slice(0, index)}`;
         edit.insert(text);
+        // Pressing Enter on the last visible row pushes the new line past the
+        // collapsed window's fold, where there is no rendered `.line` to host
+        // the caret (it would strand in the padding filler). Mirror the
+        // arrow-key boundary handling and ask the host to expand. Cheap: a
+        // single bounds read plus the `getPosition` we already need for the
+        // post-expand caret restore.
+        const { maxRow, onBoundary } = boundsRef.current;
+        if (maxRow !== undefined && onBoundary && position.line >= maxRow) {
+          state.position = getPosition(element);
+          state.skipNextRestore = true;
+          onBoundary();
+        }
       } else if (
         !event.isComposing &&
         isPlaintextInputKey(event) &&
@@ -1130,15 +1161,28 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
         // cases so the character lands inside the current line span.
         event.preventDefault();
         edit.insert(event.key);
-      } else if ((!hasPlaintextSupport || config.indentation) && event.key === 'Backspace') {
+      } else if (
+        (!hasPlaintextSupport || config.indentation) &&
+        event.key === 'Backspace' &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
         // Firefox Quirk: Since plaintext-only is unsupported we must
-        // ensure that only a single character is deleted
+        // ensure that only a single character is deleted.
+        //
+        // Modifier guard: Ctrl/Meta/Alt+Backspace request word- or
+        // line-granular deletion. Mirror the forward-`Delete` branch below
+        // and let those modified presses fall through to the browser's
+        // native `deleteWord*`/`deleteSoftLine*` so a held modifier keeps its
+        // OS deletion semantics instead of being downgraded to a single char.
         event.preventDefault();
+        const beforePosition = getPosition(element);
         const range = getCurrentRange();
         if (!range.collapsed) {
           edit.insert('', 0);
         } else {
-          const position = getPosition(element);
+          const position = beforePosition;
           const { minColumn } = boundsRef.current;
           // When the caret sits at `minColumn` on a blank (whitespace-only)
           // line inside a clipped indent gutter, a single-character Backspace
@@ -1174,15 +1218,19 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             edit.insert('', match ? -match[1].length : -1);
           }
         }
-        // If the deletion left the current line empty, the browser has a
-        // zero-height empty `.line` span in the DOM that only disappears once
-        // the change commits and React re-renders the proper blank line. Left
-        // to the keyup flush (or an async re-highlight) the line blinks out and
-        // back — the visible flash when "removing the last part of a line full
-        // of spaces". Reconcile synchronously (bypassing preParse) so the final
-        // structure is in place before the next paint.
+        // If the deletion left the current line empty, OR merged this line up
+        // into the previous one (a Backspace at column 0 deletes the preceding
+        // newline), the browser leaves a transient zero-height/collapsed
+        // `.line` span in the DOM that only disappears once the change commits
+        // and React re-renders. Left to the keyup flush (or an async
+        // re-highlight) the line blinks out and back — the visible flash when
+        // "removing the last part of a line full of spaces" or backspacing a
+        // line up into the one above. Reconcile synchronously (bypassing
+        // preParse) so the final structure is in place before the next paint.
         const afterDelete = getPosition(element);
-        if (getLineInfo(element, afterDelete.line).currentLine.length === 0) {
+        const lineEmptied = getLineInfo(element, afterDelete.line).currentLine.length === 0;
+        const lineMerged = afterDelete.line < beforePosition.line;
+        if (lineEmptied || lineMerged) {
           flushChanges(true, true);
           return;
         }
@@ -1226,6 +1274,36 @@ export const createEditableEngine: CreateEditableEngine = (ctx) => {
             (config.indentation ? ' '.repeat(config.indentation) : '\t') +
             content.slice(start);
         edit.update(newContent);
+      } else if (
+        (boundsRef.current.minRow !== undefined || boundsRef.current.maxRow !== undefined) &&
+        (event.key === 'PageDown' || event.key === 'PageUp') &&
+        !event.shiftKey &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey
+      ) {
+        // Paging inside a COLLAPSED window: the hidden out-of-window lines are
+        // still in the DOM, so the browser's native PageUp/PageDown drops the
+        // caret into the non-editable padding filler beyond the fold. Instead,
+        // move the caret to the far visible edge in the paging direction and ask
+        // the host to expand — landing it on a real, now-revealed line. Mirrors
+        // the arrow-at-edge handling; bounded cost (one `getLineInfo` for the
+        // edge line). Only acts on a collapsed selection so Shift-paging
+        // (range extension) stays native.
+        const range = getCurrentRange();
+        const { minRow, maxRow, onBoundary } = boundsRef.current;
+        if (range.collapsed && onBoundary) {
+          const column = getPosition(element).content.length;
+          const targetRow = event.key === 'PageDown' ? maxRow : minRow;
+          if (targetRow !== undefined) {
+            event.preventDefault();
+            const edge = getLineInfo(element, targetRow).currentLine;
+            edit.move({ row: targetRow, column: Math.min(column, edge.length) });
+            state.position = getPosition(element);
+            state.skipNextRestore = true;
+            onBoundary();
+          }
+        }
       } else if (
         (boundsRef.current.minColumn !== undefined ||
           boundsRef.current.minRow !== undefined ||

--- a/packages/docs-infra/src/useCode/SourceEditingEngine.ts
+++ b/packages/docs-infra/src/useCode/SourceEditingEngine.ts
@@ -41,7 +41,18 @@ export function analyzeSource(source: string): { totalLines: number; emptyLines?
   let totalLines = 1;
   let emptyLines: number[] | undefined;
   let lineStart = 0;
-  const len = source.length;
+  // Ignore a single trailing newline. The live contentEditable always
+  // terminates its serialized text with one (`toString`), and the gutter
+  // (`starryNightGutter`) plus the caret helpers (`getLineInfo`/`getPosition`)
+  // all treat that final newline as a line *terminator*, not as an extra empty
+  // line. Counting it here would over-report `totalLines` versus the rendered
+  // line elements and inflate the line delta of the first edit by one (which
+  // shifts every emphasis comment down a line). A source with no trailing
+  // newline and the same source with one therefore report the same line count.
+  let len = source.length;
+  if (len > 0 && source.charCodeAt(len - 1) === 0x0a /* \n */) {
+    len -= 1;
+  }
   for (let i = 0; i <= len; i += 1) {
     if (i === len || source.charCodeAt(i) === 0x0a /* \n */) {
       let isEmpty = true;
@@ -90,7 +101,13 @@ export function shiftComments(
   existingCollapseMap: CollapseMap | undefined,
   oldEmptyLines?: number[],
 ): ShiftResult {
-  if (!comments || Object.keys(comments).length === 0) {
+  const hasComments = comments != null && Object.keys(comments).length > 0;
+  const hasCollapsed = existingCollapseMap != null && Object.keys(existingCollapseMap).length > 0;
+
+  // Nothing to shift and nothing stashed to restore. (When the comment map is
+  // empty but the collapseMap holds a fully-deleted frame, we must still run so
+  // an undo/expansion can reopen it.)
+  if (!hasComments && !hasCollapsed) {
     return { comments, collapseMap: existingCollapseMap };
   }
 
@@ -101,18 +118,29 @@ export function shiftComments(
   // position.line is 0-indexed in the new text.
   // lineDelta is positive for insertions and negative for deletions.
   // Convert to the 1-indexed line in old text that the cursor was on:
-  // For additions (lineDelta > 0):
-  //   - Forward typing: position is the POST-edit cursor (extent === 0).
-  //     Cursor moved down by lineDelta, so old line = position.line - lineDelta.
-  //   - Undo of a multi-line delete: the saved position has extent > 0 and
-  //     points to the SELECTION-START in the redone text — i.e. where the
-  //     re-inserted lines begin. The "edit line" is that line itself; the
-  //     new lines come AFTER it.
+  // For additions (lineDelta > 0), the re-inserted lines belong AFTER the caret
+  // (`position.line + 1`) when the caret is the *pre-deletion* position rather
+  // than a forward-typing cursor that moved down with the insert:
+  //   - Undo of a deletion (`position.history === 'undo'`): the saved caret is
+  //     where the delete happened and never moved, so the lines reappear after
+  //     it. This covers a single-line merge (extent 0) — which the forward
+  //     formula would misplace by one line — as well as multi-line deletes.
+  //   - Re-inserting a multi-line selection (extent > 0): the saved position
+  //     points to the selection-start where the lines begin.
+  // Otherwise (forward typing, or redo of an insert) the cursor is the POST-edit
+  // position and moved down by lineDelta, so old line = position.line - lineDelta.
   // For deletions (lineDelta < 0): cursor stayed where it was, old line = position.line.
-  const isUndoOfMultiLineDelete = lineDelta > 0 && position.extent > 0;
-  const editLine = isUndoOfMultiLineDelete
-    ? position.line + 1
-    : position.line - Math.max(0, lineDelta) + 1; // 1-indexed
+  // On an undo, reverse the edit at the line the FORWARD edit pivoted on (its
+  // post-edit caret, supplied as `historyPivotLine`) rather than this
+  // destination caret — they diverge after a selection edit (e.g. Select All
+  // deletes from a selection that didn't start at the caret), and the
+  // collapseMap that holds the deleted frame is keyed by that forward pivot.
+  const pivotLine =
+    position.history === 'undo' && position.historyPivotLine !== undefined
+      ? position.historyPivotLine
+      : position.line;
+  const reinsertsAfterCaret = lineDelta > 0 && (position.history === 'undo' || position.extent > 0);
+  const editLine = reinsertsAfterCaret ? pivotLine + 1 : pivotLine - Math.max(0, lineDelta) + 1; // 1-indexed
 
   const shifted: SourceComments = {};
   let collapseMap: CollapseMap = existingCollapseMap ? { ...existingCollapseMap } : {};
@@ -156,7 +184,37 @@ export function shiftComments(
   const oldEmptyLineSet =
     oldEmptyLines && oldEmptyLines.length > 0 ? new Set(oldEmptyLines) : undefined;
 
-  for (const [lineStr, commentArr] of Object.entries(comments)) {
+  // For a deletion, find range bases whose BOTH `-start` and `-end` markers fall
+  // inside the deleted block. Such a range is removed entirely — there is nowhere
+  // to shift its markers to — so we stash BOTH ends in the collapseMap and leave
+  // neither visible: the frame disappears now and an undo rebuilds it intact at
+  // its original offsets. (A range whose start survives OUTSIDE the block only
+  // shrinks, so its `-end` keeps the editLine+1 placement below and stays
+  // untracked, matching the expand/contract behavior.)
+  let fullyDeletedRanges: Set<string> | undefined;
+  if (lineDelta < 0) {
+    const startBases = new Set<string>();
+    const endBases = new Set<string>();
+    for (const [lineStr, commentArr] of Object.entries(comments ?? {})) {
+      const line = Number(lineStr);
+      if (line > editLine && line <= editLine - lineDelta) {
+        for (const comment of commentArr) {
+          if (comment.endsWith('-end')) {
+            endBases.add(comment.slice(0, -'-end'.length));
+          } else if (comment.endsWith('-start')) {
+            startBases.add(comment.slice(0, -'-start'.length));
+          }
+        }
+      }
+    }
+    for (const base of startBases) {
+      if (endBases.has(base)) {
+        (fullyDeletedRanges ??= new Set()).add(base);
+      }
+    }
+  }
+
+  for (const [lineStr, commentArr] of Object.entries(comments ?? {})) {
     const line = Number(lineStr);
     if (line <= editLine) {
       // Before or at the edit line — unchanged.
@@ -177,30 +235,46 @@ export function shiftComments(
       }
     } else if (lineDelta < 0 && line <= editLine - lineDelta) {
       // Within the deleted range — collapse comments onto the edit line.
-      // Boundary comments (ending with '-end') go to editLine + 1 instead,
-      // so range-end markers stay at the first line after the highlighted range.
-      // Boundary comments are NOT tracked in collapseMap — they shift normally
-      // on subsequent edits so the range naturally expands/contracts.
-      //
-      // Empty/whitespace-only deleted lines also push their regular comments
-      // to editLine + 1: nothing actually shifted upward into editLine, so the
-      // highlighted region should shrink rather than expand onto the line above.
+      // Three destinations:
+      //  - Markers of a FULLY deleted range (both ends in the block): stash in
+      //    the collapseMap ONLY, so the frame vanishes now and an undo restores
+      //    both ends at their original offsets.
+      //  - Surviving range-end ('-end') markers, and regular comments off an
+      //    empty/whitespace-only deleted line: go to editLine + 1, so the range
+      //    shrinks rather than expanding onto the line above. Left untracked so
+      //    they shift normally as the range contracts/expands.
+      //  - Other regular comments: collapse onto editLine AND track in the
+      //    collapseMap so a later expansion can restore them at their offset.
       const wasEmptyLine = oldEmptyLineSet?.has(line) ?? false;
-      const regular = commentArr.filter((c) => !c.endsWith('-end'));
-      const boundary = commentArr.filter((c) => c.endsWith('-end'));
-
-      if (regular.length > 0) {
-        if (wasEmptyLine) {
-          const target = editLine + 1;
-          shifted[target] = [...(shifted[target] ?? []), ...regular];
+      const reopenable: string[] = [];
+      const collapseHere: string[] = [];
+      const toBoundary: string[] = [];
+      for (const comment of commentArr) {
+        const isEnd = comment.endsWith('-end');
+        let base: string | undefined;
+        if (isEnd) {
+          base = comment.slice(0, -'-end'.length);
+        } else if (comment.endsWith('-start')) {
+          base = comment.slice(0, -'-start'.length);
+        }
+        if (base !== undefined && fullyDeletedRanges?.has(base)) {
+          reopenable.push(comment);
+        } else if (isEnd || wasEmptyLine) {
+          toBoundary.push(comment);
         } else {
-          shifted[editLine] = [...(shifted[editLine] ?? []), ...regular];
-          newCollapsed.push({ offset: line - editLine, comments: regular });
+          collapseHere.push(comment);
         }
       }
-      if (boundary.length > 0) {
+      if (reopenable.length > 0) {
+        newCollapsed.push({ offset: line - editLine, comments: reopenable });
+      }
+      if (collapseHere.length > 0) {
+        shifted[editLine] = [...(shifted[editLine] ?? []), ...collapseHere];
+        newCollapsed.push({ offset: line - editLine, comments: collapseHere });
+      }
+      if (toBoundary.length > 0) {
         const boundaryTarget = editLine + 1;
-        shifted[boundaryTarget] = [...(shifted[boundaryTarget] ?? []), ...boundary];
+        shifted[boundaryTarget] = [...(shifted[boundaryTarget] ?? []), ...toBoundary];
       }
     } else {
       // After the edit — shift

--- a/packages/docs-infra/src/useCode/SourceEditingEngine.ts
+++ b/packages/docs-infra/src/useCode/SourceEditingEngine.ts
@@ -140,24 +140,49 @@ export function shiftComments(
       ? position.historyPivotLine
       : position.line;
   const reinsertsAfterCaret = lineDelta > 0 && (position.history === 'undo' || position.extent > 0);
-  const editLine = reinsertsAfterCaret ? pivotLine + 1 : pivotLine - Math.max(0, lineDelta) + 1; // 1-indexed
+  let editLine = reinsertsAfterCaret ? pivotLine + 1 : pivotLine - Math.max(0, lineDelta) + 1; // 1-indexed
+  // A selection delete that started at column 0 removed whole lines from the
+  // FIRST line down; the post-edit (or restored) caret lands on the line that
+  // shifted up from below, so the true anchor — the last surviving line above
+  // the deletion — is one line higher. Without this the deleted first line is
+  // treated as surviving, stranding a marker that sits on it (and the undo
+  // can't rebuild the frame). Rides through undo via the same flag so the
+  // reversal anchors on the same line, keeping the collapseMap keys aligned.
+  if (position.deletedFromLineStart) {
+    editLine -= 1;
+  }
 
   const shifted: SourceComments = {};
   let collapseMap: CollapseMap = existingCollapseMap ? { ...existingCollapseMap } : {};
-  const newCollapsed: Array<{ offset: number; comments: string[] }> = [];
+  const newCollapsed: Array<{ offset: number; comments: string[]; boundary?: true }> = [];
 
   // Build a list of comment strings to exclude from the edit line after restore.
   // Uses an array (not Set) to correctly handle duplicate comment strings
   // across separate collapsed entries.
   let restoredComments: string[] | undefined;
+  // Boundary `-end`/empty-line markers were also left VISIBLE at editLine+1 when
+  // the range first shrank. On an undo that restores them at their true offset we
+  // must drop that visible boundary copy (else the marker duplicates and the copy
+  // shifts a full delta, landing one line past the original). Collected here and
+  // filtered off editLine+1 in the main loop below.
+  let restoredBoundaryComments: string[] | undefined;
+  const isUndo = position.history === 'undo';
 
   // On expansion, check if we can restore previously collapsed comments
   if (lineDelta > 0 && collapseMap[editLine]) {
     const entries = collapseMap[editLine];
-    const restored: Array<{ offset: number; comments: string[] }> = [];
-    const remaining: Array<{ offset: number; comments: string[] }> = [];
+    const restored: Array<{ offset: number; comments: string[]; boundary?: true }> = [];
+    const remaining: Array<{ offset: number; comments: string[]; boundary?: true }> = [];
 
     for (const entry of entries) {
+      // Boundary entries (a shrunk range's `-end`/empty-line `-start`) are
+      // undo-only memory: they restore the marker EXACTLY on an undo. On a
+      // forward re-insert (or redo) the still-visible boundary copy expands the
+      // range as before, so the stash is dropped rather than restored — leaving
+      // it would re-restore the marker on a later undo of an unrelated edit.
+      if (entry.boundary && !isUndo) {
+        continue;
+      }
       if (entry.offset <= lineDelta) {
         restored.push(entry);
       } else {
@@ -167,10 +192,16 @@ export function shiftComments(
 
     // Place restored comments at their original offsets from the edit line
     restoredComments = [];
+    restoredBoundaryComments = [];
     for (const entry of restored) {
       const restoredLine = editLine + entry.offset;
       shifted[restoredLine] = [...(shifted[restoredLine] ?? []), ...entry.comments];
-      restoredComments.push(...entry.comments);
+      if (entry.boundary) {
+        // Filter the visible boundary copy (at editLine+1), not the editLine.
+        restoredBoundaryComments.push(...entry.comments);
+      } else {
+        restoredComments.push(...entry.comments);
+      }
     }
 
     if (remaining.length > 0) {
@@ -275,11 +306,32 @@ export function shiftComments(
       if (toBoundary.length > 0) {
         const boundaryTarget = editLine + 1;
         shifted[boundaryTarget] = [...(shifted[boundaryTarget] ?? []), ...toBoundary];
+        // Keep the marker VISIBLE at editLine+1 (the live contracted view) AND
+        // stash its TRUE offset, flagged `boundary`, so an undo can restore it
+        // exactly. A forward re-insert ignores this stash and lets the visible
+        // copy expand the range instead (see the restore loop above).
+        newCollapsed.push({ offset: line - editLine, comments: toBoundary, boundary: true });
       }
     } else {
-      // After the edit — shift
-      const newLine = line + lineDelta;
-      shifted[newLine] = [...(shifted[newLine] ?? []), ...commentArr];
+      // After the edit — shift.
+      // On an undo that restored a shrunk range's boundary marker at its true
+      // offset, drop the still-visible boundary copy (at editLine+1) so it
+      // doesn't duplicate the marker and shift a full delta past the original.
+      let arr = commentArr;
+      if (line === editLine + 1 && restoredBoundaryComments) {
+        const remaining = [...commentArr];
+        for (const c of restoredBoundaryComments) {
+          const idx = remaining.indexOf(c);
+          if (idx !== -1) {
+            remaining.splice(idx, 1);
+          }
+        }
+        arr = remaining;
+      }
+      if (arr.length > 0) {
+        const newLine = line + lineDelta;
+        shifted[newLine] = [...(shifted[newLine] ?? []), ...arr];
+      }
     }
   }
 

--- a/packages/docs-infra/src/useCode/SourceEditingEngine.ts
+++ b/packages/docs-infra/src/useCode/SourceEditingEngine.ts
@@ -152,6 +152,17 @@ export function shiftComments(
     editLine -= 1;
   }
 
+  // When the deletion reaches the very first line, `editLine` underflows to 0:
+  // there is no surviving line ABOVE the deletion to anchor onto. The 1-indexed
+  // comment map has no line 0, so collapsed comments and their collapseMap keys
+  // must instead anchor on the FIRST SURVIVING line — the one that becomes the
+  // new line 1. `editLine` itself stays 0 so the deleted-range partition below
+  // still treats the old first line as deleted (not surviving); only the WRITE
+  // targets (collapse destination, collapseMap key, restore offsets) use this
+  // clamped anchor. Off the top-of-file case `collapseLine === editLine`, so the
+  // normal middle/bottom paths are byte-for-byte unchanged.
+  const collapseLine = editLine < 1 ? 1 : editLine;
+
   const shifted: SourceComments = {};
   let collapseMap: CollapseMap = existingCollapseMap ? { ...existingCollapseMap } : {};
   const newCollapsed: Array<{ offset: number; comments: string[]; boundary?: true }> = [];
@@ -169,8 +180,8 @@ export function shiftComments(
   const isUndo = position.history === 'undo';
 
   // On expansion, check if we can restore previously collapsed comments
-  if (lineDelta > 0 && collapseMap[editLine]) {
-    const entries = collapseMap[editLine];
+  if (lineDelta > 0 && collapseMap[collapseLine]) {
+    const entries = collapseMap[collapseLine];
     const restored: Array<{ offset: number; comments: string[]; boundary?: true }> = [];
     const remaining: Array<{ offset: number; comments: string[]; boundary?: true }> = [];
 
@@ -194,10 +205,10 @@ export function shiftComments(
     restoredComments = [];
     restoredBoundaryComments = [];
     for (const entry of restored) {
-      const restoredLine = editLine + entry.offset;
+      const restoredLine = collapseLine + entry.offset;
       shifted[restoredLine] = [...(shifted[restoredLine] ?? []), ...entry.comments];
       if (entry.boundary) {
-        // Filter the visible boundary copy (at editLine+1), not the editLine.
+        // Filter the visible boundary copy (at editLine+1), not the collapseLine.
         restoredBoundaryComments.push(...entry.comments);
       } else {
         restoredComments.push(...entry.comments);
@@ -205,9 +216,9 @@ export function shiftComments(
     }
 
     if (remaining.length > 0) {
-      collapseMap[editLine] = remaining;
+      collapseMap[collapseLine] = remaining;
     } else {
-      delete collapseMap[editLine];
+      delete collapseMap[collapseLine];
     }
   }
 
@@ -296,12 +307,17 @@ export function shiftComments(
           collapseHere.push(comment);
         }
       }
+      // Offsets and the regular-collapse destination anchor on `collapseLine`
+      // (the first surviving line) so they stay valid at the top of the file,
+      // where `editLine` is 0. The boundary target stays `editLine + 1`: in the
+      // middle of the file that is the line just BELOW the surviving anchor, and
+      // at the top of the file it coincides with `collapseLine` (the new line 1).
       if (reopenable.length > 0) {
-        newCollapsed.push({ offset: line - editLine, comments: reopenable });
+        newCollapsed.push({ offset: line - collapseLine, comments: reopenable });
       }
       if (collapseHere.length > 0) {
-        shifted[editLine] = [...(shifted[editLine] ?? []), ...collapseHere];
-        newCollapsed.push({ offset: line - editLine, comments: collapseHere });
+        shifted[collapseLine] = [...(shifted[collapseLine] ?? []), ...collapseHere];
+        newCollapsed.push({ offset: line - collapseLine, comments: collapseHere });
       }
       if (toBoundary.length > 0) {
         const boundaryTarget = editLine + 1;
@@ -310,16 +326,34 @@ export function shiftComments(
         // stash its TRUE offset, flagged `boundary`, so an undo can restore it
         // exactly. A forward re-insert ignores this stash and lets the visible
         // copy expand the range instead (see the restore loop above).
-        newCollapsed.push({ offset: line - editLine, comments: toBoundary, boundary: true });
+        newCollapsed.push({ offset: line - collapseLine, comments: toBoundary, boundary: true });
       }
     } else {
       // After the edit — shift.
+      let arr = commentArr;
+      // At the top of the file the collapse anchor (`collapseLine`) is the new
+      // line 1, which sits AFTER the conceptual edit point (`editLine` is 0), so
+      // its entry lands in this shifting branch rather than the unchanged one. On
+      // an undo we restored its collapsed comments to their true lines already,
+      // so drop those copies here before the leftover (a survivor that shifted up
+      // during the delete) shifts back down. In the middle of the file
+      // `collapseLine === editLine`, which never reaches this branch, so this is
+      // inert there.
+      if (line === collapseLine && restoredComments) {
+        const remaining = [...arr];
+        for (const c of restoredComments) {
+          const idx = remaining.indexOf(c);
+          if (idx !== -1) {
+            remaining.splice(idx, 1);
+          }
+        }
+        arr = remaining;
+      }
       // On an undo that restored a shrunk range's boundary marker at its true
       // offset, drop the still-visible boundary copy (at editLine+1) so it
       // doesn't duplicate the marker and shift a full delta past the original.
-      let arr = commentArr;
       if (line === editLine + 1 && restoredBoundaryComments) {
-        const remaining = [...commentArr];
+        const remaining = [...arr];
         for (const c of restoredBoundaryComments) {
           const idx = remaining.indexOf(c);
           if (idx !== -1) {
@@ -335,11 +369,15 @@ export function shiftComments(
     }
   }
 
-  // Also shift existing collapse map entries that are after the edit line
+  // Also shift existing collapse map entries that are after the collapse anchor.
+  // Entries AT the anchor (e.g. a partially restored stash) stay put so further
+  // expansion can keep restoring from them; later ones move with the edit. Keyed
+  // on `collapseLine` (not `editLine`) so a stash held at the new line 1 isn't
+  // mistakenly shifted at the top of the file, where `editLine` is 0.
   const shiftedCollapseMap: CollapseMap = {};
   for (const [lineStr, entries] of Object.entries(collapseMap)) {
     const line = Number(lineStr);
-    if (line <= editLine) {
+    if (line <= collapseLine) {
       shiftedCollapseMap[line] = entries;
     } else {
       shiftedCollapseMap[line + lineDelta] = entries;
@@ -348,7 +386,7 @@ export function shiftComments(
   collapseMap = shiftedCollapseMap;
 
   if (newCollapsed.length > 0) {
-    collapseMap[editLine] = [...(collapseMap[editLine] ?? []), ...newCollapsed];
+    collapseMap[collapseLine] = [...(collapseMap[collapseLine] ?? []), ...newCollapsed];
   }
 
   const finalCollapseMap = Object.keys(collapseMap).length > 0 ? collapseMap : undefined;

--- a/packages/docs-infra/src/useCode/liveEditingBugs.browser.tsx
+++ b/packages/docs-infra/src/useCode/liveEditingBugs.browser.tsx
@@ -1,0 +1,690 @@
+/**
+ * Reproduction harness + tests for four live-editing bugs reported against the
+ * docs live code editor:
+ *
+ *   1. Erasing the last indent (tab) unit on a line makes the view jump.
+ *   2. Pressing ArrowUp at the visible top doesn't trigger the scroll anchor.
+ *   3. Typing `x`, then `=`, then Backspace sends the caret to column 0.
+ *   4. The first keystroke in the editable loses focus.
+ *
+ * Unlike `useEditable.browser.ts` (which drives a static highlighted DOM with a
+ * `vi.fn()` onChange and only asserts the *text* handed to onChange), these
+ * tests wire `useEditable` to a real React component whose `onChange` updates
+ * source state, re-highlights it into the production `.line`/`pl-*` span
+ * structure, and lets the engine's `observeAndRestore` restore the caret — i.e.
+ * the full type → flush → re-highlight → restore cycle that the bugs live in.
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { userEvent } from 'vitest/browser';
+import { useEditable, preloadEditableEngine, type Position, type Options } from './useEditable';
+
+beforeAll(async () => {
+  await preloadEditableEngine();
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+  window.getSelection()?.removeAllRanges();
+});
+
+// ---------------------------------------------------------------------------
+// Minimal, deterministic re-highlighter
+// ---------------------------------------------------------------------------
+// Splits each line into tokens and wraps identifiers (`pl-smi`) and single-char
+// operators (`pl-k`) in their own spans, leaving whitespace/punctuation as bare
+// text. This reproduces the multi-span-per-line DOM shape that production
+// highlighting produces — enough to surface caret-at-element-boundary bugs —
+// without pulling in the async grammar/worker pipeline. Each line span keeps its
+// trailing `\n` inside it, matching the production serializer.
+const WORD = /[A-Za-z0-9_$]/;
+const OPERATOR = new Set(['=', '+', '-', '*', '/', '<', '>', '!', '&', '|', '%', '?', ':']);
+
+function highlightLine(lineText: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let i = 0;
+  let key = 0;
+  while (i < lineText.length) {
+    const char = lineText[i];
+    if (WORD.test(char)) {
+      let j = i + 1;
+      while (j < lineText.length && WORD.test(lineText[j])) {
+        j += 1;
+      }
+      nodes.push(
+        <span className="pl-smi" key={key}>
+          {lineText.slice(i, j)}
+        </span>,
+      );
+      key += 1;
+      i = j;
+    } else if (OPERATOR.has(char)) {
+      nodes.push(
+        <span className="pl-k" key={key}>
+          {char}
+        </span>,
+      );
+      key += 1;
+      i += 1;
+    } else {
+      // Coalesce a run of bare characters (whitespace/punctuation) into one
+      // text node, as the highlighter would.
+      let j = i + 1;
+      while (j < lineText.length && !WORD.test(lineText[j]) && !OPERATOR.has(lineText[j])) {
+        j += 1;
+      }
+      nodes.push(lineText.slice(i, j));
+      i = j;
+    }
+  }
+  return nodes;
+}
+
+function Highlighted({ source }: { source: string }) {
+  // Mirror the production live-editing structure: `.line` spans live inside a
+  // `.frame`, and the newline after each line is a SEPARATE sibling text node
+  // ("trailing newline" / gap node), NOT kept inside the line span. These gap
+  // nodes are exactly what `caretSelector` + `snapCaretOutOfGapNode` exist for.
+  // `source` always carries a trailing newline.
+  const withoutTrailing = source.endsWith('\n') ? source.slice(0, -1) : source;
+  const lines = withoutTrailing.split('\n');
+  return (
+    <code>
+      <span className="frame" data-frame="0" data-lined="">
+        {lines.map((line, index) => (
+          <React.Fragment key={index}>
+            <span className="line" data-ln={index + 1}>
+              {highlightLine(line)}
+            </span>
+            {'\n'}
+          </React.Fragment>
+        ))}
+      </span>
+    </code>
+  );
+}
+
+type HarnessHandle = {
+  ref: React.RefObject<HTMLPreElement | null>;
+  onChange: ReturnType<typeof vi.fn>;
+  getSource: () => string;
+  scrollEl: HTMLDivElement | null;
+};
+
+function Editor({
+  initialSource,
+  options,
+  handleRef,
+  scroll,
+}: {
+  initialSource: string;
+  options: Options;
+  handleRef: { current: HarnessHandle | null };
+  scroll?: boolean;
+}) {
+  const [source, setSource] = React.useState(initialSource);
+  const ref = React.useRef<HTMLPreElement | null>(null);
+  const scrollRef = React.useRef<HTMLDivElement | null>(null);
+
+  const onChange = React.useMemo(
+    () =>
+      vi.fn((text: string, _position: Position) => {
+        setSource(text);
+      }),
+    [],
+  );
+
+  useEditable(ref, onChange, options);
+
+  React.useEffect(() => {
+    handleRef.current = {
+      ref,
+      onChange,
+      getSource: () =>
+        onChange.mock.calls.length
+          ? onChange.mock.calls[onChange.mock.calls.length - 1][0]
+          : initialSource,
+      scrollEl: scrollRef.current,
+    };
+  });
+
+  const editor = (
+    <React.Fragment>
+      {/* Production line/frame CSS (from CollapsibleContent.module.css): the
+          frame collapses its gap newlines via `line-height: 0`, and each `.line`
+          is a `display: block`. An EMPTY line then has no inline content and
+          renders at zero height — which is what makes consecutive empty lines
+          skippable by native vertical ArrowUp. */}
+      <style>{`
+        [data-testid="editor"] { line-height: 1.5; font-family: monospace; }
+        [data-testid="editor"] .frame[data-lined] { display: block; white-space: normal; line-height: 0; }
+        [data-testid="editor"] .frame[data-lined] .line { display: block; white-space: pre; line-height: initial; }
+      `}</style>
+      <pre ref={ref} style={{ tabSize: 2, margin: 0 }} data-testid="editor">
+        <Highlighted source={source} />
+      </pre>
+    </React.Fragment>
+  );
+
+  if (!scroll) {
+    return editor;
+  }
+  // A short, scrollable viewport so we can detect "the view jumps" by reading
+  // scrollTop before/after an edit.
+  return (
+    <div
+      ref={scrollRef}
+      style={{ height: '60px', overflow: 'auto', fontFamily: 'monospace', lineHeight: '20px' }}
+      data-testid="scroll"
+    >
+      {editor}
+    </div>
+  );
+}
+
+/** Renders the editor and returns a handle once the engine has attached. */
+async function setupEditor(
+  initialSource: string,
+  options: Options = {},
+  opts: { scroll?: boolean } = {},
+) {
+  const handleRef: { current: HarnessHandle | null } = { current: null };
+  render(
+    <Editor
+      initialSource={initialSource}
+      options={options}
+      handleRef={handleRef}
+      scroll={opts.scroll}
+    />,
+  );
+
+  // Wait a frame for the layout effects (engine attach + contentEditable).
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+
+  const handle = handleRef.current!;
+  const element = handle.ref.current!;
+  return { handle, element };
+}
+
+/**
+ * Places the caret at an absolute character offset (counting newlines that live
+ * inside `.line` spans) and waits a frame so the engine captures the position.
+ */
+async function placeCaret(element: HTMLElement, offset: number) {
+  element.focus();
+  const sel = window.getSelection()!;
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+  let current = 0;
+  let node = walker.nextNode();
+  while (node) {
+    const len = node.textContent!.length;
+    if (current + len >= offset) {
+      const range = document.createRange();
+      range.setStart(node, offset - current);
+      range.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      break;
+    }
+    current += len;
+    node = walker.nextNode();
+  }
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+}
+
+/** Computes the caret's (line, column) from the live Selection. */
+function caretLineColumn(element: HTMLElement): { line: number; column: number; position: number } {
+  const sel = window.getSelection()!;
+  const range = sel.getRangeAt(0);
+  const until = document.createRange();
+  until.setStart(element, 0);
+  until.setEnd(range.startContainer, range.startOffset);
+  const text = until.toString();
+  const lines = text.split('\n');
+  return { line: lines.length - 1, column: lines[lines.length - 1].length, position: text.length };
+}
+
+/** Lets queued microtasks / rAF callbacks / React effects settle. */
+async function settle() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+}
+
+/** Builds an async preParse that re-highlights on a macrotask (worker-like). */
+function asyncPreParse() {
+  return vi.fn(
+    (_text: string, _position: Position) =>
+      new Promise<undefined>((resolve) => {
+        setTimeout(() => resolve(undefined), 0);
+      }),
+  );
+}
+
+/**
+ * A preParse whose resolution is controlled by the test — models the worker
+ * round-trip so we can inspect the DOM *during* the async gap (before the
+ * re-highlight commits) the way the user sees "the wrong thing for a second".
+ */
+function deferredPreParse() {
+  let resolveFn: (() => void) | null = null;
+  const preParse = vi.fn(
+    (_text: string, _position: Position) =>
+      new Promise<undefined>((resolve) => {
+        resolveFn = () => resolve(undefined);
+      }),
+  );
+  return {
+    preParse,
+    resolvePending: async () => {
+      resolveFn?.();
+      resolveFn = null;
+      await settle();
+    },
+  };
+}
+
+describe('live-editing bug repros', () => {
+  // -------------------------------------------------------------------------
+  // Bug 3: type x, =, Backspace -> caret jumps to column 0
+  // -------------------------------------------------------------------------
+  it('Bug 3a: fresh line — x, =, Backspace keeps caret after x', async () => {
+    const { handle, element } = await setupEditor('\n', { indentation: 2, caretSelector: '.line' });
+    await placeCaret(element, 0);
+    await userEvent.keyboard('x');
+    await settle();
+    await userEvent.keyboard('=');
+    await settle();
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    expect(handle.getSource()).toBe('x\n');
+    expect(caretLineColumn(element)).toMatchObject({ line: 0, column: 1 });
+  });
+
+  it('Bug 3b: x, =, Backspace with async preParse keeps caret after x', async () => {
+    const { handle, element } = await setupEditor('\n', {
+      indentation: 2,
+      caretSelector: '.line',
+      preParse: asyncPreParse(),
+    });
+    await placeCaret(element, 0);
+    await userEvent.keyboard('x');
+    await settle();
+    await settle();
+    await userEvent.keyboard('=');
+    await settle();
+    await settle();
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    await settle();
+    expect(handle.getSource()).toBe('x\n');
+    expect(caretLineColumn(element)).toMatchObject({ line: 0, column: 1 });
+  });
+
+  it('Bug 3c: typing =, Backspace at end of an existing indented JSX-ish line', async () => {
+    // `      <p style=` then backspace the `=`. This mirrors typing an attribute.
+    const initial = 'function App() {\n  return <p style\n}\n';
+    const { handle, element } = await setupEditor(initial, {
+      indentation: 2,
+      caretSelector: '.line',
+    });
+    // caret at end of `  return <p style` (line 1)
+    const offset = 'function App() {\n  return <p style'.length;
+    await placeCaret(element, offset);
+    await userEvent.keyboard('=');
+    await settle();
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    expect(handle.getSource()).toBe(initial);
+    // caret should be back at end of `style` (column 17), not column 0
+    expect(caretLineColumn(element)).toMatchObject({ line: 1, column: '  return <p style'.length });
+  });
+
+  it('Bug 3d: collapsed (minColumn) — x, =, Backspace at end of an indented line keeps caret after x', async () => {
+    // The collapsed editor (clipped indent gutter) is where the real bug shows.
+    const initial = 'function foo() {\n  doStuff()\n}\n';
+    const { handle, element } = await setupEditor(initial, {
+      indentation: 2,
+      caretSelector: '.line',
+      minColumn: 2,
+      minRow: 1,
+      maxRow: 1,
+      onBoundary: vi.fn(),
+    });
+    const offset = 'function foo() {\n  doStuff()'.length; // end of line 1
+    await placeCaret(element, offset);
+    await userEvent.keyboard('x');
+    await settle();
+    await userEvent.keyboard('=');
+    await settle();
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    expect(handle.getSource()).toBe('function foo() {\n  doStuff()x\n}\n');
+    expect(caretLineColumn(element)).toMatchObject({ line: 1, column: '  doStuff()x'.length });
+  });
+
+  it('Bug 3e: collapsed + async preParse — x, =, Backspace keeps caret after x', async () => {
+    const initial = 'function foo() {\n  doStuff()\n}\n';
+    const { handle, element } = await setupEditor(initial, {
+      indentation: 2,
+      caretSelector: '.line',
+      minColumn: 2,
+      minRow: 1,
+      maxRow: 1,
+      onBoundary: vi.fn(),
+      preParse: asyncPreParse(),
+    });
+    const offset = 'function foo() {\n  doStuff()'.length;
+    await placeCaret(element, offset);
+    await userEvent.keyboard('x');
+    await settle();
+    await settle();
+    await userEvent.keyboard('=');
+    await settle();
+    await settle();
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    await settle();
+    expect(handle.getSource()).toBe('function foo() {\n  doStuff()x\n}\n');
+    expect(caretLineColumn(element)).toMatchObject({ line: 1, column: '  doStuff()x'.length });
+  });
+
+  it('Bug 3f: End then x, =, Backspace at a line end (caret lands at the line/gap boundary)', async () => {
+    // The real bug uses the `End` key to land the caret at the line end — which
+    // in the framed `.line` structure is the boundary with the inter-line gap
+    // node. Native typing there can flatten the spans / split across lines.
+    const initial = 'function foo() {\n  doStuff()\n}\n';
+    const { handle, element } = await setupEditor(initial, {
+      indentation: 2,
+      caretSelector: '.line',
+    });
+    // Put the caret somewhere on line 1, then End to the line end.
+    await placeCaret(element, 'function foo() {\n  do'.length);
+    await userEvent.keyboard('{End}');
+    await settle();
+    await userEvent.keyboard('x');
+    await settle();
+    await userEvent.keyboard('=');
+    await settle();
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    expect(handle.getSource()).toBe('function foo() {\n  doStuff()x\n}\n');
+    expect(caretLineColumn(element)).toMatchObject({ line: 1, column: '  doStuff()x'.length });
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug 1: erasing the last indent on a clipped (collapsed-window) line jumps
+  // -------------------------------------------------------------------------
+  it('Bug 1a: Backspace of last indent on a blank clipped line (minColumn) — where does caret land?', async () => {
+    // Simulate a collapsed window: indentation clipped to minColumn=2, the
+    // visible region is rows 1..3. Line 2 is a blank line with exactly 2 spaces.
+    const initial = 'function foo() {\n  const a = 1;\n  \n  return a;\n}\n';
+    const { handle, element } = await setupEditor(
+      initial,
+      {
+        indentation: 2,
+        caretSelector: '.line',
+        minColumn: 2,
+        minRow: 1,
+        maxRow: 3,
+        onBoundary: vi.fn(),
+      },
+      { scroll: true },
+    );
+    // caret at end of the blank line 2 (column 2 == minColumn)
+    const offset = 'function foo() {\n  const a = 1;\n  '.length;
+    await placeCaret(element, offset);
+    const before = caretLineColumn(element);
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    const after = caretLineColumn(element);
+    // The reported source + caret movement reveal whether the whole line
+    // collapsed (caret jumps to the previous line) or just one indent went away.
+    // eslint-disable-next-line no-console
+    console.log(
+      'Bug1a before',
+      before,
+      'after',
+      after,
+      'source',
+      JSON.stringify(handle.getSource()),
+    );
+    // Assert the (arguably correct) behavior: stay on the same line, now empty.
+    expect(after.line).toBe(before.line);
+  });
+
+  it('Bug 1b: Backspace of indent on a content line in a clipped gutter (minColumn)', async () => {
+    const initial = 'function foo() {\n  const a = 1;\n}\n';
+    const { handle, element } = await setupEditor(
+      initial,
+      {
+        indentation: 2,
+        caretSelector: '.line',
+        minColumn: 2,
+        minRow: 1,
+        maxRow: 1,
+        onBoundary: vi.fn(),
+      },
+      { scroll: true },
+    );
+    // caret right after the 2-space indent on line 1 (`  const a = 1;`)
+    const offset = 'function foo() {\n  '.length;
+    await placeCaret(element, offset);
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+    const after = caretLineColumn(element);
+    // eslint-disable-next-line no-console
+    console.log('Bug1b after', after, 'source', JSON.stringify(handle.getSource()));
+    expect(after).toBeTruthy();
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug 2: ArrowUp at the visible top should fire onBoundary (scroll anchor)
+  // -------------------------------------------------------------------------
+  it('Bug 2: ArrowUp at minRow fires onBoundary; ArrowDown at maxRow fires onBoundary', async () => {
+    const onBoundary = vi.fn();
+    const initial = 'line0\nline1\nline2\nline3\nline4\n';
+    const { element } = await setupEditor(
+      initial,
+      { indentation: 2, caretSelector: '.line', minRow: 2, maxRow: 3, onBoundary },
+      { scroll: true },
+    );
+    // Caret on line 2 (minRow), then ArrowUp.
+    const upOffset = 'line0\nline1\n'.length + 2;
+    await placeCaret(element, upOffset);
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const upCalls = onBoundary.mock.calls.length;
+
+    // Caret on line 3 (maxRow), then ArrowDown.
+    const downOffset = 'line0\nline1\nline2\n'.length + 2;
+    await placeCaret(element, downOffset);
+    await userEvent.keyboard('{ArrowDown}');
+    await settle();
+    const downCalls = onBoundary.mock.calls.length - upCalls;
+
+    // eslint-disable-next-line no-console
+    console.log('Bug2 onBoundary up-calls', upCalls, 'down-calls', downCalls);
+    expect(upCalls).toBeGreaterThan(0); // ArrowUp must fire the boundary
+    expect(downCalls).toBeGreaterThan(0); // ArrowDown must fire the boundary
+  });
+
+  // -------------------------------------------------------------------------
+  // Clue A: backspace last indent + async re-highlight shows the wrong thing
+  // transiently (during the worker round-trip the line is collapsed but the
+  // committed source hasn't caught up yet).
+  // -------------------------------------------------------------------------
+  it('Clue A: async backspace of last indent — transient DOM vs committed source', async () => {
+    const { preParse, resolvePending } = deferredPreParse();
+    const initial = 'function foo() {\n  const a = 1;\n  \n  return a;\n}\n';
+    const { handle, element } = await setupEditor(
+      initial,
+      {
+        indentation: 2,
+        caretSelector: '.line',
+        minColumn: 2,
+        minRow: 1,
+        maxRow: 3,
+        onBoundary: vi.fn(),
+        preParse,
+      },
+      { scroll: true },
+    );
+    const offset = 'function foo() {\n  const a = 1;\n  '.length;
+    await placeCaret(element, offset);
+
+    // Compact structural signature: the frame's direct children, each as
+    // either `LINE(<text>)` or `TEXT(<text>)`, so we can see the mangled
+    // transient structure without vitest truncating a long innerHTML string.
+    const signature = () => {
+      const frame = element.querySelector('.frame')!;
+      return Array.from(frame.childNodes).map((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          return `TEXT(${JSON.stringify(node.textContent)})`;
+        }
+        const childEl = node as HTMLElement;
+        if (childEl.classList?.contains('line')) {
+          return `LINE(${JSON.stringify(childEl.textContent)})`;
+        }
+        return `OTHER(${childEl.tagName})`;
+      });
+    };
+
+    await userEvent.keyboard('{Backspace}');
+    await settle();
+
+    // DURING the async gap (preParse not yet resolved): what does the DOM show?
+    const transientText = element.textContent ?? '';
+    const transientLineCount = element.querySelectorAll('.line').length;
+    const transientSig = signature();
+    const committedDuringGap = handle.onChange.mock.calls.length;
+
+    await resolvePending();
+    await settle();
+
+    const finalText = element.textContent ?? '';
+    const finalSig = signature();
+    const finalSource = handle.getSource();
+    // eslint-disable-next-line no-console
+    console.log(
+      'ClueA transient',
+      JSON.stringify(transientText),
+      'lines',
+      transientLineCount,
+      'committedDuringGap',
+      committedDuringGap,
+      '| final',
+      JSON.stringify(finalText),
+      'source',
+      JSON.stringify(finalSource),
+    );
+    // The transient DOM should already match the final committed text — i.e.
+    // the user must NOT see a wrong intermediate state. If they differ, the
+    // async path is showing the wrong thing for a moment.
+    void transientText;
+    void transientLineCount;
+    void committedDuringGap;
+    void finalText;
+    void finalSource;
+    // DESIRED: the DOM the user sees during the async worker round-trip should
+    // already be structurally consistent with the committed result. Currently
+    // it is NOT — `edit.insert` leaves a dangling empty `.line` span and drops
+    // the gap newline, so this fails (reproducing "shows the wrong thing for a
+    // second") until the async commit cleans it up.
+    expect(transientSig).toEqual(finalSig);
+  });
+
+  // -------------------------------------------------------------------------
+  // Clue B: ArrowUp navigation across empty lines is "weird".
+  // -------------------------------------------------------------------------
+  it('Clue B: ArrowUp across an empty line lands on the empty line, then the line above', async () => {
+    const initial = 'aaa\n\nbbb\nccc\n';
+    const { element } = await setupEditor(initial, { indentation: 2, caretSelector: '.line' });
+
+    // Start on "ccc" (line 3), column 1.
+    const start = 'aaa\n\nbbb\n'.length + 1;
+    await placeCaret(element, start);
+
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const step1 = caretLineColumn(element); // expect line 2 ("bbb")
+
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const step2 = caretLineColumn(element); // expect line 1 (empty)
+
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const step3 = caretLineColumn(element); // expect line 0 ("aaa")
+
+    // At the engine level the empty line IS reachable and each step lands on
+    // the expected row (this passes in all 3 browsers). If the "weird" ArrowUp
+    // behavior shows up in the real docs, it is not in this engine path —
+    // suspect the real frame/visibleFrames render or layout, not navigation.
+    expect(step1.line).toBe(2);
+    expect(step2.line).toBe(1); // the empty line — reachable, not skipped
+    expect(step3.line).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // New bug: TWO consecutive empty lines — ArrowUp skips both at once.
+  // -------------------------------------------------------------------------
+  it('Clue B2: ArrowUp stops on each of two consecutive empty lines (does not skip both)', async () => {
+    // Lines: 0 "aaa", 1 "" , 2 "", 3 "bbb", 4 "ccc".
+    const initial = 'aaa\n\n\nbbb\nccc\n';
+    const { element } = await setupEditor(initial, { indentation: 2, caretSelector: '.line' });
+
+    // Start on "bbb" (line 3), column 1.
+    const start = 'aaa\n\n\n'.length + 1;
+    await placeCaret(element, start);
+
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const step1 = caretLineColumn(element); // expect line 2 (second empty line)
+
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const step2 = caretLineColumn(element); // expect line 1 (first empty line)
+
+    await userEvent.keyboard('{ArrowUp}');
+    await settle();
+    const step3 = caretLineColumn(element); // expect line 0 ("aaa")
+
+    // DESIRED: ArrowUp stops on EACH line, including the zero-height empty ones.
+    // The bug skips both empty lines, so a single ArrowUp from "bbb" jumps
+    // straight to "aaa" (step1.line === 0).
+    const ctx = JSON.stringify({ step1, step2, step3 });
+    expect(step1.line, ctx).toBe(2); // second empty line
+    expect(step2.line, ctx).toBe(1); // first empty line
+    expect(step3.line, ctx).toBe(0); // "aaa"
+  });
+
+  // -------------------------------------------------------------------------
+  // Bug 4: first keystroke loses focus (async preParse path)
+  // -------------------------------------------------------------------------
+  it('Bug 4: editable keeps focus after the first keystroke (async preParse)', async () => {
+    const { element } = await setupEditor('hello\n', {
+      indentation: 2,
+      caretSelector: '.line',
+      preParse: asyncPreParse(),
+    });
+    await placeCaret(element, 5);
+    expect(document.activeElement).toBe(element);
+    await userEvent.keyboard('!');
+    await settle();
+    await settle();
+    expect(document.activeElement).toBe(element);
+  });
+});

--- a/packages/docs-infra/src/useCode/liveEditingBugs.browser.tsx
+++ b/packages/docs-infra/src/useCode/liveEditingBugs.browser.tsx
@@ -111,6 +111,12 @@ type HarnessHandle = {
   onChange: ReturnType<typeof vi.fn>;
   getSource: () => string;
   scrollEl: HTMLDivElement | null;
+  /**
+   * Forces an idle host re-render without touching the source — models an async
+   * enhancer / parent `setState` that re-runs the engine's `observeAndRestore`
+   * (and thus its caret/selection restore) between keystrokes.
+   */
+  rerender: () => void;
 };
 
 function Editor({
@@ -125,6 +131,7 @@ function Editor({
   scroll?: boolean;
 }) {
   const [source, setSource] = React.useState(initialSource);
+  const [, forceRerender] = React.useReducer((count: number) => count + 1, 0);
   const ref = React.useRef<HTMLPreElement | null>(null);
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
 
@@ -147,6 +154,7 @@ function Editor({
           ? onChange.mock.calls[onChange.mock.calls.length - 1][0]
           : initialSource,
       scrollEl: scrollRef.current,
+      rerender: forceRerender,
     };
   });
 
@@ -672,6 +680,66 @@ describe('live-editing bug repros', () => {
   });
 
   // -------------------------------------------------------------------------
+  // Bug 5: a BACKWARD Shift+Arrow selection keeps its focus at the top across a
+  // host re-render (the restore must not flip the focus to the bottom end).
+  // -------------------------------------------------------------------------
+  it('Bug 5: backward Shift+ArrowUp selection survives a re-render with the focus still at the top', async () => {
+    const initial = 'aaa\nbbb\nccc\nddd\n';
+    const { handle, element } = await setupEditor(initial, {
+      indentation: 2,
+      caretSelector: '.line',
+    });
+
+    // Reads the moving end (focus) and the fixed end (anchor) of the live
+    // selection as (line, column), so we can assert the selection DIRECTION —
+    // `caretLineColumn` only reports the forward-normalized range start.
+    const endPoint = (node: Node, offset: number) => {
+      const until = document.createRange();
+      until.setStart(element, 0);
+      until.setEnd(node, offset);
+      const lines = until.toString().split('\n');
+      return { line: lines.length - 1, column: lines[lines.length - 1].length };
+    };
+    const focusPoint = () => {
+      const sel = window.getSelection()!;
+      return endPoint(sel.focusNode!, sel.focusOffset);
+    };
+    const anchorPoint = () => {
+      const sel = window.getSelection()!;
+      return endPoint(sel.anchorNode!, sel.anchorOffset);
+    };
+
+    // Start collapsed on "ddd" (line 3), column 0, then grow the selection
+    // UPWARD twice so the focus is above the anchor (a backward range).
+    await placeCaret(element, 'aaa\nbbb\nccc\n'.length);
+    await userEvent.keyboard('{Shift>}{ArrowUp}{ArrowUp}{/Shift}');
+    await settle();
+
+    // Anchor stays on line 3; the focus has climbed two lines up to line 1.
+    expect(anchorPoint().line, 'anchor before re-render').toBe(3);
+    expect(focusPoint().line, 'focus before re-render').toBe(1);
+
+    // An idle host re-render (e.g. an async re-highlight committing) re-runs the
+    // engine's caret/selection restore. The backward direction must survive it.
+    act(() => {
+      handle.rerender();
+    });
+    await settle();
+
+    expect(anchorPoint().line, 'anchor after re-render').toBe(3);
+    // The bug: the restore rebuilt a forward range, flipping the focus to the
+    // bottom (line 3). With the fix the focus stays at the top (line 1).
+    expect(focusPoint().line, 'focus after re-render').toBe(1);
+
+    // And the next Shift+ArrowUp must keep extending from the TOP — landing the
+    // focus on line 0 — rather than collapsing the selection from the bottom.
+    await userEvent.keyboard('{Shift>}{ArrowUp}{/Shift}');
+    await settle();
+    expect(focusPoint().line, 'focus after a third Shift+ArrowUp').toBe(0);
+    expect(anchorPoint().line, 'anchor unchanged after third Shift+ArrowUp').toBe(3);
+  });
+
+  // -------------------------------------------------------------------------
   // Bug 4: first keystroke loses focus (async preParse path)
   // -------------------------------------------------------------------------
   it('Bug 4: editable keeps focus after the first keystroke (async preParse)', async () => {
@@ -686,5 +754,55 @@ describe('live-editing bug repros', () => {
     await settle();
     await settle();
     expect(document.activeElement).toBe(element);
+  });
+
+  // -------------------------------------------------------------------------
+  // Single-bound paging: PageDown engages only when `maxRow` is set and PageUp
+  // only when `minRow` is set — mirroring ArrowDown (needs `maxRow`) / ArrowUp
+  // (needs `minRow`). With only the OPPOSITE bound present the page key has no
+  // fold in its direction, so it falls through to native and must NOT fire
+  // `onBoundary`. Latent through `Pre` (which always supplies both bounds), but
+  // `Options.minRow`/`maxRow` are independently optional.
+  // -------------------------------------------------------------------------
+  it('pages to the fold only for the bound in its own direction', async () => {
+    const initial = 'line0\nline1\nline2\nline3\nline4\n';
+
+    // Only `maxRow` (a bottom fold, no top fold): PageDown expands, PageUp is native.
+    {
+      const onBoundary = vi.fn();
+      const { element } = await setupEditor(
+        initial,
+        { indentation: 2, caretSelector: '.line', maxRow: 2, onBoundary },
+        { scroll: true },
+      );
+      await placeCaret(element, 'line0\n'.length); // line 1, inside the window
+      await userEvent.keyboard('{PageUp}');
+      await settle();
+      expect(onBoundary, 'PageUp with no minRow stays native').not.toHaveBeenCalled();
+
+      await userEvent.keyboard('{PageDown}');
+      await settle();
+      expect(onBoundary, 'PageDown expands the bottom fold').toHaveBeenCalledTimes(1);
+      expect(caretLineColumn(element).line, 'caret jumped to the bottom edge').toBe(2);
+    }
+
+    // Only `minRow` (a top fold, no bottom fold): PageUp expands, PageDown is native.
+    {
+      const onBoundary = vi.fn();
+      const { element } = await setupEditor(
+        initial,
+        { indentation: 2, caretSelector: '.line', minRow: 2, onBoundary },
+        { scroll: true },
+      );
+      await placeCaret(element, 'line0\nline1\nline2\nline3\n'.length); // line 4, inside the window
+      await userEvent.keyboard('{PageDown}');
+      await settle();
+      expect(onBoundary, 'PageDown with no maxRow stays native').not.toHaveBeenCalled();
+
+      await userEvent.keyboard('{PageUp}');
+      await settle();
+      expect(onBoundary, 'PageUp expands the top fold').toHaveBeenCalledTimes(1);
+      expect(caretLineColumn(element).line, 'caret jumped to the top edge').toBe(2);
+    }
   });
 });

--- a/packages/docs-infra/src/useCode/useCode.ts
+++ b/packages/docs-infra/src/useCode/useCode.ts
@@ -45,6 +45,17 @@ export type UseCodeOpts = {
    */
   disabled?: boolean;
   /**
+   * Called when the code block is asked to expand its collapsed window — most
+   * importantly from the editor itself, when the caret navigates past the
+   * visible region (e.g. `ArrowUp` at the top of a collapsed block). Fires
+   * synchronously, *before* the expansion re-renders, so a host can capture the
+   * still-collapsed layout and engage a scroll anchor (e.g. `useCodeWindow`'s
+   * `anchorScroll('expand')`) — matching the timing of a click on the expand
+   * toggle. Without this, keyboard-driven expansion would jump the viewport
+   * instead of smoothly anchoring it.
+   */
+  onExpand?: () => void;
+  /**
    * Delay in milliseconds between a transform change and the actual swap
    * of the rendered file tree to the new transform. `selectedTransform`
    * still updates synchronously so UI controls reflect the change
@@ -239,6 +250,7 @@ export function useCode<T extends {} = {}>(
     saveHashVariantToLocalStorage = 'on-interaction',
     sourceEnhancers,
     disabled,
+    onExpand,
     transformDelay,
     transformLayoutShift = 'selected',
     strictCollapseInFocus = false,
@@ -519,7 +531,19 @@ export function useCode<T extends {} = {}>(
   const setExpanded = uiState.setExpanded;
   const swapInFlight = transforming !== null || !!context?.deferHighlight;
   const [pendingExpand, setPendingExpand] = React.useState(false);
+  // Keep the latest `onExpand` in a ref so the stable `expand` callback below
+  // can call it without changing identity (it is forwarded down to `<Pre>`).
+  const onExpandRef = React.useRef(onExpand);
+  React.useLayoutEffect(() => {
+    onExpandRef.current = onExpand;
+  });
   const expand = React.useCallback(() => {
+    // Notify the host synchronously, while the block is still collapsed, so it
+    // can capture the pre-expansion layout and engage a scroll anchor (the
+    // expansion itself is deferred below via `pendingExpand`). This mirrors the
+    // timing of clicking the expand toggle, where the host anchors the scroll
+    // before the layout changes.
+    onExpandRef.current?.();
     setPendingExpand(true);
   }, []);
   React.useEffect(() => {

--- a/packages/docs-infra/src/useCode/useCopyFunctionality.test.ts
+++ b/packages/docs-infra/src/useCode/useCopyFunctionality.test.ts
@@ -90,4 +90,43 @@ describe('collectVariantFiles', () => {
 
     expect(files).toEqual([{ name: 'a.js', source: 'const Button = 1;\nconst Checkbox = 2;' }]);
   });
+
+  it('decodes a transformed file the transform left untouched (still hastCompressed) from its `originalName` fallback', () => {
+    // A transform that only rewrote `a.js` passes `b.js` through as its original
+    // `hastCompressed` source. Copy must still resolve `b.js`'s dictionary by
+    // `originalName` instead of throwing on the un-decoded payload.
+    const selectedVariant: VariantCode = {
+      fileName: 'a.js',
+      source: 'const Button = 1;\nconst Checkbox = 2;',
+      extraFiles: {
+        'b.js': {
+          source: {
+            hastCompressed: compressHast(JSON.stringify(utilsRoot), fallbackToText(utilsFallback)),
+          },
+          fallback: utilsFallback,
+        },
+      },
+    };
+
+    const transformedFiles = {
+      files: [
+        { name: 'a.js', originalName: 'a.js', source: 'const Button = 1;\nconst Checkbox = 2;' },
+        {
+          name: 'b.js',
+          originalName: 'b.js',
+          source: {
+            hastCompressed: compressHast(JSON.stringify(utilsRoot), fallbackToText(utilsFallback)),
+          },
+        },
+      ],
+      filenameMap: { 'a.js': 'a.js', 'b.js': 'b.js' },
+    };
+
+    const files = collectVariantFiles(selectedVariant, transformedFiles, undefined);
+
+    expect(files).toEqual([
+      { name: 'a.js', source: 'const Button = 1;\nconst Checkbox = 2;' },
+      { name: 'b.js', source: 'export const myFunction = () => {};' },
+    ]);
+  });
 });

--- a/packages/docs-infra/src/useCode/useCopyFunctionality.ts
+++ b/packages/docs-infra/src/useCode/useCopyFunctionality.ts
@@ -40,16 +40,6 @@ export function collectVariantFiles(
     return [];
   }
 
-  // When a transform has produced files, prefer them so the copied snippet
-  // matches what the user is currently viewing. Transformed sources are live
-  // HAST (already decoded), so they need no decompression dictionary.
-  if (transformedFiles && transformedFiles.files.length > 0) {
-    return transformedFiles.files.map((file) => ({
-      name: file.name,
-      source: stringOrHastToString(file.source),
-    }));
-  }
-
   // Resolve per-file DEFLATE dictionaries from both places a fallback can
   // arrive (mirrors `resolvedFallbacks` in `useFileNavigation`): the passed
   // `fallbacks` (hoisted from a `ContentLoading` component) and the variant's
@@ -68,6 +58,18 @@ export function collectVariantFiles(
     if (typeof fileData === 'object' && fileData?.fallback) {
       resolvedFallbacks[name] = fileData.fallback;
     }
+  }
+
+  // When a transform has produced files, prefer them so the copied snippet
+  // matches what the user is currently viewing. Files the transform actually
+  // rewrote are live HAST (already decoded), but files it left untouched are
+  // passed through as their ORIGINAL source, which may still be `hastCompressed`
+  // and needs its dictionary — resolved here by `originalName`.
+  if (transformedFiles && transformedFiles.files.length > 0) {
+    return transformedFiles.files.map((file) => ({
+      name: file.name,
+      source: stringOrHastToString(file.source, resolvedFallbacks[file.originalName]),
+    }));
   }
 
   const files: MarkdownFile[] = [];

--- a/packages/docs-infra/src/useCode/useEditable.test.ts
+++ b/packages/docs-infra/src/useCode/useEditable.test.ts
@@ -1179,13 +1179,14 @@ describe('useEditable', () => {
       expect(pre.toString().length).toBe('hello\n '.length);
     });
 
-    it('Backspace at minColumn on a blank indented line collapses the line and lands the caret on the previous line', () => {
+    it('Backspace at minColumn on a blank indented line clears the indent and keeps the caret on the line', () => {
       // Three lines: `hello`, a blank line of exactly minColumn (4)
       // whitespace characters, and `world`. With the caret at the end of
-      // the blank line (column = minColumn), Backspace would normally
-      // delete one indent space and leave the caret in the clipped
-      // `[0, minColumn)` gutter. Instead we collapse the entire blank
-      // line so the caret lands at the end of `hello`.
+      // the blank line (column = minColumn), a single-character Backspace
+      // would leave the caret in the clipped `[0, minColumn)` gutter
+      // (invisible). Instead we clear the entire clipped indent so the line
+      // becomes truly empty and the caret lands at its (visible) column 0 —
+      // WITHOUT collapsing the line or jumping the caret to the previous one.
       const { element, onChange } = setup('hello\n    \n    world', {
         minColumn: 4,
         indentation: 2,
@@ -1201,16 +1202,18 @@ describe('useEditable', () => {
       element.dispatchEvent(keyDown);
 
       expect(keyDown.defaultPrevented).toBe(true);
-      expect(element.textContent).toBe('hello\n    world');
+      // The blank line is now empty; the line itself is preserved.
+      expect(element.textContent).toBe('hello\n\n    world');
       const range = window.getSelection()!.getRangeAt(0);
       const pre = document.createRange();
       pre.setStart(element, 0);
       pre.setEnd(range.startContainer, range.startOffset);
-      expect(pre.toString().length).toBe('hello'.length);
+      // Caret stays on the (now empty) blank line, not the previous line.
+      expect(pre.toString().length).toBe('hello\n'.length);
 
       element.dispatchEvent(new KeyboardEvent('keyup', { key: 'Backspace', bubbles: true }));
       const [text] = onChange.mock.calls[onChange.mock.calls.length - 1];
-      expect(text).toBe('hello\n    world\n');
+      expect(text).toBe('hello\n\n    world\n');
     });
 
     it('Backspace at minColumn on a non-blank indented line falls through to a single-character delete', () => {
@@ -1498,7 +1501,7 @@ describe('useEditable', () => {
 
       const ref = { current: element };
       const onChange = vi.fn<(text: string, position: Position) => void>();
-      const { unmount } = renderHook(
+      const { unmount, rerender } = renderHook(
         (props) => useEditable(props.ref, props.onChange, props.opts),
         { initialProps: { ref, onChange, opts } },
       );
@@ -1514,7 +1517,7 @@ describe('useEditable', () => {
         selection.addRange(range);
       }
 
-      return { element, placeInLine, unmount };
+      return { element, placeInLine, unmount, rerender: () => rerender({ ref, onChange, opts }) };
     }
 
     function dispatchArrow(element: HTMLElement, key: string) {
@@ -1612,6 +1615,84 @@ describe('useEditable', () => {
       expect(dispatchArrow(element, 'ArrowDown').defaultPrevented).toBe(false);
       placeInLine(1, 2);
       expect(dispatchArrow(element, 'ArrowUp').defaultPrevented).toBe(false);
+    });
+
+    it('steps onto a zero-height blank line on ArrowUp instead of letting the browser skip it', () => {
+      // A `.line` with no content renders at zero height (the gap newline is
+      // `line-height: 0`), so native vertical navigation skips it. The hook
+      // must move onto the blank line synchronously.
+      const { element, placeInLine } = setupLined(['head', '', 'world'], {
+        caretSelector: '.line',
+      });
+      placeInLine(2, 2); // on 'world'
+
+      const event = dispatchArrow(element, 'ArrowUp');
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(caretOffset(element)).toBe('head\n'.length); // start of the blank row 1
+    });
+
+    it('lands on the nearest blank line when two blank lines stack (ArrowUp does not skip both)', () => {
+      // Reproduces: "two empty lines, pressing up arrow skips both". One
+      // ArrowUp must advance exactly one row — onto the second blank line —
+      // not jump past both blanks to the non-empty line above.
+      const { element, placeInLine } = setupLined(['head', '', '', 'world'], {
+        caretSelector: '.line',
+      });
+      placeInLine(3, 2); // on 'world'
+
+      const event = dispatchArrow(element, 'ArrowUp');
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(caretOffset(element)).toBe('head\n\n'.length); // row 2 (second blank), not row 0
+    });
+
+    it('steps onto a zero-height blank line on ArrowDown instead of skipping it', () => {
+      const { element, placeInLine } = setupLined(['head', '', 'world'], {
+        caretSelector: '.line',
+      });
+      placeInLine(0, 2); // on 'head'
+
+      const event = dispatchArrow(element, 'ArrowDown');
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(caretOffset(element)).toBe('head\n'.length); // start of the blank row 1
+    });
+
+    it('keeps the caret where ArrowUp moved it after a boundary expand, not at the click position', () => {
+      // Repro: after ArrowUp at the boundary expands the block, the caret
+      // jumps back to where the user last clicked instead of staying where the
+      // ArrowUp left it. Cause: arrow moves never refreshed `state.position`,
+      // so the host re-render's caret restore replays the stale click position.
+      const onBoundary = vi.fn();
+      const { element, placeInLine, rerender } = setupLined(['head', 'world', 'tail'], {
+        caretSelector: '.line',
+        minRow: 1,
+        onBoundary,
+      });
+
+      // 1. Click at line 2 ("tail") — seeds `state.position` via mouseup.
+      placeInLine(2, 3);
+      element.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+
+      // 2. Caret is now on line 1 (the visible top / minRow), e.g. after the
+      //    user arrowed up — DOM caret moved but `state.position` is unchanged.
+      placeInLine(1, 3);
+
+      // 3. ArrowUp at minRow moves the caret onto line 0 and asks the host to
+      //    expand (onBoundary). The host re-renders; restore runs.
+      const event = dispatchArrow(element, 'ArrowUp');
+      expect(event.defaultPrevented).toBe(true);
+      expect(onBoundary).toHaveBeenCalledTimes(1);
+
+      // The expand re-render skips one restore (skipNextRestore); a later
+      // re-render then restores `state.position`.
+      rerender();
+      rerender();
+
+      // Caret should sit where ArrowUp left it (line 0, column 3 = "hea|d"),
+      // NOT back at the click position on line 2.
+      expect(caretOffset(element)).toBe('hea'.length);
     });
 
     it('does nothing when caretSelector is undefined', () => {

--- a/packages/docs-infra/src/useCode/useEditable.test.ts
+++ b/packages/docs-infra/src/useCode/useEditable.test.ts
@@ -965,6 +965,68 @@ describe('useEditable', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // forward delete (Delete key)
+  // ---------------------------------------------------------------------------
+  describe('forward delete', () => {
+    function dispatchDelete(element: HTMLElement) {
+      const keyDown = new KeyboardEvent('keydown', {
+        key: 'Delete',
+        code: 'Delete',
+        bubbles: true,
+        cancelable: true,
+      });
+      element.dispatchEvent(keyDown);
+      return keyDown;
+    }
+
+    it('deletes the character after the caret (collapsed)', () => {
+      const { element } = setup('hello world', { caretSelector: '.line' });
+      placeSelection(element, 'hello'.length); // caret before the space
+      const keyDown = dispatchDelete(element);
+      expect(keyDown.defaultPrevented).toBe(true);
+      // Non-emptying delete: the live DOM holds the edit until the keyup flush.
+      expect(element.textContent).toBe('helloworld');
+    });
+
+    it('merges the next line up when deleting at the end of a line', () => {
+      const { element } = setup('foo\nbar', { caretSelector: '.line' });
+      placeSelection(element, 'foo'.length); // caret at end of `foo`
+      const keyDown = dispatchDelete(element);
+      expect(keyDown.defaultPrevented).toBe(true);
+      expect(element.textContent).toBe('foobar');
+    });
+
+    it('deletes a non-collapsed selection forward', () => {
+      const { element } = setup('hello world', { caretSelector: '.line' });
+      placeSelection(element, 'hello'.length, ' world'.length); // select ` world`
+      const keyDown = dispatchDelete(element);
+      expect(keyDown.defaultPrevented).toBe(true);
+      expect(element.textContent).toBe('hello');
+    });
+
+    it('flushes synchronously when the delete empties a line (no transient empty line)', () => {
+      // Middle line is a single space; deleting it forward empties the line.
+      const { element, onChange } = setup('hello\n \nworld', { caretSelector: '.line' });
+      placeSelection(element, 'hello\n'.length); // caret at column 0 of the ` ` line
+      const keyDown = dispatchDelete(element);
+      expect(keyDown.defaultPrevented).toBe(true);
+      // Synchronous flush reverts the live DOM for React to re-render, so assert
+      // the engine's committed output (matching the Backspace-empty test above).
+      const [text, position] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(text).toBe('hello\n\nworld\n');
+      expect(position.position).toBe('hello\n'.length); // caret stays on the now-empty line
+    });
+
+    it('is a no-op at the very end of the document', () => {
+      const { element } = setup('hello', { caretSelector: '.line' });
+      placeSelection(element, 'hello'.length); // caret at the end
+      dispatchDelete(element);
+      // Nothing to delete forward — the content is unchanged.
+      expect(element.textContent).toBe('hello');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // minColumn option
   // ---------------------------------------------------------------------------
   describe('minColumn option', () => {
@@ -1202,18 +1264,17 @@ describe('useEditable', () => {
       element.dispatchEvent(keyDown);
 
       expect(keyDown.defaultPrevented).toBe(true);
+      // Emptying the line flushes synchronously (bypassing the async
+      // re-highlight) so React commits the cleared blank line in the same tick
+      // — there is no transient zero-height empty `.line` to flash. The flush
+      // reverts the live DOM for React to re-render from `onChange`, so in this
+      // static harness (mock `onChange`, no re-render) we verify the engine's
+      // authoritative output: the committed text and caret position.
+      const [text, position] = onChange.mock.calls[onChange.mock.calls.length - 1];
       // The blank line is now empty; the line itself is preserved.
-      expect(element.textContent).toBe('hello\n\n    world');
-      const range = window.getSelection()!.getRangeAt(0);
-      const pre = document.createRange();
-      pre.setStart(element, 0);
-      pre.setEnd(range.startContainer, range.startOffset);
-      // Caret stays on the (now empty) blank line, not the previous line.
-      expect(pre.toString().length).toBe('hello\n'.length);
-
-      element.dispatchEvent(new KeyboardEvent('keyup', { key: 'Backspace', bubbles: true }));
-      const [text] = onChange.mock.calls[onChange.mock.calls.length - 1];
       expect(text).toBe('hello\n\n    world\n');
+      // Caret stays on the (now empty) blank line, not the previous line.
+      expect(position.position).toBe('hello\n'.length);
     });
 
     it('Backspace at minColumn on a non-blank indented line falls through to a single-character delete', () => {

--- a/packages/docs-infra/src/useCode/useEditable.test.ts
+++ b/packages/docs-infra/src/useCode/useEditable.test.ts
@@ -565,7 +565,7 @@ describe('useEditable', () => {
   // ---------------------------------------------------------------------------
   describe('keyboard interactions', () => {
     it('calls onChange on Enter key', () => {
-      const { element } = setup('hello');
+      const { element, onChange } = setup('hello');
       placeSelection(element, 5);
 
       const event = new KeyboardEvent('keydown', {
@@ -577,8 +577,11 @@ describe('useEditable', () => {
       // bubbles:true ensures the window keydown listener receives it.
       element.dispatchEvent(event);
 
-      // The Enter handler calls edit.insert which modifies the DOM
-      expect(element.textContent).toContain('\n');
+      // Enter inserts a newline and reconciles synchronously (the raw DOM
+      // mutation is reverted and re-rendered from source via flushSync), so the
+      // newline surfaces in the reported content rather than the reverted DOM.
+      const [text] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(text).toContain('\n');
     });
 
     it('does not handle events from other elements', () => {
@@ -997,11 +1000,15 @@ describe('useEditable', () => {
     });
 
     it('deletes a non-collapsed selection forward', () => {
-      const { element } = setup('hello world', { caretSelector: '.line' });
+      const { element, onChange } = setup('hello world', { caretSelector: '.line' });
       placeSelection(element, 'hello'.length, ' world'.length); // select ` world`
       const keyDown = dispatchDelete(element);
       expect(keyDown.defaultPrevented).toBe(true);
-      expect(element.textContent).toBe('hello');
+      // A non-collapsed delete reconciles synchronously (reverts the live DOM for
+      // React to re-render — guarding the frame-wrapper-removal crash), so assert
+      // the engine's committed output rather than the reverted DOM.
+      const [text] = onChange.mock.calls[onChange.mock.calls.length - 1];
+      expect(text.replace(/\n$/, '')).toBe('hello');
     });
 
     it('flushes synchronously when the delete empties a line (no transient empty line)', () => {

--- a/packages/docs-infra/src/useCode/useEditableUtils.ts
+++ b/packages/docs-infra/src/useCode/useEditableUtils.ts
@@ -36,6 +36,17 @@ export interface Position {
    * stranded. Rides through undo as well so the reversal anchors identically.
    */
   deletedFromLineStart?: boolean;
+  /**
+   * Set when the tracked selection is a BACKWARD range — its focus (the moving
+   * end) sits at the range START, above/before the anchor. `position`/`extent`
+   * only describe the range's extent, not which end is the focus, so a backward
+   * Shift+Arrow selection that survives a host re-render would otherwise be
+   * rebuilt as a forward range (focus flipped to the bottom), making the next
+   * Shift+Arrow extend from the wrong end. The restore honors this flag by
+   * collapsing to the anchor then extending back to the focus. Absent for a
+   * collapsed caret or a forward selection.
+   */
+  backward?: boolean;
 }
 
 export const getCurrentRange = (): Range => {
@@ -452,4 +463,35 @@ export const adjustCursorAtNewlineBoundary = (range: Range): void => {
       }
     }
   }
+};
+
+/**
+ * Rebuild the browser selection from a tracked {@link Position} after a host
+ * re-render. Recreates the `[position, position + extent]` range (collapsed when
+ * `extent` is 0) and applies the newline-boundary nudge.
+ *
+ * When `position.backward` is set, the range is restored as a BACKWARD selection
+ * — anchor at the range end, focus at the range start — by collapsing to the end
+ * and extending back to the start. A range added via `Selection.addRange` is
+ * always forward, so without this a backward Shift+Arrow selection would have its
+ * focus flipped to the bottom end on every restore. Forward and collapsed
+ * positions take the plain `addRange` path unchanged.
+ */
+export const restoreSelection = (element: HTMLElement, position: Position): void => {
+  const range = makeRange(element, position.position, position.position + position.extent);
+  adjustCursorAtNewlineBoundary(range);
+
+  if (position.backward && position.extent > 0) {
+    const selection = window.getSelection();
+    if (selection) {
+      selection.removeAllRanges();
+      // Anchor at the bottom (range end), then move the focus up to the range
+      // start so the selection direction matches the user's Shift+Arrow.
+      selection.collapse(range.endContainer, range.endOffset);
+      selection.extend(range.startContainer, range.startOffset);
+      return;
+    }
+  }
+
+  setCurrentRange(range);
 };

--- a/packages/docs-infra/src/useCode/useEditableUtils.ts
+++ b/packages/docs-infra/src/useCode/useEditableUtils.ts
@@ -27,6 +27,15 @@ export interface Position {
    * edit pivoted on instead of guessing from the destination caret.
    */
   historyPivotLine?: number;
+  /**
+   * Set when the edit removed whole lines starting at the very beginning of a
+   * line (a selection delete whose start was at column 0). The post-edit caret
+   * then sits on the line that shifted up from BELOW the deletion, so the edit's
+   * anchor is one line higher than the caret implies. Derived state (comment
+   * map) must drop its anchor by one or markers on the deleted first line are
+   * stranded. Rides through undo as well so the reversal anchors identically.
+   */
+  deletedFromLineStart?: boolean;
 }
 
 export const getCurrentRange = (): Range => {

--- a/packages/docs-infra/src/useCode/useEditableUtils.ts
+++ b/packages/docs-infra/src/useCode/useEditableUtils.ts
@@ -11,6 +11,22 @@ export interface Position {
   extent: number;
   content: string;
   line: number;
+  /**
+   * Set only when this position originates from an undo/redo navigation, naming
+   * the direction. On `'undo'` the caret is the PRE-edit position (it did not
+   * move as forward typing would), so derived state (e.g. the comment/highlight
+   * map) must reverse the edit rather than assume a post-edit caret. Absent for
+   * a fresh edit.
+   */
+  history?: 'undo' | 'redo';
+  /**
+   * On an `'undo'`, the 0-indexed line the reversed edit was anchored at — its
+   * POST-edit caret line, which can differ from this (destination) caret when
+   * the edit ran over a selection that didn't start at the caret (e.g. Select
+   * All). Lets derived state reverse the edit at the exact line the forward
+   * edit pivoted on instead of guessing from the destination caret.
+   */
+  historyPivotLine?: number;
 }
 
 export const getCurrentRange = (): Range => {

--- a/packages/docs-infra/src/useCode/useSourceEditing.test.ts
+++ b/packages/docs-infra/src/useCode/useSourceEditing.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { Position } from 'use-editable';
 import { useSourceEditing, preloadSourceEditingEngine } from './useSourceEditing';
+import { analyzeSource } from './SourceEditingEngine';
 import type { Code, ControlledCode, VariantCode, SourceComments } from '../CodeHighlighter/types';
 import type { CodeHighlighterContextType } from '../CodeHighlighter/CodeHighlighterContext';
 
@@ -418,7 +419,69 @@ describe('useSourceEditing', () => {
     });
   });
 
+  describe('analyzeSource', () => {
+    it('counts a source without a trailing newline', () => {
+      expect(analyzeSource('a\nb\nc').totalLines).toBe(3);
+    });
+
+    it('ignores a single trailing newline so terminated and unterminated sources agree', () => {
+      // The contentEditable always appends a trailing newline; the original
+      // source may not. Both must report the same line count so the first edit
+      // sees a 0 line delta (no phantom comment/emphasis shift).
+      expect(analyzeSource('a\nb').totalLines).toBe(2);
+      expect(analyzeSource('a\nb\n').totalLines).toBe(2);
+    });
+
+    it('counts interior blank lines but not the phantom trailing line', () => {
+      expect(analyzeSource('a\n\nb\n')).toEqual({ totalLines: 3, emptyLines: [2] });
+    });
+
+    it('treats an empty source and a lone newline as a single empty line', () => {
+      expect(analyzeSource('')).toEqual({ totalLines: 1, emptyLines: [1] });
+      expect(analyzeSource('\n')).toEqual({ totalLines: 1, emptyLines: [1] });
+    });
+
+    it('only ignores ONE trailing newline (a blank last line still counts)', () => {
+      // `a`, `b`, then a genuine blank line — the second trailing newline is the
+      // terminator that gets ignored, leaving the blank line as line 3.
+      expect(analyzeSource('a\nb\n\n')).toEqual({ totalLines: 3, emptyLines: [3] });
+    });
+  });
+
   describe('comment shifting', () => {
+    it('does not shift comments when an edit only adds the contentEditable trailing newline', () => {
+      // The live contentEditable always serializes its text WITH a trailing
+      // newline, but the host source here has none. Typing a character adds no
+      // line, yet the edited text gains that trailing newline. The shift delta
+      // must read 0 (not +1) so the highlight comment stays put — otherwise the
+      // first edit drifts every emphasis frame down a line.
+      const comments: SourceComments = { 2: ['@highlight'] };
+      const originalSource = 'line0\nline1\nline2'; // host source: no trailing newline
+      const editedSource = 'line0X\nline1\nline2\n'; // char typed + CE trailing newline
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      act(() => result.current.setSource!(editedSource, undefined, pos(0)));
+
+      const controlled = captureControlledCode(context);
+      // The highlight stays on line 2 — it must not drift to line 3.
+      expect(controlled!.Default!.comments).toEqual({ 2: ['@highlight'] });
+    });
+
     it('shifts comments down when lines are added, and reverses on undo', () => {
       const comments: SourceComments = { 1: ['@highlight'], 4: ['@focus'] };
       const originalSource = 'line0\nline1\nline2\nline3';
@@ -837,6 +900,106 @@ describe('useSourceEditing', () => {
 
       expect(undone!.Default!.comments).toEqual({ 1: ['@main-highlight'] });
       expect(undone!.Default!.extraFiles!['styles.css'].comments).toEqual(extraComments);
+    });
+
+    it('restores the exact comment map on undo/redo of a line merge', () => {
+      // A forward Delete at the end of line 2 merges line 3 up. Undo restores the
+      // pre-merge caret (0-indexed line 1) — the SAME position the merge reported —
+      // so without a direction signal a relative re-shift cannot tell undo-of-a-merge
+      // from forward typing and would drift the highlighted range. The `history`
+      // flag tells `shiftComments` to reverse the edit after the pre-edit caret.
+      const comments: SourceComments = {
+        2: ['@highlight-start'],
+        4: ['@highlight-end'],
+      };
+      const originalSource = 'a\nb\nc\nd\ne';
+      const mergedSource = 'a\nbc\nd\ne'; // line 3 merged up into line 2
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      // Forward merge: caret stays at the join (0-indexed line 1), delta -1.
+      act(() => result.current.setSource!(mergedSource, undefined, pos(1)));
+      const merged = captureControlledCode(context);
+      const mergedComments = merged!.Default!.comments;
+
+      // Undo: restore the original source with a history-flagged position.
+      act(() =>
+        result.current.setSource!(originalSource, undefined, { ...pos(1), history: 'undo' }),
+      );
+      const undone = captureControlledCode(context, merged);
+      expect(undone!.Default!.comments).toEqual(comments);
+
+      // Redo: re-apply the merge (a deletion) relative to the post-merge caret.
+      act(() => result.current.setSource!(mergedSource, undefined, { ...pos(1), history: 'redo' }));
+      const redone = captureControlledCode(context, undone);
+      expect(redone!.Default!.comments).toEqual(mergedComments);
+    });
+
+    it('removes a fully-selected range on delete and restores it on undo', () => {
+      // Selecting both ends of a range (here lines 3-5) plus the lines around it
+      // and deleting leaves nowhere to shift the markers to, so the frame is
+      // removed entirely — but its ends are stashed in the collapseMap so undo
+      // rebuilds the frame at its original offsets.
+      const comments: SourceComments = {
+        3: ['@highlight-start'],
+        5: ['@highlight-end'],
+      };
+      const originalSource = 'a\nb\nc\nd\ne\nf\ng';
+      // Delete lines 2-6 (padding b/f AND the whole range c/d/e). delta = -5.
+      const editedSource = 'a\ng';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      // Delete: caret collapses to line 2 (0-indexed 1) — this is the pivot.
+      act(() => result.current.setSource!(editedSource, undefined, pos(1)));
+      const deleted = captureControlledCode(context);
+
+      // The frame is gone (no markers remain visible)...
+      expect(deleted!.Default!.comments).toEqual({});
+      // ...but both ends are stashed so undo can reopen it.
+      expect(deleted!.Default!.collapseMap).toBeDefined();
+
+      // Undo: the restored caret lands on a DIFFERENT line than the deletion's
+      // collapse point (as a select-all does — the caret was elsewhere when the
+      // selection was made). `historyPivotLine` carries the forward edit's anchor
+      // so the reversal still pivots on the collapse line and finds the stash.
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(3),
+          history: 'undo',
+          historyPivotLine: 1,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+      expect(undone!.Default!.comments).toEqual(comments);
     });
 
     it('partially restores collapsed comments when fewer lines are re-added', () => {

--- a/packages/docs-infra/src/useCode/useSourceEditing.test.ts
+++ b/packages/docs-infra/src/useCode/useSourceEditing.test.ts
@@ -1070,6 +1070,244 @@ describe('useSourceEditing', () => {
       expect(undone!.Default!.comments).toEqual(comments);
     });
 
+    it('collapses comments onto the new first line when the deletion starts at line 1', () => {
+      // Column-0 selection delete that reaches the VERY FIRST line: there is no
+      // surviving line above, so the post-delete caret lands on the line that
+      // shifted up from below (now 0-indexed line 0). The deleted first line's
+      // comments must collapse onto the new line 1 (a valid 1-indexed key), NOT
+      // a phantom line 0 — otherwise they are stranded and undo can't rebuild.
+      const comments: SourceComments = {
+        1: ['@a'],
+        2: ['@b'],
+        4: ['@d'],
+      };
+      const originalSource = 'a\nb\nc\nd';
+      // Select lines 1-3 (a/b/c) from line 1 column 0 and delete → 'd'. delta -3.
+      const editedSource = 'd';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      act(() =>
+        result.current.setSource!(editedSource, undefined, {
+          ...pos(0),
+          deletedFromLineStart: true,
+        }),
+      );
+      const deleted = captureControlledCode(context);
+      const variant = deleted!.Default!;
+
+      // @a and @b collapse onto the new line 1; @d (a survivor) shifts there too.
+      expect(variant.comments![1]).toEqual(['@a', '@b', '@d']);
+      // Nothing stranded on the invalid line 0.
+      expect(variant.comments![0]).toBeUndefined();
+      // The collapsed comments are tracked at their offsets from the new line 1.
+      expect(variant.collapseMap![1]).toEqual([
+        { offset: 0, comments: ['@a'] },
+        { offset: 1, comments: ['@b'] },
+      ]);
+
+      // Undo: re-add the 3 lines. The caret is restored to line 0 and the
+      // column-0 flag rides along, so the reversal anchors identically.
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(0),
+          history: 'undo',
+          historyPivotLine: 0,
+          deletedFromLineStart: true,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+
+      // Comments fully restored to their original lines; @d back on line 4.
+      expect(undone!.Default!.comments).toEqual(comments);
+      expect(undone!.Default!.collapseMap).toBeUndefined();
+    });
+
+    it('collapses a single-line column-0 merge at the top of the file and reverses on undo', () => {
+      // The single-line variant of the top-of-file case: a column-0 selection
+      // that removes exactly the first line. The deleted line's comment collapses
+      // onto the new line 1 and the survivor below shifts up onto it.
+      const comments: SourceComments = {
+        1: ['@a'],
+        2: ['@b'],
+      };
+      const originalSource = 'a\nb\nc';
+      // Select line 1 ('a\n') from column 0 and delete → 'b\nc'. delta -1.
+      const editedSource = 'b\nc';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      act(() =>
+        result.current.setSource!(editedSource, undefined, {
+          ...pos(0),
+          deletedFromLineStart: true,
+        }),
+      );
+      const deleted = captureControlledCode(context);
+
+      // @a collapses onto the new line 1; @b (old line 2) shifts up onto it.
+      expect(deleted!.Default!.comments![1]).toEqual(['@a', '@b']);
+      expect(deleted!.Default!.comments![0]).toBeUndefined();
+
+      // Undo restores the original lines exactly.
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(0),
+          history: 'undo',
+          historyPivotLine: 0,
+          deletedFromLineStart: true,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+      expect(undone!.Default!.comments).toEqual(comments);
+      expect(undone!.Default!.collapseMap).toBeUndefined();
+    });
+
+    it('removes a fully-deleted range that starts at line 1 and rebuilds it on undo', () => {
+      // The whole range sits at the top of the file and both its ends are deleted
+      // by a column-0 selection. With no surviving line above, the frame's ends
+      // must stash at offsets from the new line 1 so undo reopens it intact.
+      const comments: SourceComments = {
+        1: ['@highlight-start'],
+        2: ['@highlight-end'],
+      };
+      const originalSource = 'a\nb\nc\nd';
+      // Select lines 1-3 from column 0 and delete → 'd'. delta -3.
+      const editedSource = 'd';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      act(() =>
+        result.current.setSource!(editedSource, undefined, {
+          ...pos(0),
+          deletedFromLineStart: true,
+        }),
+      );
+      const deleted = captureControlledCode(context);
+
+      // The frame is gone (no markers stranded on line 0 or anywhere)...
+      expect(deleted!.Default!.comments).toEqual({});
+      // ...but both ends are stashed at the new line 1 — each at its own offset
+      // from that anchor (old line 1 → 0, old line 2 → 1) — so undo reopens it.
+      expect(deleted!.Default!.collapseMap![1]).toEqual([
+        { offset: 0, comments: ['@highlight-start'] },
+        { offset: 1, comments: ['@highlight-end'] },
+      ]);
+
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(0),
+          history: 'undo',
+          historyPivotLine: 0,
+          deletedFromLineStart: true,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+      expect(undone!.Default!.comments).toEqual(comments);
+      expect(undone!.Default!.collapseMap).toBeUndefined();
+    });
+
+    it('leaves a column-0 delete in the MIDDLE of the file unchanged by the top-of-file handling', () => {
+      // Regression guard: the top-of-file fix must not touch a column-0 delete
+      // that has a surviving line above it. Here the surviving line above keeps
+      // its comment AND receives the collapsed ones; survivors below shift up.
+      const comments: SourceComments = {
+        2: ['@above'],
+        3: ['@c'],
+        5: ['@e'],
+      };
+      const originalSource = 'a\nb\nc\nd\ne\nf';
+      // Select lines 3-4 (c/d) from line 3 column 0 and delete → 'a\nb\ne\nf'. delta -2.
+      const editedSource = 'a\nb\ne\nf';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      // Caret collapses onto 0-indexed line 2; the column-0 flag drops the anchor
+      // to surviving line 2 (1-indexed). delta -2.
+      act(() =>
+        result.current.setSource!(editedSource, undefined, {
+          ...pos(2),
+          deletedFromLineStart: true,
+        }),
+      );
+      const deleted = captureControlledCode(context);
+      const variant = deleted!.Default!;
+
+      // @above stays on its surviving line and @c collapses onto it.
+      expect(variant.comments![2]).toEqual(['@above', '@c']);
+      // @e (old line 5) shifts up by 2 to line 3.
+      expect(variant.comments![3]).toEqual(['@e']);
+
+      // Undo restores everything exactly.
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(2),
+          history: 'undo',
+          historyPivotLine: 2,
+          deletedFromLineStart: true,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+      expect(undone!.Default!.comments).toEqual(comments);
+      expect(undone!.Default!.collapseMap).toBeUndefined();
+    });
+
     it('restores a shrunk range exactly on undo when only the -end was deleted', () => {
       // A partial-range delete: the selection covers the range's `-end` but its
       // `-start` survives above the deletion. The live view SHRINKS — the `-end`

--- a/packages/docs-infra/src/useCode/useSourceEditing.test.ts
+++ b/packages/docs-infra/src/useCode/useSourceEditing.test.ts
@@ -760,8 +760,12 @@ describe('useSourceEditing', () => {
       // This preserves the range [2, 3] instead of shrinking to [2, 2]
       expect(variant.comments![4]).toEqual(['@highlight-end']);
       expect(variant.comments![3]).toBeUndefined();
-      // Boundary comments are not tracked in collapseMap
-      expect(variant.collapseMap).toBeUndefined();
+      // The boundary marker is also stashed at its true offset (flagged
+      // `boundary`) so an undo can restore it exactly. A forward re-insert
+      // ignores the stash and lets the visible copy expand the range.
+      expect(variant.collapseMap![3]).toEqual([
+        { offset: 1, comments: ['@highlight-end'], boundary: true },
+      ]);
 
       // Re-add a line: @highlight-end shifts normally from 4 to 5,
       // expanding the range to include the new line.
@@ -808,8 +812,13 @@ describe('useSourceEditing', () => {
       expect(variant.comments![2]).toEqual(['@highlight-start', '@regular']);
       // @highlight-end at editLine+1 = 3, @after shifts from 6 to 3
       expect(variant.comments![3]).toEqual(['@highlight-end', '@after']);
-      // Only @regular tracked in collapseMap, not @highlight-end
-      expect(variant.collapseMap![2]).toEqual([{ offset: 2, comments: ['@regular'] }]);
+      // @regular tracked for restore; @highlight-end is also stashed but flagged
+      // `boundary` so it only restores on an undo (a forward re-insert lets the
+      // visible boundary copy expand the range — see the re-add assertions below).
+      expect(variant.collapseMap![2]).toEqual([
+        { offset: 2, comments: ['@regular'] },
+        { offset: 3, comments: ['@highlight-end'], boundary: true },
+      ]);
 
       // Re-add 3 lines: @regular restores from collapseMap to line 4,
       // but @highlight-end and @after shift normally from 3 to 6.
@@ -1000,6 +1009,168 @@ describe('useSourceEditing', () => {
       );
       const undone = captureControlledCode(context, deleted);
       expect(undone!.Default!.comments).toEqual(comments);
+    });
+
+    it('anchors the deletion one line up when the selection started at column 0', () => {
+      // Selecting from the very start of the range's first line (column 0)
+      // through its end deletes whole lines from that first line down, so the
+      // post-delete caret lands on the line that shifted UP from below the
+      // deletion — one line lower than the edit's true anchor. `deletedFromLineStart`
+      // corrects for that so the deleted first line isn't treated as surviving
+      // (which would strand `@highlight-start`) and the frame is removed cleanly.
+      const comments: SourceComments = {
+        2: ['@highlight-start'],
+        4: ['@highlight-end'],
+      };
+      const originalSource = 'a\nb\nc\nd\ne';
+      // Delete lines 2-4 (the whole range b/c/d) selecting b from column 0. The
+      // caret collapses onto the line that was 'e' (now 0-indexed line 1).
+      const editedSource = 'a\ne';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      act(() =>
+        result.current.setSource!(editedSource, undefined, {
+          ...pos(1),
+          deletedFromLineStart: true,
+        }),
+      );
+      const deleted = captureControlledCode(context);
+
+      // The whole frame is gone — the start marker was NOT stranded on a
+      // surviving line — and both ends are stashed for undo.
+      expect(deleted!.Default!.comments).toEqual({});
+      expect(deleted!.Default!.collapseMap).toBeDefined();
+
+      // Undo carries the same column-0 flag so it anchors on the same line and
+      // rebuilds the frame at its original offsets.
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(1),
+          history: 'undo',
+          historyPivotLine: 1,
+          deletedFromLineStart: true,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+      expect(undone!.Default!.comments).toEqual(comments);
+    });
+
+    it('restores a shrunk range exactly on undo when only the -end was deleted', () => {
+      // A partial-range delete: the selection covers the range's `-end` but its
+      // `-start` survives above the deletion. The live view SHRINKS — the `-end`
+      // collapses to the boundary (editLine+1) — but an undo must rebuild the
+      // range EXACTLY at its original lines, not one line short or long.
+      const comments: SourceComments = {
+        2: ['@highlight-start'],
+        5: ['@highlight-end'],
+      };
+      const originalSource = 'a\nb\nc\nd\ne\nf';
+      // Select from line 3 column 0 through line 5 and delete → 'a\nb\nf'.
+      const editedSource = 'a\nb\nf';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      // Delete: caret collapses to 0-indexed line 2; the column-0 start drops the
+      // anchor one line, so editLine = 2. delta = -3.
+      act(() =>
+        result.current.setSource!(editedSource, undefined, {
+          ...pos(2),
+          deletedFromLineStart: true,
+        }),
+      );
+      const deleted = captureControlledCode(context);
+
+      // Live view shrinks: -start stays on line 2, -end collapses to editLine+1.
+      expect(deleted!.Default!.comments![2]).toEqual(['@highlight-start']);
+      expect(deleted!.Default!.comments![3]).toEqual(['@highlight-end']);
+      // The -end is stashed at its true offset, flagged boundary, for undo.
+      expect(deleted!.Default!.collapseMap![2]).toEqual([
+        { offset: 3, comments: ['@highlight-end'], boundary: true },
+      ]);
+
+      // Undo restores the range EXACTLY (5, not 6).
+      act(() =>
+        result.current.setSource!(originalSource, undefined, {
+          ...pos(2),
+          history: 'undo',
+          historyPivotLine: 2,
+          deletedFromLineStart: true,
+        }),
+      );
+      const undone = captureControlledCode(context, deleted);
+      expect(undone!.Default!.comments).toEqual(comments);
+      expect(undone!.Default!.collapseMap).toBeUndefined();
+    });
+
+    it('expands a shrunk range on a forward re-insert (not an undo) of the -end', () => {
+      // The mirror of the undo case: after the same partial delete, RE-INSERTING
+      // lines forward (no history flag) must let the boundary -end expand the
+      // range — the stashed boundary entry is ignored on a non-undo re-insert.
+      const comments: SourceComments = {
+        2: ['@highlight-start'],
+        5: ['@highlight-end'],
+      };
+      const originalSource = 'a\nb\nc\nd\ne\nf';
+      const editedSource = 'a\nb\nf';
+      const selectedVariant: VariantCode = {
+        fileName: 'App.tsx',
+        source: originalSource,
+        comments,
+      };
+      const effectiveCode: Code = { Default: selectedVariant };
+      const context = createContext();
+
+      const { result } = renderHook(() =>
+        useSourceEditing({
+          context,
+          selectedVariantKey: 'Default',
+          effectiveCode,
+          selectedVariant,
+        }),
+      );
+
+      // Delete lines c, d, e (caret stays at 0-indexed line 1 → editLine 2).
+      act(() => result.current.setSource!(editedSource, undefined, pos(1)));
+      const deleted = captureControlledCode(context);
+
+      // Forward re-insert 3 lines (caret 0-indexed line 4 → editLine 2, no
+      // history). The boundary -end (now visible on line 3) shifts a full +3 to
+      // expand the range; the stash is discarded.
+      act(() => result.current.setSource!(originalSource, undefined, pos(4)));
+      const expanded = captureControlledCode(context, deleted);
+
+      expect(expanded!.Default!.comments![2]).toEqual(['@highlight-start']);
+      expect(expanded!.Default!.comments![6]).toEqual(['@highlight-end']);
+      expect(expanded!.Default!.collapseMap).toBeUndefined();
     });
 
     it('partially restores collapsed comments when fewer lines are re-added', () => {

--- a/packages/docs-infra/src/useCode/useSourceEditing.ts
+++ b/packages/docs-infra/src/useCode/useSourceEditing.ts
@@ -5,7 +5,12 @@ import type { Root as HastRoot } from 'hast';
 // keeps that engine chunk from statically pulling it (and `hastDecompress`).
 import { stringOrHastToString } from '../pipeline/hastUtils';
 import type { Position } from './useEditable';
-import type { Code, ControlledCode, VariantCode } from '../CodeHighlighter/types';
+import type {
+  Code,
+  ControlledCode,
+  ControlledVariantCode,
+  VariantCode,
+} from '../CodeHighlighter/types';
 import type { CodeHighlighterContextType } from '../CodeHighlighter/CodeHighlighterContext';
 import { useCodeContext } from '../CodeProvider/CodeContext';
 import {
@@ -143,51 +148,70 @@ export function useSourceEditing({
           const effectiveFileName = fileName ?? selectedVariant?.fileName;
           const isMainFile = effectiveFileName === selectedVariant?.fileName;
 
+          // Recompute the edited file's comment/window state for `source`.
+          // `shiftComments` shifts the comment map by the line delta relative to
+          // the edit position; on undo/redo the `position.history` flag tells it
+          // to reverse the edit (re-inserting deleted lines after the pre-edit
+          // caret), and its `collapseMap` restores comments that a deletion
+          // collapsed — so undo/redo is reversed from existing state, with no
+          // per-edit snapshots kept. `entry` is the file being edited (main
+          // variant or an extra file); both expose the same
+          // source/comments/collapseMap/totalLines/emptyLines shape.
+          const deriveFileState = (
+            entry:
+              | Pick<
+                  ControlledVariantCode,
+                  'source' | 'comments' | 'collapseMap' | 'totalLines' | 'emptyLines'
+                >
+              | undefined,
+            nextSource: string,
+          ) => {
+            // `analyzeSource` ignores a single trailing newline, so the host
+            // source (often unterminated) and the live contentEditable text
+            // (always terminated) report consistent line counts — the delta is
+            // 0 when no line was actually added or removed.
+            const { totalLines, emptyLines } = engine.analyzeSource(nextSource);
+            if (!position) {
+              return { comments: undefined, collapseMap: undefined, totalLines, emptyLines };
+            }
+            const oldLineCount =
+              entry?.totalLines ??
+              (entry?.source != null ? engine.analyzeSource(entry.source).totalLines : 0);
+            const { comments, collapseMap } = engine.shiftComments(
+              entry?.comments,
+              totalLines - oldLineCount,
+              position,
+              entry?.collapseMap,
+              entry?.emptyLines,
+            );
+            return { comments, collapseMap, totalLines, emptyLines };
+          };
+
           if (isMainFile) {
             if (source === variant.source) {
               return currentCode ?? newCode;
             }
-            const { totalLines: newLineCount, emptyLines: newEmptyLines } =
-              engine.analyzeSource(source);
-            const oldLineCount =
-              variant.totalLines ??
-              (variant.source != null ? engine.analyzeSource(variant.source).totalLines : 0);
-            const { comments: shiftedComments, collapseMap: newCollapseMap } = position
-              ? engine.shiftComments(
-                  variant.comments,
-                  newLineCount - oldLineCount,
-                  position,
-                  variant.collapseMap,
-                  variant.emptyLines,
-                )
-              : { comments: undefined, collapseMap: undefined };
+            const { totalLines, emptyLines, comments, collapseMap } = deriveFileState(
+              variant,
+              source,
+            );
             newCode[selectedVariantKey] = {
               ...variant,
               source,
-              totalLines: newLineCount,
-              emptyLines: newEmptyLines,
-              comments: shiftedComments,
-              collapseMap: newCollapseMap,
+              totalLines,
+              emptyLines,
+              comments,
+              collapseMap,
             };
           } else if (effectiveFileName) {
             const extraEntry = variant.extraFiles?.[effectiveFileName];
             if (source === extraEntry?.source) {
               return currentCode ?? newCode;
             }
-            const { totalLines: newLineCount, emptyLines: newEmptyLines } =
-              engine.analyzeSource(source);
-            const oldLineCount =
-              extraEntry?.totalLines ??
-              (extraEntry?.source != null ? engine.analyzeSource(extraEntry.source).totalLines : 0);
-            const { comments: shiftedComments, collapseMap: newCollapseMap } = position
-              ? engine.shiftComments(
-                  extraEntry?.comments,
-                  newLineCount - oldLineCount,
-                  position,
-                  extraEntry?.collapseMap,
-                  extraEntry?.emptyLines,
-                )
-              : { comments: undefined, collapseMap: undefined };
+            const { totalLines, emptyLines, comments, collapseMap } = deriveFileState(
+              extraEntry,
+              source,
+            );
             newCode[selectedVariantKey] = {
               ...variant,
               extraFiles: {
@@ -195,10 +219,10 @@ export function useSourceEditing({
                 [effectiveFileName]: {
                   ...extraEntry,
                   source,
-                  totalLines: newLineCount,
-                  emptyLines: newEmptyLines,
-                  comments: shiftedComments,
-                  collapseMap: newCollapseMap,
+                  totalLines,
+                  emptyLines,
+                  comments,
+                  collapseMap,
                 },
               },
             };

--- a/packages/docs-infra/src/useCode/user.spec.ts
+++ b/packages/docs-infra/src/useCode/user.spec.ts
@@ -1356,6 +1356,36 @@ describe('useCode integration tests', () => {
       expect(result.current.expanded).toBe(true);
     });
 
+    it('fires onExpand synchronously, while still collapsed, when expand() is called', async () => {
+      // The editor's `onBoundary` (e.g. ArrowUp at the top of a collapsed
+      // block) calls `expand()`. `onExpand` must fire BEFORE the block reports
+      // expanded so a host can anchor the scroll against the still-collapsed
+      // layout — otherwise keyboard-driven expansion jumps the viewport.
+      const contentProps: ContentProps<{}> = {
+        code: { Default: { fileName: 'demo.js', source: 'const x = 1;' } },
+      };
+      const handle: { expanded?: boolean } = {};
+      let expandedWhenOnExpandFired: boolean | undefined;
+      const onExpand = vi.fn(() => {
+        expandedWhenOnExpandFired = handle.expanded;
+      });
+
+      const { result } = renderHook(() => {
+        const code = useCode(contentProps, { onExpand });
+        handle.expanded = code.expanded;
+        return code;
+      });
+      expect(onExpand).not.toHaveBeenCalled();
+
+      act(() => {
+        result.current.expand();
+      });
+
+      expect(onExpand).toHaveBeenCalledTimes(1);
+      expect(expandedWhenOnExpandFired).toBe(false); // fired before the expansion
+      expect(result.current.expanded).toBe(true);
+    });
+
     it('keeps setExpanded synchronous even during a variant swap', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/docs-infra/src/useCodeWindow/useCodeWindow.test.ts
+++ b/packages/docs-infra/src/useCodeWindow/useCodeWindow.test.ts
@@ -264,6 +264,53 @@ describe('useCodeWindow', () => {
     expect(pre.getAttribute('data-scrollbar-gutter')).toBe('expand-from');
   });
 
+  it('animates the expand gutter for a collapse-to-empty block whose collapsed content does not overflow', () => {
+    setupResizeObserver();
+    const { result } = renderHook(() => useCodeWindow());
+
+    const { container, pre, code } = buildContainer();
+    // A collapse-to-empty block (`data-focused-lines="0"`) shows nothing while
+    // collapsed, so its `scrollWidth` is narrow and can't predict the (wide)
+    // post-expand source the way a normal collapsed snippet's would.
+    code.setAttribute('data-collapsible', '');
+    code.setAttribute('data-focused-lines', '0');
+    Object.defineProperty(pre, 'offsetHeight', { value: 30, configurable: true });
+    Object.defineProperty(pre, 'clientHeight', { value: 20, configurable: true });
+    Object.defineProperty(pre, 'clientWidth', { value: 100, configurable: true });
+    Object.defineProperty(code, 'scrollWidth', { value: 50, configurable: true });
+    result.current.containerRef.current = container;
+
+    act(() => {
+      result.current.anchorScroll('expand');
+    });
+
+    // Engages despite the narrow collapsed width, so `overflow-x` stays hidden
+    // through the reveal instead of flashing a scrollbar mid-expand.
+    expect(pre.getAttribute('data-scrollbar-gutter')).toBe('expand-from');
+  });
+
+  it('still skips the gutter when collapsing an empty-focus block whose content fits', () => {
+    setupResizeObserver();
+    const { result } = renderHook(() => useCodeWindow());
+
+    const { container, pre, code } = buildContainer();
+    code.setAttribute('data-collapsible', '');
+    code.setAttribute('data-focused-lines', '0');
+    Object.defineProperty(pre, 'offsetHeight', { value: 30, configurable: true });
+    Object.defineProperty(pre, 'clientHeight', { value: 20, configurable: true });
+    Object.defineProperty(pre, 'clientWidth', { value: 100, configurable: true });
+    Object.defineProperty(code, 'scrollWidth', { value: 50, configurable: true });
+    result.current.containerRef.current = container;
+
+    act(() => {
+      result.current.anchorScroll('collapse');
+    });
+
+    // The bypass is expand-only — on collapse the current width is real, so a
+    // block that fits still skips the swap.
+    expect(pre.hasAttribute('data-scrollbar-gutter')).toBe(false);
+  });
+
   it('drives the gutter on the attached scrollContainerRef instead of the pre', () => {
     setupResizeObserver();
     const { result } = renderHook(() => useCodeWindow());

--- a/packages/docs-infra/src/useCodeWindow/useCodeWindow.ts
+++ b/packages/docs-infra/src/useCodeWindow/useCodeWindow.ts
@@ -252,7 +252,16 @@ function animateScrollbarGutter(
   // `scrollWidth` reflects hidden frames (via `min-width: fit-content`), so it
   // predicts the post-expand width and still reflects the wide source during
   // collapse; compare it against the scroll owner's visible width.
-  if (!code || code.scrollWidth <= scrollEl.clientWidth) {
+  //
+  // Exception: a collapse-to-empty block (`data-focused-lines="0"`) shows
+  // nothing while collapsed, so its `scrollWidth` can't predict the post-expand
+  // width that way. On expand, run the swap anyway so `overflow-x` stays hidden
+  // through the reveal instead of flashing a scrollbar; if the expanded source
+  // turns out to fit, the swap simply ends without one. On collapse the current
+  // width is real, so the normal skip still applies.
+  const widthUnknownOnExpand =
+    from === 'expand-from' && code?.getAttribute('data-focused-lines') === '0';
+  if (!code || (!widthUnknownOnExpand && code.scrollWidth <= scrollEl.clientWidth)) {
     return;
   }
 

--- a/packages/docs-infra/src/useDemo/exportVariant.test.ts
+++ b/packages/docs-infra/src/useDemo/exportVariant.test.ts
@@ -4,8 +4,9 @@
 
 import { describe, it, expect } from 'vitest';
 import { exportVariant, type ExportConfig } from './exportVariant';
-import type { VariantCode, VariantExtraFiles } from '../CodeHighlighter/types';
-import { stringOrHastToString } from '../pipeline/hastUtils';
+import type { VariantCode, VariantExtraFiles, VariantSource } from '../CodeHighlighter/types';
+import { compressHast, stringOrHastToString } from '../pipeline/hastUtils';
+import { fallbackToText, type FallbackNode } from '../CodeHighlighter/fallbackFormat';
 import { flattenCodeVariant } from '../pipeline/loadIsomorphicCodeVariant/flattenCodeVariant';
 
 describe('exportVariant', () => {
@@ -1061,6 +1062,124 @@ describe('exportVariant', () => {
         expect(packageJson.name).toBe('transformed-demo');
         expect(packageJson.dependencies['custom-lib']).toBe('1.0.0');
       }
+    });
+  });
+
+  describe('source decoding before transformVariant', () => {
+    const themeText = ':root {\n  color: red;\n}\n';
+    const themeRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'span',
+          properties: {},
+          children: [{ type: 'text', value: themeText }],
+        },
+      ],
+    };
+    // The DEFLATE dictionary for a compressed source is the file's fallback text.
+    const themeFallback: FallbackNode[] = [themeText];
+
+    const mainText = 'const value = 1;\n';
+    const mainRoot = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'span',
+          properties: {},
+          children: [{ type: 'text', value: mainText }],
+        },
+      ],
+    };
+    const mainFallback: FallbackNode[] = [mainText];
+
+    it('decodes a hastCompressed metadata global to a live HastRoot before transformVariant runs', () => {
+      let received: VariantSource | undefined;
+      const variantCode: VariantCode = {
+        url: 'file:///src/MyComponent.tsx',
+        fileName: 'MyComponent.tsx',
+        source: 'export default function MyComponent() { return null; }',
+        extraFiles: {
+          'theme.css': {
+            source: {
+              hastCompressed: compressHast(
+                JSON.stringify(themeRoot),
+                fallbackToText(themeFallback),
+              ),
+            },
+            fallback: themeFallback,
+            metadata: true,
+          },
+        },
+      };
+
+      exportVariant(variantCode, {
+        useTypescript: true,
+        transformVariant: (variant, variantName, globals) => {
+          const theme = globals?.['theme.css'];
+          received = typeof theme === 'object' ? theme.source : undefined;
+          return undefined;
+        },
+      });
+
+      // A live HAST tree, not a serialized `hastCompressed` / `hastJson` payload.
+      expect(received).toMatchObject({ type: 'root' });
+      expect(received).not.toHaveProperty('hastCompressed');
+      const text =
+        received === undefined || typeof received === 'string'
+          ? received
+          : stringOrHastToString(received);
+      expect(text).toBe(themeText);
+    });
+
+    it('decodes a hastCompressed main source to a live HastRoot before transformVariant runs', () => {
+      let received: VariantSource | undefined;
+      const variantCode: VariantCode = {
+        url: 'file:///src/MyComponent.tsx',
+        fileName: 'MyComponent.tsx',
+        source: {
+          hastCompressed: compressHast(JSON.stringify(mainRoot), fallbackToText(mainFallback)),
+        },
+        fallback: mainFallback,
+      };
+
+      exportVariant(variantCode, {
+        useTypescript: true,
+        transformVariant: (variant) => {
+          received = variant.source;
+          return undefined;
+        },
+      });
+
+      expect(received).toMatchObject({ type: 'root' });
+      expect(received).not.toHaveProperty('hastCompressed');
+      const text =
+        received === undefined || typeof received === 'string'
+          ? received
+          : stringOrHastToString(received);
+      expect(text).toBe(mainText);
+    });
+
+    it('leaves plain-string sources unchanged (back-compat)', () => {
+      let received: VariantSource | undefined;
+      exportVariant(
+        {
+          url: 'file:///src/MyComponent.tsx',
+          fileName: 'MyComponent.tsx',
+          source: 'export default function MyComponent() { return null; }',
+        },
+        {
+          useTypescript: true,
+          transformVariant: (variant) => {
+            received = variant.source;
+            return undefined;
+          },
+        },
+      );
+
+      expect(received).toBe('export default function MyComponent() { return null; }');
     });
   });
 

--- a/packages/docs-infra/src/useDemo/exportVariant.ts
+++ b/packages/docs-infra/src/useDemo/exportVariant.ts
@@ -7,6 +7,7 @@ import type { VariantCode, VariantExtraFiles } from '../CodeHighlighter/types';
 import { externalsToPackages } from '../pipeline/loaderUtils';
 import { getFileNameFromUrl } from '../pipeline/loaderUtils/getFileNameFromUrl';
 import { examineCodeVariant } from '../pipeline/loadIsomorphicCodeVariant/examineCodeVariant';
+import { decodeSource } from '../pipeline/loadIsomorphicCodeVariant/decodeSource';
 import {
   mergeCodeMetadata,
   extractCodeMetadata,
@@ -33,6 +34,45 @@ function mergeFiles(...fileSets: Array<VariantExtraFiles>): VariantExtraFiles {
   }
 
   return merged;
+}
+
+/**
+ * Decode every `source` in an extra-files map to `string | HastRoot` (never a
+ * serialized `hastJson` / `hastCompressed` payload), reusing the shared decode
+ * cache. Each file's own `fallback` is the DEFLATE dictionary for a
+ * `hastCompressed` source. URL-only string entries are passed through untouched.
+ */
+function decodeExtraFilesSources(files: VariantExtraFiles): VariantExtraFiles {
+  const decoded: VariantExtraFiles = {};
+  for (const [name, fileData] of Object.entries(files)) {
+    if (typeof fileData === 'string' || fileData.source === undefined) {
+      decoded[name] = fileData;
+    } else {
+      decoded[name] = {
+        ...fileData,
+        source: decodeSource(fileData.source, fileData.fallback),
+      };
+    }
+  }
+  return decoded;
+}
+
+/**
+ * Decode a variant's main `source` and all of its extra-file sources to
+ * `string | HastRoot` (see {@link decodeExtraFilesSources}), so downstream
+ * consumers — most notably the user-supplied `transformVariant` hook — never
+ * have to handle serialized `hastCompressed` / `hastJson` payloads or thread
+ * their dictionaries.
+ */
+function decodeVariantSources(variant: VariantCode): VariantCode {
+  const decoded: VariantCode = { ...variant };
+  if (variant.source !== undefined) {
+    decoded.source = decodeSource(variant.source, variant.fallback);
+  }
+  if (variant.extraFiles) {
+    decoded.extraFiles = decodeExtraFilesSources(variant.extraFiles);
+  }
+  return decoded;
 }
 
 /**
@@ -227,12 +267,19 @@ export interface ExportConfig {
     config: ExportConfig,
   ) => { exported: VariantCode; rootFile: string };
   /**
-   * Transform function that runs at the very start of the export process
-   * Can modify the variant code and metadata before any other processing happens
+   * Transform function that runs at the very start of the export process.
+   * Can modify the variant code and metadata before any other processing happens.
+   *
+   * Every source handed to this hook — `variant.source`, each
+   * `variant.extraFiles[*].source`, and each `globals[*].source` — is decoded to
+   * either a plain string or a live HAST tree (`HastRoot`); the serialized
+   * `hastCompressed` / `hastJson` shapes never reach it. Read a source as text
+   * with `stringOrHastToString`, or inspect / transform the HAST directly.
+   * Decoded trees are clones you own, so mutating them is safe.
    * @example
-   * transformVariant: (variant, globals, variantName) => ({
-   *   variant: { ...variant, source: modifiedSource },
-   *   globals: { ...globals, extraFiles: { ...globals.extraFiles, 'theme.css': { source: '.new {}', metadata: true } } }
+   * transformVariant: (variant, variantName, globals) => ({
+   *   variant: { ...variant, source: `// ${variantName}\n${stringOrHastToString(variant.source)}` },
+   *   globals: { ...globals, 'theme.css': { source: '.new {}', metadata: true } },
    * })
    */
   transformVariant?: (
@@ -316,13 +363,24 @@ export function exportVariant(
   let { variant: processedVariantCode, metadata: processedGlobals } =
     extractCodeMetadata(variantCode);
 
-  // Run optional transform hook to modify variant and globals before processing
+  // Run optional transform hook to modify variant and globals before processing.
   if (transformVariant) {
-    const transformed = transformVariant(processedVariantCode, variantName, processedGlobals);
+    // Decode sources before handing them to the hook so it only ever sees a
+    // plain string or a live `HastRoot`, never a serialized `hastJson` /
+    // `hastCompressed` payload. Precomputed / SSR variants can still carry
+    // serialized sources here; the co-located `fallback` is the dictionary
+    // needed to decode them. `decodeSource` reuses the shared decode cache (so a
+    // source already decoded for rendering is not inflated again) and clones the
+    // tree so the hook owns what it receives. Decoding lazily here keeps it off
+    // the no-transform path, where `flattenCodeVariant` decodes at the end.
+    const decodedVariant = decodeVariantSources(processedVariantCode);
+    const decodedGlobals = decodeExtraFilesSources(processedGlobals);
+
+    const transformed = transformVariant(decodedVariant, variantName, decodedGlobals);
     if (transformed) {
       // Re-extract metadata after transformation
       const result = transformed.variant && extractCodeMetadata(transformed.variant);
-      processedVariantCode = result?.variant || processedVariantCode;
+      processedVariantCode = result?.variant || decodedVariant;
 
       // Start fresh with only the new metadata and explicitly transformed globals
       // Do NOT merge with the original processedGlobals to avoid duplication


### PR DESCRIPTION
- Bug where erasing the last tab in a line, it jumps
- Bug where pressing up arrow doesn't trigger scroll anchor
- Bug where typing x  then typing = and pressing backspace sends the cursor to the start of the line
- Bug where first typing in editable loses focus

Adds many e2e tests for live editing