### PR TITLE
[docs-infra] Fix Next.js folder ESLint config

### DIFF
--- a/packages/code-infra/src/eslint/docsConfig.mjs
+++ b/packages/code-infra/src/eslint/docsConfig.mjs
@@ -1,6 +1,7 @@
 import nextjs from '@next/eslint-plugin-next';
 // TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
 import { defineConfig } from '@eslint/config-helpers';
+import { EXTENSION_TS } from './extensions.mjs';
 
 /**
  * @returns {import('eslint').Linter.Config[]}
@@ -25,7 +26,7 @@ export function createDocsConfig() {
         rootDir: 'docs',
       },
     },
-    files: ['**/*.js', '**/*.mjs', '**/*.jsx', '**/*.ts', '**/*.tsx'],
+    files: [`**/*${EXTENSION_TS}`],
     rules: {
       'compat/compat': 'off',
       'jsx-a11y/anchor-is-valid': 'off',


### PR DESCRIPTION
The .mts is not covered by this files filter, which led to this warning when running eslint:

> Pages directory cannot be found at /Users/oliviertassinari/base-ui/pages or /Users/oliviertassinari/base-ui/src/pages. If using a custom path, please configure with the `no-html-link-for-pages` rule in your eslint config file.

This had led projects to need to duplicate the `rootDir: 'docs',` setting. TODO, remove those:

- [ ] https://github.com/mui/material-ui/blob/62d4d11a902cb1454259807ce4096398cf4b9461/eslint.config.mjs#L80
- [ ] https://github.com/mui/base-ui/blob/361eea6bd3172787bea06b172f41995b507de76a/eslint.config.mjs#L69
- [ ] https://github.com/mui/base-ui-mosaic/blob/d8c468ed2907b71e26bd1dd32d6947e6899a92ce/eslint.config.mjs#L57

This PR fixes the root cause, so next we can remove this duplication.

*(Context: I was looking at https://github.com/mui/base-ui/pull/4385 while I was looking at SEO topics, and this added line in the PR made me wonder.)*