### PR TITLE
[docs-infra] Update eslint rule to reflect the latest standards

### DIFF
--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -464,9 +464,9 @@ export function createCoreConfig(options = {}) {
         'react/state-in-constructor': 'off',
         // stylistic opinion. For conditional assignment we want it outside, otherwise as static
         'react/static-property-placement': 'off',
-        // noopener is enough
-        // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md#rule-options
-        'react/jsx-no-target-blank': ['error', { allowReferrer: true }],
+        // This rule is outdated, rel are no longer needed for security on target="_blank" links.
+        // See https://github.com/mui/material-ui/pull/40447 for more details.
+        'react/jsx-no-target-blank': 'off',
 
         'no-restricted-syntax': [
           'error',


### PR DESCRIPTION
Another step forward on https://github.com/mui/material-ui/pull/40447 (almost a 10-year-old thing now https://github.com/mui/material-ui/pull/10307). 

This should help get more signals, make it clearer about the real rel intent on a link when we really want it. Meaning, no more rel noopener or noreferrer for security, only `rel="noreferrer"` when we want to hide the traffic source, and or `rel="sponsored"` when we want Google to know it's a paid backlink, etc.