### PR TITLE
[benchmark] Fix infinite pr fetch loop in private repos

### DIFF
--- a/apps/code-infra-dashboard/src/views/BenchmarkDetails.tsx
+++ b/apps/code-infra-dashboard/src/views/BenchmarkDetails.tsx
@@ -101,15 +101,13 @@ export default function BenchmarkDetails() {
     <React.Fragment>
       <Heading level={1}>Benchmark Details</Heading>
 
-      {!isBaseResolving && (
-        <ReportHeader
-          repo={repo}
-          sha={sha}
-          baseSha={effectiveBaseSha}
-          prNumber={prNumber ? Number(prNumber) : undefined}
-          baseRef={baseRef ?? effectiveBase?.branch ?? undefined}
-        />
-      )}
+      <ReportHeader
+        repo={repo}
+        sha={sha}
+        baseSha={effectiveBaseSha}
+        prNumber={prNumber ? Number(prNumber) : undefined}
+        baseRef={baseRef ?? effectiveBase?.branch ?? undefined}
+      />
 
       <Paper elevation={2} sx={{ p: 3, mb: 3 }}>
         {isBaseResolving && (


### PR DESCRIPTION
I copied https://github.com/mui/base-ui/pull/4618 to base-ui-mosaic in https://github.com/mui/base-ui-mosaic/pull/297 and noticed that benchmark report fetches PR details from github api infinitely: https://code-infra-dashboard.onrender.com/benchmark-details/mui/base-ui-mosaic?sha=97fcc41dfedee54b3ab2ab29cc8b4f489f80218b&prNumber=297&baseRef=master
This only happens in private repos, where github API returns 403

Before: https://code-infra-dashboard.onrender.com/benchmark-details/mui/base-ui-mosaic?sha=97fcc41dfedee54b3ab2ab29cc8b4f489f80218b&prNumber=297&baseRef=master
After: _No render deployment for PRs from forks_