### PR TITLE
[code-infra] Generate package.json imports field on build

### DIFF
--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -115,8 +115,7 @@ async function writePackageJson({
   delete packageJson.bin;
 
   const [{ exports: packageExports, main, types }, packageImports] = await Promise.all([
-    createPackageExports({
-      exports: originalExports,
+    createPackageExports(originalExports, {
       bundles,
       outputDir,
       cwd,
@@ -125,16 +124,17 @@ async function writePackageJson({
       expand,
       packageType: resolvedPackageType,
     }),
-    createPackageImports({
-      imports: originalImports,
-      bundles,
-      cwd,
-      outputDir,
-      addTypes,
-      isFlat,
-      expand,
-      packageType: resolvedPackageType,
-    }),
+    originalImports
+      ? createPackageImports(originalImports, {
+          bundles,
+          cwd,
+          outputDir,
+          addTypes,
+          isFlat,
+          expand,
+          packageType: resolvedPackageType,
+        })
+      : Promise.resolve(undefined),
   ]);
 
   packageJson.exports = packageExports;
@@ -148,8 +148,7 @@ async function writePackageJson({
     packageJson.types = types;
   }
 
-  const bin = await createPackageBin({
-    bin: originalBin,
+  const bin = await createPackageBin(originalBin, {
     bundles,
     cwd,
     isFlat,

--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -32,6 +32,7 @@ import {
  * @property {boolean} [enableReactCompiler] - Whether to use the React compiler.
  * @property {boolean} [tsgo] - Whether to build types using typescript native (tsgo).
  * @property {boolean} [flat] - Builds the package in a flat structure without subdirectories for each module type.
+ * @property {boolean} expand - Whether to enumerate glob patterns in exports/imports into concrete entries.
  */
 
 const validBundles = [
@@ -86,6 +87,7 @@ ${content}`,
  * @param {string} param0.cwd
  * @param {boolean} param0.addTypes - Whether to add type declarations for the package.
  * @param {boolean} param0.isFlat - Whether the build is flat structure.
+ * @param {boolean} [param0.expand] - Whether to enumerate glob patterns into concrete entries.
  * @param {'module' | 'commonjs'} param0.packageType - The package.json type field.
  */
 async function writePackageJson({
@@ -95,6 +97,7 @@ async function writePackageJson({
   cwd,
   addTypes = false,
   isFlat = false,
+  expand = true,
   packageType,
 }) {
   delete packageJson.scripts;
@@ -119,14 +122,17 @@ async function writePackageJson({
       cwd,
       addTypes,
       isFlat,
+      expand,
       packageType: resolvedPackageType,
     }),
     createPackageImports({
       imports: originalImports,
       bundles,
       cwd,
+      outputDir,
       addTypes,
       isFlat,
+      expand,
       packageType: resolvedPackageType,
     }),
   ]);
@@ -239,6 +245,12 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         default: process.env.MUI_BUILD_FLAT === '1',
         description:
           'Builds the package in a flat structure without subdirectories for each module type.',
+      })
+      .option('expand', {
+        type: 'boolean',
+        default: true,
+        description:
+          'Enumerate glob patterns in the package.json "exports"/"imports" into concrete entries. Use --no-expand to keep them as Node runtime subpath patterns.',
       });
   },
   async handler(args) {
@@ -427,6 +439,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       outputDir: buildDir,
       addTypes: buildTypes,
       isFlat: !!args.flat,
+      expand: args.expand,
       packageType,
     });
 

--- a/packages/code-infra/src/cli/cmdBuild.mjs
+++ b/packages/code-infra/src/cli/cmdBuild.mjs
@@ -10,6 +10,7 @@ import * as semver from 'semver';
 import {
   createPackageBin,
   createPackageExports,
+  createPackageImports,
   getOutExtension,
   mapConcurrently,
   validatePkgJson,
@@ -99,31 +100,41 @@ async function writePackageJson({
   delete packageJson.scripts;
   delete packageJson.publishConfig?.directory;
   delete packageJson.devDependencies;
-  delete packageJson.imports;
 
   const resolvedPackageType = packageType || packageJson.type || 'commonjs';
   packageJson.type = resolvedPackageType;
 
   const originalExports = packageJson.exports;
   delete packageJson.exports;
+  const originalImports = packageJson.imports;
+  delete packageJson.imports;
   const originalBin = packageJson.bin;
   delete packageJson.bin;
 
-  const {
-    exports: packageExports,
-    main,
-    types,
-  } = await createPackageExports({
-    exports: originalExports,
-    bundles,
-    outputDir,
-    cwd,
-    addTypes,
-    isFlat,
-    packageType: resolvedPackageType,
-  });
+  const [{ exports: packageExports, main, types }, packageImports] = await Promise.all([
+    createPackageExports({
+      exports: originalExports,
+      bundles,
+      outputDir,
+      cwd,
+      addTypes,
+      isFlat,
+      packageType: resolvedPackageType,
+    }),
+    createPackageImports({
+      imports: originalImports,
+      bundles,
+      cwd,
+      addTypes,
+      isFlat,
+      packageType: resolvedPackageType,
+    }),
+  ]);
 
   packageJson.exports = packageExports;
+  if (packageImports) {
+    packageJson.imports = packageImports;
+  }
   if (main) {
     packageJson.main = main;
   }

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -59,8 +59,7 @@ function sortExportConditions(conditions) {
  * @returns {void}
  */
 function finalizeConditions(conditionsMap, addTypes, kind) {
-  Object.keys(conditionsMap).forEach((key) => {
-    const conditionVal = conditionsMap[key];
+  Object.entries(conditionsMap).forEach(([key, conditionVal]) => {
     if (Array.isArray(conditionVal)) {
       throw new Error(
         `Array form of package.json ${kind}s is not supported yet. Found in ${kind} "${key}".`,
@@ -95,10 +94,11 @@ function finalizeConditions(conditionsMap, addTypes, kind) {
  * @param {string} param0.cwd
  * @param {string} param0.dir
  * @param {string} param0.type
- * @param {import('../cli/packageJson').PackageJson.ExportConditions} param0.newExports
+ * @param {import('../cli/packageJson').PackageJson.ExportConditions} param0.conditionsMap
  * @param {string} param0.typeOutExtension
  * @param {string} param0.outExtension
  * @param {boolean} param0.addTypes
+ * @param {string} param0.kind - Used for error messages, e.g. `export` or `import`.
  * @returns {Promise<void>}
  */
 async function createExportsFor({
@@ -107,14 +107,15 @@ async function createExportsFor({
   cwd,
   dir,
   type,
-  newExports,
+  conditionsMap,
   typeOutExtension,
   outExtension,
   addTypes,
+  kind,
 }) {
   if (Array.isArray(importPath)) {
     throw new Error(
-      `Array form of package.json exports is not supported yet. Found in export "${key}".`,
+      `Array form of package.json ${kind}s is not supported yet. Found in ${kind} "${key}".`,
     );
   }
 
@@ -124,37 +125,37 @@ async function createExportsFor({
 
   if (typeof srcPath !== 'string') {
     throw new Error(
-      `Unsupported export for "${key}". Only a string or an object with "mui-src" field is supported for now.`,
+      `Unsupported ${kind} for "${key}". Only a string or an object with "mui-src" field is supported for now.`,
     );
   }
 
-  const exportFileExists = srcPath.includes('*')
+  const targetFileExists = srcPath.includes('*')
     ? true
     : await fs.stat(path.join(cwd, srcPath)).then(
         (stats) => stats.isFile() || stats.isDirectory(),
         () => false,
       );
-  if (!exportFileExists) {
+  if (!targetFileExists) {
     throw new Error(
-      `The import path "${srcPath}" for export "${key}" does not exist in the package. Either remove the export or add the file/folder to the package.`,
+      `The path "${srcPath}" for ${kind} "${key}" does not exist in the package. Either remove the ${kind} or add the file/folder to the package.`,
     );
   }
   srcPath = srcPath.replace(/\.\/src\//, `./${dir === '.' ? '' : `${dir}/`}`);
   const ext = path.extname(srcPath);
 
   if (ext === '.css') {
-    newExports[key] = srcPath;
+    conditionsMap[key] = srcPath;
     return;
   }
 
-  if (typeof newExports[key] === 'string' || Array.isArray(newExports[key])) {
-    throw new Error(`The export "${key}" is already defined as a string or Array.`);
+  if (typeof conditionsMap[key] === 'string' || Array.isArray(conditionsMap[key])) {
+    throw new Error(`The ${kind} "${key}" is already defined as a string or Array.`);
   }
 
-  newExports[key] ??= {};
+  conditionsMap[key] ??= {};
   const exportPath = srcPath.replace(ext, outExtension);
   // eslint-disable-next-line no-nested-ternary
-  newExports[key][type === 'cjs' ? 'require' : 'import'] = addTypes
+  conditionsMap[key][type === 'cjs' ? 'require' : 'import'] = addTypes
     ? {
         ...rest,
         types: srcPath.replace(ext, typeOutExtension),
@@ -406,10 +407,11 @@ export async function createPackageExports({
           cwd,
           dir,
           type,
-          newExports,
+          conditionsMap: newExports,
           typeOutExtension,
           outExtension,
           addTypes,
+          kind: 'export',
         });
       }
     }),
@@ -505,10 +507,11 @@ export async function createPackageImports({
           cwd,
           dir,
           type,
-          newExports: newImports,
+          conditionsMap: newImports,
           typeOutExtension,
           outExtension,
           addTypes,
+          kind: 'import',
         });
       }
     }),

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -606,26 +606,28 @@ function createBundleMetas(bundles, isFlat, packageType) {
 }
 
 /**
- * @param {Object} param0
- * @param {import('../cli/packageJson').PackageJson['exports']} param0.exports
- * @param {{type: BundleType; dir: string}[]} param0.bundles
- * @param {string} param0.outputDir
- * @param {string} param0.cwd
- * @param {boolean} [param0.addTypes]
- * @param {boolean} [param0.isFlat]
- * @param {boolean} [param0.expand] - Whether to enumerate glob patterns into concrete entries.
- * @param {'module' | 'commonjs'} [param0.packageType]
+ * @param {import('../cli/packageJson').PackageJson['exports']} packageExports
+ * @param {Object} options
+ * @param {{type: BundleType; dir: string}[]} options.bundles
+ * @param {string} options.outputDir
+ * @param {string} options.cwd
+ * @param {boolean} [options.addTypes]
+ * @param {boolean} [options.isFlat]
+ * @param {boolean} [options.expand] - Whether to enumerate glob patterns into concrete entries.
+ * @param {'module' | 'commonjs'} [options.packageType]
  */
-export async function createPackageExports({
-  exports: packageExports,
-  bundles,
-  outputDir,
-  cwd,
-  addTypes = false,
-  isFlat = false,
-  expand = true,
-  packageType = 'commonjs',
-}) {
+export async function createPackageExports(
+  packageExports,
+  {
+    bundles,
+    outputDir,
+    cwd,
+    addTypes = false,
+    isFlat = false,
+    expand = true,
+    packageType = 'commonjs',
+  },
+) {
   const resolvedPackageType = packageType === 'module' ? 'module' : 'commonjs';
   /**
    * @type {import('../cli/packageJson').PackageJson.ExportConditions}
@@ -713,27 +715,29 @@ export async function createPackageExports({
  * `main` / `types` index handling that only applies to public exports. Entries
  * that resolve to bare specifiers (e.g. an external package) are passed through
  * unchanged, since the `imports` field commonly aliases dependencies.
- * @param {Object} param0
- * @param {import('../cli/packageJson').PackageJson['imports']} param0.imports
- * @param {{type: BundleType; dir: string}[]} param0.bundles
- * @param {string} param0.cwd
- * @param {string} [param0.outputDir] - Used to verify non-source passthrough paths exist in the build output.
- * @param {boolean} [param0.addTypes]
- * @param {boolean} [param0.isFlat]
- * @param {boolean} [param0.expand] - Whether to enumerate glob patterns into concrete entries.
- * @param {'module' | 'commonjs'} [param0.packageType]
+ * @param {import('../cli/packageJson').PackageJson['imports']} packageImports
+ * @param {Object} options
+ * @param {{type: BundleType; dir: string}[]} options.bundles
+ * @param {string} options.cwd
+ * @param {string} [options.outputDir] - Used to verify non-source passthrough paths exist in the build output.
+ * @param {boolean} [options.addTypes]
+ * @param {boolean} [options.isFlat]
+ * @param {boolean} [options.expand] - Whether to enumerate glob patterns into concrete entries.
+ * @param {'module' | 'commonjs'} [options.packageType]
  * @returns {Promise<import('../cli/packageJson').PackageJson.Imports | undefined>}
  */
-export async function createPackageImports({
-  imports: packageImports,
-  bundles,
-  cwd,
-  outputDir,
-  addTypes = false,
-  isFlat = false,
-  expand = true,
-  packageType = 'commonjs',
-}) {
+export async function createPackageImports(
+  packageImports,
+  {
+    bundles,
+    cwd,
+    outputDir,
+    addTypes = false,
+    isFlat = false,
+    expand = true,
+    packageType = 'commonjs',
+  },
+) {
   if (!packageImports || Object.keys(packageImports).length === 0) {
     return undefined;
   }
@@ -767,14 +771,14 @@ export async function createPackageImports({
 }
 
 /**
- * @param {Object} param0
- * @param {import('../cli/packageJson').PackageJson['bin']} param0.bin
- * @param {{type: BundleType; dir: string}[]} param0.bundles
- * @param {string} param0.cwd
- * @param {boolean} [param0.isFlat]
- * @param {'module' | 'commonjs'} [param0.packageType]
+ * @param {import('../cli/packageJson').PackageJson['bin']} bin
+ * @param {Object} options
+ * @param {{type: BundleType; dir: string}[]} options.bundles
+ * @param {string} options.cwd
+ * @param {boolean} [options.isFlat]
+ * @param {'module' | 'commonjs'} [options.packageType]
  */
-export async function createPackageBin({ bin, bundles, cwd, isFlat = false, packageType }) {
+export async function createPackageBin(bin, { bundles, cwd, isFlat = false, packageType }) {
   if (!bin) {
     return undefined;
   }

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -1,12 +1,40 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { globby } from 'globby';
-import { minimatch } from 'minimatch';
 import * as semver from 'semver';
 
 /**
  * @typedef {'esm' | 'cjs'} BundleType
  */
+
+/**
+ * @typedef {Object} BundleMeta
+ * @property {BundleType} type
+ * @property {string} dir
+ * @property {'import' | 'require'} condition - The package.json condition this bundle maps to.
+ * @property {string} outExtension
+ * @property {string} typeOutExtension
+ */
+
+/**
+ * Source files in JS/TS-like languages that the build compiles. These are the
+ * only leaves that get an extension swap + `import`/`require`/`types` conditions.
+ * Other files under `src/` (e.g. `.css`, `.json`) are copied verbatim and only
+ * get their `./src/` prefix rewritten.
+ */
+const JS_TS_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts', '.js', '.jsx', '.mjs', '.cjs']);
+
+export const BASE_IGNORES = [
+  '**/*.test.js',
+  '**/*.test.ts',
+  '**/*.test.tsx',
+  '**/*.spec.js',
+  '**/*.spec.ts',
+  '**/*.spec.tsx',
+  '**/*.d.ts',
+  '**/*.test/*.*',
+  '**/test-cases/*.*',
+];
 
 /**
  * @param {BundleType} bundle
@@ -49,260 +77,433 @@ function sortExportConditions(conditions) {
 }
 
 /**
- * Rebuilds condition objects with a stable key order and fills in the `default`
- * condition. Bundles run in parallel, so `import`/`require` insertion order would
- * otherwise depend on Promise timing. Entries that aren't condition objects
- * (plain strings, bare specifiers, `null`) are left untouched.
+ * Recursively fills in the `default` condition and stabilizes key order for a
+ * single condition value. Bundles run in parallel, so `import`/`require`
+ * insertion order would otherwise depend on Promise timing. Nested condition
+ * objects (e.g. `{ node: {...}, default: {...} }`) are handled at every level
+ * that carries `import`/`require`. Non-condition values (plain strings, bare
+ * specifiers, `null`) are returned untouched.
+ * @param {any} value
+ * @param {boolean} addTypes
+ * @param {string} kind - Used for error messages, e.g. `export` or `import`.
+ * @param {string} key - Used for error messages.
+ * @returns {any}
+ */
+function finalizeConditionValue(value, addTypes, kind, key) {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    throw new Error(
+      `Array form of package.json ${kind}s is not supported yet. Found in ${kind} "${key}".`,
+    );
+  }
+
+  for (const childKey of Object.keys(value)) {
+    value[childKey] = finalizeConditionValue(value[childKey], addTypes, kind, key);
+  }
+
+  if (value.import || value.require) {
+    // Use ESM (import) for default if available, otherwise use require
+    const defaultExport = value.import || value.require;
+    if (addTypes) {
+      value.default = defaultExport;
+    } else {
+      value.default =
+        defaultExport && typeof defaultExport === 'object' && 'default' in defaultExport
+          ? defaultExport.default
+          : defaultExport;
+    }
+    return sortExportConditions(value);
+  }
+
+  return value;
+}
+
+/**
+ * Applies {@link finalizeConditionValue} to every entry of a conditions map.
  * @param {import('../cli/packageJson').PackageJson.ExportConditions} conditionsMap
  * @param {boolean} addTypes
  * @param {string} kind - Used for error messages, e.g. `export` or `import`.
  * @returns {void}
  */
 function finalizeConditions(conditionsMap, addTypes, kind) {
-  Object.entries(conditionsMap).forEach(([key, conditionVal]) => {
-    if (Array.isArray(conditionVal)) {
-      throw new Error(
-        `Array form of package.json ${kind}s is not supported yet. Found in ${kind} "${key}".`,
-      );
-    }
-    if (
-      conditionVal &&
-      typeof conditionVal === 'object' &&
-      (conditionVal.import || conditionVal.require)
-    ) {
-      // Use ESM (import) for default if available, otherwise use require
-      const defaultExport = conditionVal.import || conditionVal.require;
-
-      if (addTypes) {
-        conditionVal.default = defaultExport;
-      } else {
-        conditionVal.default =
-          defaultExport && typeof defaultExport === 'object' && 'default' in defaultExport
-            ? defaultExport.default
-            : defaultExport;
-      }
-
-      conditionsMap[key] = sortExportConditions(conditionVal);
-    }
-  });
+  for (const key of Object.keys(conditionsMap)) {
+    conditionsMap[key] = finalizeConditionValue(conditionsMap[key], addTypes, kind, key);
+  }
 }
 
 /**
- * @param {Object} param0
- * @param {NonNullable<import('../cli/packageJson').PackageJson.Exports>} param0.importPath
- * @param {string} param0.key
- * @param {string} param0.cwd
- * @param {string} param0.dir
- * @param {string} param0.type
- * @param {import('../cli/packageJson').PackageJson.ExportConditions} param0.conditionsMap
- * @param {string} param0.typeOutExtension
- * @param {string} param0.outExtension
- * @param {boolean} param0.addTypes
- * @param {string} param0.kind - Used for error messages, e.g. `export` or `import`.
- * @returns {Promise<void>}
+ * Returns the path relative to `src/` if `leaf` points inside the source tree
+ * (accepting both `./src/…` and `src/…`), otherwise `null`.
+ * @param {string} leaf
+ * @returns {string | null}
  */
-async function createExportsFor({
-  importPath,
-  key,
-  cwd,
-  dir,
-  type,
-  conditionsMap,
-  typeOutExtension,
-  outExtension,
-  addTypes,
-  kind,
-}) {
-  if (Array.isArray(importPath)) {
-    throw new Error(
-      `Array form of package.json ${kind}s is not supported yet. Found in ${kind} "${key}".`,
-    );
+function srcRelative(leaf) {
+  if (leaf.startsWith('./src/')) {
+    return leaf.slice('./src/'.length);
   }
-
-  let srcPath = typeof importPath === 'string' ? importPath : importPath['mui-src'];
-  const rest = typeof importPath === 'string' ? {} : { ...importPath };
-  delete rest['mui-src'];
-
-  if (typeof srcPath !== 'string') {
-    throw new Error(
-      `Unsupported ${kind} for "${key}". Only a string or an object with "mui-src" field is supported for now.`,
-    );
+  if (leaf.startsWith('src/')) {
+    return leaf.slice('src/'.length);
   }
-
-  const targetFileExists = srcPath.includes('*')
-    ? true
-    : await fs.stat(path.join(cwd, srcPath)).then(
-        (stats) => stats.isFile() || stats.isDirectory(),
-        () => false,
-      );
-  if (!targetFileExists) {
-    throw new Error(
-      `The path "${srcPath}" for ${kind} "${key}" does not exist in the package. Either remove the ${kind} or add the file/folder to the package.`,
-    );
-  }
-  srcPath = srcPath.replace(/\.\/src\//, `./${dir === '.' ? '' : `${dir}/`}`);
-  const ext = path.extname(srcPath);
-
-  if (ext === '.css') {
-    conditionsMap[key] = srcPath;
-    return;
-  }
-
-  if (typeof conditionsMap[key] === 'string' || Array.isArray(conditionsMap[key])) {
-    throw new Error(`The ${kind} "${key}" is already defined as a string or Array.`);
-  }
-
-  conditionsMap[key] ??= {};
-  const exportPath = srcPath.replace(ext, outExtension);
-  // eslint-disable-next-line no-nested-ternary
-  conditionsMap[key][type === 'cjs' ? 'require' : 'import'] = addTypes
-    ? {
-        ...rest,
-        types: srcPath.replace(ext, typeOutExtension),
-        default: exportPath,
-      }
-    : Object.keys(rest).length
-      ? {
-          ...rest,
-          default: exportPath,
-        }
-      : exportPath;
+  return null;
 }
 
 /**
- * Expands glob patterns (containing `*`) in package.json export keys/values
- * into concrete entries by resolving them against actual files on disk.
+ * Maps a source-relative path to its built location, optionally swapping the
+ * extension. `*` wildcards are preserved verbatim (Node resolves them at runtime).
+ * @param {string} rel - Path relative to `src/`.
+ * @param {string} dir - The bundle output dir (`.` for the root).
+ * @param {string} ext - The current extension (from `path.extname`).
+ * @param {string | null} newExt - The replacement extension, or `null` to keep `ext`.
+ * @returns {string}
+ */
+function buildOutPath(rel, dir, ext, newExt) {
+  const dirPrefix = dir === '.' ? '' : `${dir}/`;
+  const base = `./${dirPrefix}${rel}`;
+  if (!newExt) {
+    return base;
+  }
+  return `${base.slice(0, base.length - ext.length)}${newExt}`;
+}
+
+/**
+ * @param {string} target
+ * @returns {Promise<boolean>}
+ */
+function fileOrDirExists(target) {
+  return fs.stat(target).then(
+    (stats) => stats.isFile() || stats.isDirectory(),
+    () => false,
+  );
+}
+
+/**
+ * Rewrites a single leaf path for every bundle. A source JS/TS path becomes a
+ * per-bundle `{ types?, default }` (or bare out-path string when not adding
+ * types). A source asset (e.g. `.css`) gets only its `./src/` prefix rewritten.
+ * Anything else (a path already in the build output, or a bare specifier) is
+ * passed through verbatim — the escape hatch for `--copy`'d/custom paths.
+ * @param {string} leaf
+ * @param {Object} ctx
+ * @param {BundleMeta[]} ctx.bundleMetas
+ * @param {boolean} ctx.addTypes
+ * @param {string} ctx.cwd
+ * @param {string} [ctx.outputDir]
+ * @param {string} ctx.key
+ * @param {string} ctx.kind
+ * @returns {Promise<any>}
+ */
+async function rewriteLeaf(leaf, ctx) {
+  const { bundleMetas, addTypes, cwd, outputDir, key, kind } = ctx;
+  const rel = srcRelative(leaf);
+
+  if (rel === null) {
+    // Not a source path: it already names a path present in the published
+    // output (via `--copy` or because it's there literally), or a bare
+    // specifier (external package). Emit verbatim.
+    if (outputDir && leaf.startsWith('.') && !leaf.includes('*')) {
+      const exists = await fileOrDirExists(path.join(outputDir, leaf));
+      if (!exists) {
+        // `--copy` runs after package.json generation, so the file may legitimately
+        // not be on disk yet — warn rather than fail.
+        console.warn(
+          `The ${kind} path "${leaf}" for "${key}" was not found in the build output. Ensure it is generated or copied into the output directory.`,
+        );
+      }
+    }
+    return leaf;
+  }
+
+  const hasGlob = leaf.includes('*');
+  if (!hasGlob) {
+    const exists = await fileOrDirExists(path.join(cwd, leaf));
+    if (!exists) {
+      throw new Error(
+        `The path "${leaf}" for ${kind} "${key}" does not exist in the package. Either remove the ${kind} or add the file/folder to the package.`,
+      );
+    }
+  }
+
+  const ext = path.extname(rel);
+  if (!JS_TS_EXTENSIONS.has(ext)) {
+    // Asset copied verbatim into the output: only rewrite the `./src/` prefix.
+    const meta = bundleMetas.find((bundle) => bundle.dir === '.') ?? bundleMetas[0];
+    return buildOutPath(rel, meta.dir, ext, null);
+  }
+
+  /** @type {Record<string, any>} */
+  const result = {};
+  for (const meta of bundleMetas) {
+    const outPath = buildOutPath(rel, meta.dir, ext, meta.outExtension);
+    result[meta.condition] = addTypes
+      ? { types: buildOutPath(rel, meta.dir, ext, meta.typeOutExtension), default: outPath }
+      : outPath;
+  }
+  return result;
+}
+
+/**
+ * Recursively rewrites an export/import entry value, rewriting every source-path
+ * leaf (including those nested inside standard condition objects) into its built
+ * equivalent. Condition keys and their order are preserved (conditions stay
+ * outer; the build-owned `import`/`require` split lives at the leaves).
+ * @param {import('../cli/packageJson').PackageJson.Exports} value
+ * @param {Object} ctx
+ * @param {BundleMeta[]} ctx.bundleMetas
+ * @param {boolean} ctx.addTypes
+ * @param {string} ctx.cwd
+ * @param {string} [ctx.outputDir]
+ * @param {string} ctx.key
+ * @param {string} ctx.kind
+ * @returns {Promise<any>}
+ */
+async function rewriteEntryValue(value, ctx) {
+  if (value === null) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    throw new Error(
+      `Array form of package.json ${ctx.kind}s is not supported yet. Found in ${ctx.kind} "${ctx.key}".`,
+    );
+  }
+  if (typeof value === 'string') {
+    return rewriteLeaf(value, ctx);
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value);
+    const results = await Promise.all(entries.map(([, child]) => rewriteEntryValue(child, ctx)));
+    /** @type {Record<string, any>} */
+    const out = {};
+    entries.forEach(([condition], index) => {
+      out[condition] = results[index];
+    });
+    return out;
+  }
+  throw new Error(`Unsupported ${ctx.kind} value for "${ctx.key}".`);
+}
+
+/**
+ * Splits a pattern around its first `*` wildcard.
+ * @param {string} pattern
+ * @returns {{ prefix: string; suffix: string }}
+ */
+function splitStar(pattern) {
+  const star = pattern.indexOf('*');
+  return { prefix: pattern.slice(0, star), suffix: pattern.slice(star + 1) };
+}
+
+/**
+ * Finds the source glob to expand inside an entry value: the plain string, else
+ * the `default` condition, else the first leaf that carries a `*`. The captured
+ * stem is applied to every sibling leaf so all conditions expand consistently.
+ * @param {import('../cli/packageJson').PackageJson.Exports} value
+ * @returns {string | undefined}
+ */
+function primarySourcePattern(value) {
+  if (typeof value === 'string') {
+    return value.includes('*') ? value : undefined;
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    if (typeof value.default === 'string' && value.default.includes('*')) {
+      return value.default;
+    }
+    for (const child of Object.values(value)) {
+      const found = primarySourcePattern(child);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Substitutes the matched stem into the `*` of every leaf string in a value.
+ * @param {import('../cli/packageJson').PackageJson.Exports} value
+ * @param {string} stem
+ * @returns {any}
+ */
+function substituteStem(value, stem) {
+  if (typeof value === 'string') {
+    return value.replace('*', stem);
+  }
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    /** @type {Record<string, any>} */
+    const out = {};
+    for (const [condition, child] of Object.entries(value)) {
+      out[condition] = substituteStem(child, stem);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Tests whether a subpath-pattern (or exact) key matches a concrete subpath.
+ * @param {string} key
+ * @param {string} subpath
+ * @returns {boolean}
+ */
+function keyMatches(key, subpath) {
+  const star = key.indexOf('*');
+  if (star === -1) {
+    return key === subpath;
+  }
+  const base = key.slice(0, star);
+  const suffix = key.slice(star + 1);
+  return (
+    subpath.length >= base.length + suffix.length &&
+    subpath.startsWith(base) &&
+    subpath.endsWith(suffix)
+  );
+}
+
+/**
+ * Selects the most-specific key that matches `subpath`, mirroring Node's
+ * resolution: an exact key beats any pattern, and among patterns the longest
+ * base (substring before `*`) wins, tie-broken by the longest suffix.
+ * @param {string} subpath
+ * @param {string[]} keys
+ * @returns {string | null}
+ */
+function selectMostSpecificKey(subpath, keys) {
+  /** @type {string | null} */
+  let best = null;
+  let bestBase = -1;
+  let bestSuffix = -1;
+  for (const key of keys) {
+    if (!keyMatches(key, subpath)) {
+      continue;
+    }
+    const star = key.indexOf('*');
+    const base = star === -1 ? Infinity : star;
+    const suffix = star === -1 ? 0 : key.length - star - 1;
+    if (base > bestBase || (base === bestBase && suffix > bestSuffix)) {
+      best = key;
+      bestBase = base;
+      bestSuffix = suffix;
+    }
+  }
+  return best;
+}
+
+/**
+ * Expands glob patterns (containing `*`) in export/import keys into concrete
+ * entries resolved against files on disk. Each `*` matches a single path segment
+ * (use `--no-expand` to keep the pattern as a Node runtime subpath, whose `*`
+ * matches across `/`). Negation (`null`) keys are applied via most-specific-key
+ * selection rather than cascade-subtraction, so a deeper positive pattern still
+ * resolves under a shallower `null`, and a zero-match pattern warns instead of
+ * silently dropping.
  * @param {import('../cli/packageJson').PackageJson.ExportConditions} originalExports
  * @param {string} cwd
  * @returns {Promise<import('../cli/packageJson').PackageJson.ExportConditions>}
  */
 async function expandExportGlobs(originalExports, cwd) {
+  const allKeys = Object.keys(originalExports);
   /** @type {import('../cli/packageJson').PackageJson.ExportConditions} */
   const expandedExports = {};
 
-  /**
-   * @typedef {{
-   *   value: import('../cli/packageJson').PackageJson.Exports;
-   *   srcPattern: string;
-   *   srcPrefix: string;
-   *   srcSuffix: string;
-   *   keyPrefix: string;
-   *   keySuffix: string;
-   * }} GlobEntry
-   */
-
-  // Collect entries that need glob expansion
-  /** @type {GlobEntry[]} */
+  /** @type {{ key: string; value: import('../cli/packageJson').PackageJson.Exports; srcPattern: string }[]} */
   const globEntries = [];
 
-  // Collect negation patterns (glob keys with null values)
-  /** @type {string[]} */
-  const negationPatterns = [];
-
   for (const [key, value] of Object.entries(originalExports)) {
-    // Null value acts as a negation/exclusion
-    if (value === null) {
-      if (key.includes('*')) {
-        negationPatterns.push(key);
-      } else {
-        delete expandedExports[key];
-      }
-      continue;
-    }
-
     if (!key.includes('*')) {
+      // Exact keys (including exact `null` blocks) pass straight through.
       expandedExports[key] = value;
       continue;
     }
-
-    // Extract the source pattern from the value
-    /** @type {string | undefined} */
-    let srcPattern;
-    if (typeof value === 'string') {
-      srcPattern = value;
-    } else if (value && typeof value === 'object' && !Array.isArray(value)) {
-      srcPattern = /** @type {string | undefined} */ (value['mui-src']);
+    if (value === null) {
+      // Negation pattern: carried through after expansion (see below).
+      continue;
     }
-
-    if (typeof srcPattern !== 'string' || !srcPattern.includes('*')) {
+    const srcPattern = primarySourcePattern(value);
+    if (typeof srcPattern !== 'string') {
+      // Glob key whose value has no wildcard: pass through unchanged.
       expandedExports[key] = value;
       continue;
     }
-
-    // Split patterns around the * wildcard
-    const srcStarIndex = srcPattern.indexOf('*');
-    const srcPrefix = srcPattern.substring(0, srcStarIndex);
-    const srcSuffix = srcPattern.substring(srcStarIndex + 1);
-
-    const keyStarIndex = key.indexOf('*');
-    const keyPrefix = key.substring(0, keyStarIndex);
-    const keySuffix = key.substring(keyStarIndex + 1);
-
-    globEntries.push({
-      value,
-      srcPattern,
-      srcPrefix,
-      srcSuffix,
-      keyPrefix,
-      keySuffix,
-    });
+    if (srcPattern.indexOf('*') !== srcPattern.lastIndexOf('*')) {
+      console.warn(
+        `The pattern "${srcPattern}" for "${key}" contains multiple "*" wildcards; only the first is supported.`,
+      );
+    }
+    globEntries.push({ key, value, srcPattern });
   }
 
-  // Resolve all globby calls in parallel
   const globResults = await Promise.all(
-    globEntries.map(({ srcPattern }) => globby(srcPattern, { cwd })),
+    globEntries.map(({ srcPattern }) => globby(srcPattern, { cwd, ignore: BASE_IGNORES })),
   );
 
+  /** @type {Set<string>} */
+  const usedNegations = new Set();
+
   for (let i = 0; i < globEntries.length; i += 1) {
-    const { value, srcPrefix, srcSuffix, keyPrefix, keySuffix } = globEntries[i];
-    const matches = globResults[i];
+    const { key, value, srcPattern } = globEntries[i];
+    const { prefix: srcPrefix, suffix: srcSuffix } = splitStar(srcPattern);
+    const { prefix: keyPrefix, suffix: keySuffix } = splitStar(key);
 
     const stems = [];
-    for (const match of matches) {
-      if (match.startsWith(srcPrefix) && match.endsWith(srcSuffix)) {
-        const stem =
-          srcSuffix.length > 0
-            ? match.substring(srcPrefix.length, match.length - srcSuffix.length)
-            : match.substring(srcPrefix.length);
-        if (stem.length > 0) {
-          stems.push(stem);
-        }
+    for (const match of globResults[i]) {
+      if (
+        match.startsWith(srcPrefix) &&
+        match.endsWith(srcSuffix) &&
+        match.length > srcPrefix.length + srcSuffix.length
+      ) {
+        stems.push(match.slice(srcPrefix.length, match.length - srcSuffix.length));
       }
     }
-
     stems.sort();
 
-    for (const stem of stems) {
-      const expandedKey = `${keyPrefix}${stem}${keySuffix}`;
-      const expandedSrcPath = `${srcPrefix}${stem}${srcSuffix}`;
+    if (stems.length === 0) {
+      console.warn(`No files matched the pattern "${srcPattern}" for "${key}".`);
+      continue;
+    }
 
-      if (typeof value === 'string') {
-        expandedExports[expandedKey] = expandedSrcPath;
-      } else {
-        expandedExports[expandedKey] = {
-          ...value,
-          'mui-src': expandedSrcPath,
-        };
+    for (const stem of stems) {
+      const concreteKey = `${keyPrefix}${stem}${keySuffix}`;
+      // Honour Node's most-specific-wins resolution: only emit this concrete
+      // entry when this positive pattern is the most-specific match. A deeper
+      // positive pattern emits its own entries; a `null` blocks it entirely.
+      const winner = selectMostSpecificKey(concreteKey, allKeys);
+      if (winner !== key) {
+        if (winner !== null && originalExports[winner] === null) {
+          usedNegations.add(winner);
+        }
+        continue;
       }
+      expandedExports[concreteKey] = substituteStem(value, stem);
     }
   }
 
-  // Apply negation patterns: remove any expanded keys that match a null-valued glob.
-  // If no keys matched, preserve the pattern itself with null to block that path at runtime.
-  for (const pattern of negationPatterns) {
-    let matched = false;
-    for (const expandedKey of Object.keys(expandedExports)) {
-      if (minimatch(expandedKey, pattern)) {
-        delete expandedExports[expandedKey];
-        matched = true;
-      }
-    }
-    if (!matched) {
-      expandedExports[pattern] = null;
+  // Carry through negation patterns that didn't claim any expanded entry so they
+  // still block their subtree at runtime.
+  for (const [key, value] of Object.entries(originalExports)) {
+    if (value === null && key.includes('*') && !usedNegations.has(key)) {
+      expandedExports[key] = null;
     }
   }
 
   return expandedExports;
+}
+
+/**
+ * Builds the per-bundle metadata (output extensions + the `import`/`require`
+ * condition each bundle maps to).
+ * @param {{type: BundleType; dir: string}[]} bundles
+ * @param {boolean} isFlat
+ * @param {'module' | 'commonjs'} packageType
+ * @returns {BundleMeta[]}
+ */
+function createBundleMetas(bundles, isFlat, packageType) {
+  return bundles.map(({ type, dir }) => ({
+    type,
+    dir,
+    condition: type === 'cjs' ? 'require' : 'import',
+    outExtension: getOutExtension(type, { isFlat, packageType }),
+    typeOutExtension: getOutExtension(type, { isFlat, isType: true, packageType }),
+  }));
 }
 
 /**
@@ -313,6 +514,7 @@ async function expandExportGlobs(originalExports, cwd) {
  * @param {string} param0.cwd
  * @param {boolean} [param0.addTypes]
  * @param {boolean} [param0.isFlat]
+ * @param {boolean} [param0.expand] - Whether to enumerate glob patterns into concrete entries.
  * @param {'module' | 'commonjs'} [param0.packageType]
  */
 export async function createPackageExports({
@@ -322,6 +524,7 @@ export async function createPackageExports({
   cwd,
   addTypes = false,
   isFlat = false,
+  expand = true,
   packageType = 'commonjs',
 }) {
   const resolvedPackageType = packageType === 'module' ? 'module' : 'commonjs';
@@ -332,7 +535,8 @@ export async function createPackageExports({
     typeof packageExports === 'string' || Array.isArray(packageExports)
       ? { '.': packageExports }
       : packageExports || {};
-  const originalExports = isFlat ? await expandExportGlobs(rawExports, cwd) : rawExports;
+  const originalExports = expand ? await expandExportGlobs(rawExports, cwd) : rawExports;
+  const bundleMetas = createBundleMetas(bundles, isFlat, resolvedPackageType);
   /**
    * @type {import('../cli/packageJson').PackageJson.ExportConditions}
    */
@@ -346,76 +550,58 @@ export async function createPackageExports({
     exports: newExports,
   };
 
+  // Derive the `.` index entry (plus `main`/`types`) from the built index files.
   await Promise.all(
-    bundles.map(async ({ type, dir }) => {
-      const outExtension = getOutExtension(type, {
-        isFlat,
-        packageType: resolvedPackageType,
-      });
-      const typeOutExtension = getOutExtension(type, {
-        isFlat,
-        isType: true,
-        packageType: resolvedPackageType,
-      });
-      const indexFileExists = await fs.stat(path.join(outputDir, dir, `index${outExtension}`)).then(
-        (stats) => stats.isFile(),
-        () => false,
+    bundleMetas.map(async (meta) => {
+      const indexFileExists = await fileOrDirExists(
+        path.join(outputDir, meta.dir, `index${meta.outExtension}`),
       );
       const typeFileExists =
         addTypes &&
-        (await fs.stat(path.join(outputDir, dir, `index${typeOutExtension}`)).then(
+        (await fs.stat(path.join(outputDir, meta.dir, `index${meta.typeOutExtension}`)).then(
           (stats) => stats.isFile(),
           () => false,
         ));
-      const dirPrefix = dir === '.' ? '' : `${dir}/`;
-      const exportDir = `./${dirPrefix}index${outExtension}`;
-      const typeExportDir = `./${dirPrefix}index${typeOutExtension}`;
+      const dirPrefix = meta.dir === '.' ? '' : `${meta.dir}/`;
+      const exportDir = `./${dirPrefix}index${meta.outExtension}`;
+      const typeExportDir = `./${dirPrefix}index${meta.typeOutExtension}`;
 
       if (indexFileExists) {
         // skip `packageJson.module` to support parcel and some older bundlers
-        if (type === 'cjs') {
+        if (meta.type === 'cjs') {
           result.main = exportDir;
         }
-
         if (typeof newExports['.'] === 'string' || Array.isArray(newExports['.'])) {
           throw new Error(`The export "." is already defined as a string or Array.`);
         }
-
         newExports['.'] ??= {};
-        newExports['.'][type === 'cjs' ? 'require' : 'import'] = typeFileExists
-          ? {
-              types: typeExportDir,
-              default: exportDir,
-            }
+        newExports['.'][meta.condition] = typeFileExists
+          ? { types: typeExportDir, default: exportDir }
           : exportDir;
       }
-      if (typeFileExists && type === 'cjs') {
+      if (typeFileExists && meta.type === 'cjs') {
         result.types = typeExportDir;
-      }
-      const exportKeys = Object.keys(originalExports);
-      // need to maintain the order of exports
-      for (const key of exportKeys) {
-        const importPath = originalExports[key];
-        if (!importPath) {
-          newExports[key] = null;
-          continue;
-        }
-        // eslint-disable-next-line no-await-in-loop
-        await createExportsFor({
-          importPath,
-          key,
-          cwd,
-          dir,
-          type,
-          conditionsMap: newExports,
-          typeOutExtension,
-          outExtension,
-          addTypes,
-          kind: 'export',
-        });
       }
     }),
   );
+
+  // Rewrite the user-configured entries, preserving their declared order.
+  const exportKeys = Object.keys(originalExports);
+  const rewritten = await Promise.all(
+    exportKeys.map((key) =>
+      rewriteEntryValue(originalExports[key], {
+        bundleMetas,
+        addTypes,
+        cwd,
+        outputDir,
+        key,
+        kind: 'export',
+      }),
+    ),
+  );
+  exportKeys.forEach((key, index) => {
+    newExports[key] = rewritten[index];
+  });
 
   bundles.forEach(({ dir }) => {
     if (dir !== '.') {
@@ -441,8 +627,10 @@ export async function createPackageExports({
  * @param {import('../cli/packageJson').PackageJson['imports']} param0.imports
  * @param {{type: BundleType; dir: string}[]} param0.bundles
  * @param {string} param0.cwd
+ * @param {string} [param0.outputDir]
  * @param {boolean} [param0.addTypes]
  * @param {boolean} [param0.isFlat]
+ * @param {boolean} [param0.expand] - Whether to enumerate glob patterns into concrete entries.
  * @param {'module' | 'commonjs'} [param0.packageType]
  * @returns {Promise<import('../cli/packageJson').PackageJson.Imports | undefined>}
  */
@@ -450,8 +638,10 @@ export async function createPackageImports({
   imports: packageImports,
   bundles,
   cwd,
+  outputDir,
   addTypes = false,
   isFlat = false,
+  expand = true,
   packageType = 'commonjs',
 }) {
   if (!packageImports || Object.keys(packageImports).length === 0) {
@@ -470,52 +660,29 @@ export async function createPackageImports({
   const rawImports = /** @type {import('../cli/packageJson').PackageJson.ExportConditions} */ (
     packageImports
   );
-  const originalImports = isFlat ? await expandExportGlobs(rawImports, cwd) : rawImports;
+  const originalImports = expand ? await expandExportGlobs(rawImports, cwd) : rawImports;
+  const bundleMetas = createBundleMetas(bundles, isFlat, resolvedPackageType);
   /**
    * @type {import('../cli/packageJson').PackageJson.ExportConditions}
    */
   const newImports = {};
 
-  await Promise.all(
-    bundles.map(async ({ type, dir }) => {
-      const outExtension = getOutExtension(type, {
-        isFlat,
-        packageType: resolvedPackageType,
-      });
-      const typeOutExtension = getOutExtension(type, {
-        isFlat,
-        isType: true,
-        packageType: resolvedPackageType,
-      });
-      // need to maintain the order of imports
-      for (const key of Object.keys(originalImports)) {
-        const importPath = originalImports[key];
-        if (!importPath) {
-          newImports[key] = null;
-          continue;
-        }
-        // Bare specifiers (external packages, builtins) aren't local files to
-        // rewrite, so leave them as-is. Assigning per bundle is idempotent.
-        if (typeof importPath === 'string' && !importPath.startsWith('.')) {
-          newImports[key] = importPath;
-          continue;
-        }
-        // eslint-disable-next-line no-await-in-loop
-        await createExportsFor({
-          importPath,
-          key,
-          cwd,
-          dir,
-          type,
-          conditionsMap: newImports,
-          typeOutExtension,
-          outExtension,
-          addTypes,
-          kind: 'import',
-        });
-      }
-    }),
+  const importKeys = Object.keys(originalImports);
+  const rewritten = await Promise.all(
+    importKeys.map((key) =>
+      rewriteEntryValue(originalImports[key], {
+        bundleMetas,
+        addTypes,
+        cwd,
+        outputDir,
+        key,
+        kind: 'import',
+      }),
+    ),
   );
+  importKeys.forEach((key, index) => {
+    newImports[key] = rewritten[index];
+  });
 
   finalizeConditions(newImports, addTypes, 'import');
 
@@ -677,18 +844,6 @@ export function measureFn(label) {
   const endMark = `${label}-end`;
   return performance.measure(label, startMark, endMark);
 }
-
-export const BASE_IGNORES = [
-  '**/*.test.js',
-  '**/*.test.ts',
-  '**/*.test.tsx',
-  '**/*.spec.js',
-  '**/*.spec.ts',
-  '**/*.spec.tsx',
-  '**/*.d.ts',
-  '**/*.test/*.*',
-  '**/test-cases/*.*',
-];
 
 /**
  * A utility to map a function over an array of items in a worker pool.

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -161,10 +161,18 @@ function srcRelative(leaf) {
 function buildOutPath(rel, dir, ext, newExt) {
   const dirPrefix = dir === '.' ? '' : `${dir}/`;
   const base = `./${dirPrefix}${rel}`;
-  if (!newExt) {
-    return base;
-  }
-  return `${base.slice(0, base.length - ext.length)}${newExt}`;
+  return newExt ? `${base.slice(0, base.length - ext.length)}${newExt}` : base;
+}
+
+/**
+ * @param {string} target
+ * @returns {Promise<boolean>}
+ */
+function fileExists(target) {
+  return fs.stat(target).then(
+    (stats) => stats.isFile(),
+    () => false,
+  );
 }
 
 /**
@@ -281,6 +289,30 @@ async function rewriteEntryValue(value, ctx) {
     return out;
   }
   throw new Error(`Unsupported ${ctx.kind} value for "${ctx.key}".`);
+}
+
+/**
+ * Rewrites every entry of a conditions map, preserving declared key order.
+ * @param {import('../cli/packageJson').PackageJson.ExportConditions} conditionsMap
+ * @param {Object} baseCtx - The {@link rewriteEntryValue} context minus `key`.
+ * @param {BundleMeta[]} baseCtx.bundleMetas
+ * @param {boolean} baseCtx.addTypes
+ * @param {string} baseCtx.cwd
+ * @param {string} [baseCtx.outputDir]
+ * @param {string} baseCtx.kind
+ * @returns {Promise<import('../cli/packageJson').PackageJson.ExportConditions>}
+ */
+async function rewriteConditionsMap(conditionsMap, baseCtx) {
+  const keys = Object.keys(conditionsMap);
+  const rewritten = await Promise.all(
+    keys.map((key) => rewriteEntryValue(conditionsMap[key], { ...baseCtx, key })),
+  );
+  /** @type {import('../cli/packageJson').PackageJson.ExportConditions} */
+  const result = {};
+  keys.forEach((key, index) => {
+    result[key] = rewritten[index];
+  });
+  return result;
 }
 
 /**
@@ -446,12 +478,11 @@ async function expandExportGlobs(originalExports, cwd) {
 
     const stems = [];
     for (const match of globResults[i]) {
-      if (
-        match.startsWith(srcPrefix) &&
-        match.endsWith(srcSuffix) &&
-        match.length > srcPrefix.length + srcSuffix.length
-      ) {
-        stems.push(match.slice(srcPrefix.length, match.length - srcSuffix.length));
+      if (match.startsWith(srcPrefix) && match.endsWith(srcSuffix)) {
+        const stem = match.slice(srcPrefix.length, match.length - srcSuffix.length);
+        if (stem) {
+          stems.push(stem);
+        }
       }
     }
     stems.sort();
@@ -553,15 +584,12 @@ export async function createPackageExports({
   // Derive the `.` index entry (plus `main`/`types`) from the built index files.
   await Promise.all(
     bundleMetas.map(async (meta) => {
-      const indexFileExists = await fileOrDirExists(
+      const indexFileExists = await fileExists(
         path.join(outputDir, meta.dir, `index${meta.outExtension}`),
       );
       const typeFileExists =
         addTypes &&
-        (await fs.stat(path.join(outputDir, meta.dir, `index${meta.typeOutExtension}`)).then(
-          (stats) => stats.isFile(),
-          () => false,
-        ));
+        (await fileExists(path.join(outputDir, meta.dir, `index${meta.typeOutExtension}`)));
       const dirPrefix = meta.dir === '.' ? '' : `${meta.dir}/`;
       const exportDir = `./${dirPrefix}index${meta.outExtension}`;
       const typeExportDir = `./${dirPrefix}index${meta.typeOutExtension}`;
@@ -586,22 +614,16 @@ export async function createPackageExports({
   );
 
   // Rewrite the user-configured entries, preserving their declared order.
-  const exportKeys = Object.keys(originalExports);
-  const rewritten = await Promise.all(
-    exportKeys.map((key) =>
-      rewriteEntryValue(originalExports[key], {
-        bundleMetas,
-        addTypes,
-        cwd,
-        outputDir,
-        key,
-        kind: 'export',
-      }),
-    ),
+  Object.assign(
+    newExports,
+    await rewriteConditionsMap(originalExports, {
+      bundleMetas,
+      addTypes,
+      cwd,
+      outputDir,
+      kind: 'export',
+    }),
   );
-  exportKeys.forEach((key, index) => {
-    newExports[key] = rewritten[index];
-  });
 
   bundles.forEach(({ dir }) => {
     if (dir !== '.') {
@@ -627,7 +649,7 @@ export async function createPackageExports({
  * @param {import('../cli/packageJson').PackageJson['imports']} param0.imports
  * @param {{type: BundleType; dir: string}[]} param0.bundles
  * @param {string} param0.cwd
- * @param {string} [param0.outputDir]
+ * @param {string} [param0.outputDir] - Used to verify non-source passthrough paths exist in the build output.
  * @param {boolean} [param0.addTypes]
  * @param {boolean} [param0.isFlat]
  * @param {boolean} [param0.expand] - Whether to enumerate glob patterns into concrete entries.
@@ -662,26 +684,13 @@ export async function createPackageImports({
   );
   const originalImports = expand ? await expandExportGlobs(rawImports, cwd) : rawImports;
   const bundleMetas = createBundleMetas(bundles, isFlat, resolvedPackageType);
-  /**
-   * @type {import('../cli/packageJson').PackageJson.ExportConditions}
-   */
-  const newImports = {};
 
-  const importKeys = Object.keys(originalImports);
-  const rewritten = await Promise.all(
-    importKeys.map((key) =>
-      rewriteEntryValue(originalImports[key], {
-        bundleMetas,
-        addTypes,
-        cwd,
-        outputDir,
-        key,
-        kind: 'import',
-      }),
-    ),
-  );
-  importKeys.forEach((key, index) => {
-    newImports[key] = rewritten[index];
+  const newImports = await rewriteConditionsMap(originalImports, {
+    bundleMetas,
+    addTypes,
+    cwd,
+    outputDir,
+    kind: 'import',
   });
 
   finalizeConditions(newImports, addTypes, 'import');

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -104,15 +104,18 @@ function finalizeConditionValue(value, addTypes, kind, key) {
   }
 
   if (value.import || value.require) {
-    // Use ESM (import) for default if available, otherwise use require
-    const defaultExport = value.import || value.require;
-    if (addTypes) {
-      value.default = defaultExport;
-    } else {
-      value.default =
-        defaultExport && typeof defaultExport === 'object' && 'default' in defaultExport
-          ? defaultExport.default
-          : defaultExport;
+    // Synthesize `default` from import/require (preferring ESM), but never clobber
+    // a user-authored `default` condition that sits alongside them.
+    if (value.default === undefined) {
+      const defaultExport = value.import || value.require;
+      if (addTypes) {
+        value.default = defaultExport;
+      } else {
+        value.default =
+          defaultExport && typeof defaultExport === 'object' && 'default' in defaultExport
+            ? defaultExport.default
+            : defaultExport;
+      }
     }
     return sortExportConditions(value);
   }
@@ -372,6 +375,55 @@ function substituteStem(value, stem) {
 }
 
 /**
+ * Drops source-path conditions whose file is missing for a glob-expanded entry,
+ * so a sibling glob that doesn't match every stem of the primary pattern omits
+ * that condition for the unmatched stems instead of failing the build. Only used
+ * on glob-expanded values; explicit (non-glob) entries still validate strictly.
+ * @param {import('../cli/packageJson').PackageJson.Exports} value
+ * @param {string} cwd
+ * @returns {Promise<any>}
+ */
+async function pruneMissingSourceConditions(value, cwd) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const entries = Object.entries(value);
+  const resolved = await Promise.all(
+    entries.map(async ([condition, child]) => {
+      if (typeof child === 'string') {
+        const rel = srcRelative(child);
+        if (
+          rel !== null &&
+          !child.includes('*') &&
+          !(await fileOrDirExists(path.join(cwd, child)))
+        ) {
+          return undefined;
+        }
+        return /** @type {[string, any]} */ ([condition, child]);
+      }
+      const pruned = await pruneMissingSourceConditions(child, cwd);
+      if (
+        pruned &&
+        typeof pruned === 'object' &&
+        !Array.isArray(pruned) &&
+        Object.keys(pruned).length === 0
+      ) {
+        return undefined;
+      }
+      return /** @type {[string, any]} */ ([condition, pruned]);
+    }),
+  );
+  /** @type {Record<string, any>} */
+  const out = {};
+  for (const entry of resolved) {
+    if (entry) {
+      out[entry[0]] = entry[1];
+    }
+  }
+  return out;
+}
+
+/**
  * Tests whether a subpath-pattern (or exact) key matches a concrete subpath.
  * @param {string} key
  * @param {string} subpath
@@ -470,6 +522,8 @@ async function expandExportGlobs(originalExports, cwd) {
 
   /** @type {Set<string>} */
   const usedNegations = new Set();
+  /** @type {string[]} */
+  const expandedObjectKeys = [];
 
   for (let i = 0; i < globEntries.length; i += 1) {
     const { key, value, srcPattern } = globEntries[i];
@@ -505,8 +559,22 @@ async function expandExportGlobs(originalExports, cwd) {
         continue;
       }
       expandedExports[concreteKey] = substituteStem(value, stem);
+      if (value && typeof value === 'object') {
+        expandedObjectKeys.push(concreteKey);
+      }
     }
   }
+
+  // For glob-expanded condition objects, drop any condition whose source file is
+  // absent for this stem (a sibling glob need not match every primary stem).
+  await Promise.all(
+    expandedObjectKeys.map(async (concreteKey) => {
+      expandedExports[concreteKey] = await pruneMissingSourceConditions(
+        expandedExports[concreteKey],
+        cwd,
+      );
+    }),
+  );
 
   // Carry through negation patterns that didn't claim any expanded entry so they
   // still block their subtree at runtime.

--- a/packages/code-infra/src/utils/build.mjs
+++ b/packages/code-infra/src/utils/build.mjs
@@ -49,6 +49,46 @@ function sortExportConditions(conditions) {
 }
 
 /**
+ * Rebuilds condition objects with a stable key order and fills in the `default`
+ * condition. Bundles run in parallel, so `import`/`require` insertion order would
+ * otherwise depend on Promise timing. Entries that aren't condition objects
+ * (plain strings, bare specifiers, `null`) are left untouched.
+ * @param {import('../cli/packageJson').PackageJson.ExportConditions} conditionsMap
+ * @param {boolean} addTypes
+ * @param {string} kind - Used for error messages, e.g. `export` or `import`.
+ * @returns {void}
+ */
+function finalizeConditions(conditionsMap, addTypes, kind) {
+  Object.keys(conditionsMap).forEach((key) => {
+    const conditionVal = conditionsMap[key];
+    if (Array.isArray(conditionVal)) {
+      throw new Error(
+        `Array form of package.json ${kind}s is not supported yet. Found in ${kind} "${key}".`,
+      );
+    }
+    if (
+      conditionVal &&
+      typeof conditionVal === 'object' &&
+      (conditionVal.import || conditionVal.require)
+    ) {
+      // Use ESM (import) for default if available, otherwise use require
+      const defaultExport = conditionVal.import || conditionVal.require;
+
+      if (addTypes) {
+        conditionVal.default = defaultExport;
+      } else {
+        conditionVal.default =
+          defaultExport && typeof defaultExport === 'object' && 'default' in defaultExport
+            ? defaultExport.default
+            : defaultExport;
+      }
+
+      conditionsMap[key] = sortExportConditions(conditionVal);
+    }
+  });
+}
+
+/**
  * @param {Object} param0
  * @param {NonNullable<import('../cli/packageJson').PackageJson.Exports>} param0.importPath
  * @param {string} param0.key
@@ -381,33 +421,102 @@ export async function createPackageExports({
     }
   });
 
-  // Rebuild condition objects with stable key order; bundles run in parallel so
-  // import/require insertion order would otherwise depend on Promise timing.
-  Object.keys(newExports).forEach((key) => {
-    const exportVal = newExports[key];
-    if (Array.isArray(exportVal)) {
-      throw new Error(
-        `Array form of package.json exports is not supported yet. Found in export "${key}".`,
-      );
-    }
-    if (exportVal && typeof exportVal === 'object' && (exportVal.import || exportVal.require)) {
-      // Use ESM (import) for default if available, otherwise use require
-      const defaultExport = exportVal.import || exportVal.require;
-
-      if (addTypes) {
-        exportVal.default = defaultExport;
-      } else {
-        exportVal.default =
-          defaultExport && typeof defaultExport === 'object' && 'default' in defaultExport
-            ? defaultExport.default
-            : defaultExport;
-      }
-
-      newExports[key] = sortExportConditions(exportVal);
-    }
-  });
+  finalizeConditions(newExports, addTypes, 'export');
 
   return result;
+}
+
+/**
+ * Generates the package.json `imports` field for the built package, rewriting
+ * internal subpath imports (keys starting with `#`) that point at source files
+ * into their built equivalents with `import`/`require`/`types` conditions.
+ *
+ * Mirrors {@link createPackageExports} but without the `.` / `package.json` /
+ * `main` / `types` index handling that only applies to public exports. Entries
+ * that resolve to bare specifiers (e.g. an external package) are passed through
+ * unchanged, since the `imports` field commonly aliases dependencies.
+ * @param {Object} param0
+ * @param {import('../cli/packageJson').PackageJson['imports']} param0.imports
+ * @param {{type: BundleType; dir: string}[]} param0.bundles
+ * @param {string} param0.cwd
+ * @param {boolean} [param0.addTypes]
+ * @param {boolean} [param0.isFlat]
+ * @param {'module' | 'commonjs'} [param0.packageType]
+ * @returns {Promise<import('../cli/packageJson').PackageJson.Imports | undefined>}
+ */
+export async function createPackageImports({
+  imports: packageImports,
+  bundles,
+  cwd,
+  addTypes = false,
+  isFlat = false,
+  packageType = 'commonjs',
+}) {
+  if (!packageImports || Object.keys(packageImports).length === 0) {
+    return undefined;
+  }
+  for (const key of Object.keys(packageImports)) {
+    if (!key.startsWith('#')) {
+      throw new Error(
+        `Invalid import "${key}": all package.json "imports" keys must start with "#".`,
+      );
+    }
+  }
+  const resolvedPackageType = packageType === 'module' ? 'module' : 'commonjs';
+  // `Imports` uses `#`-prefixed keys; treat it as a generic conditions map so the
+  // same glob/condition helpers used for exports can process it.
+  const rawImports = /** @type {import('../cli/packageJson').PackageJson.ExportConditions} */ (
+    packageImports
+  );
+  const originalImports = isFlat ? await expandExportGlobs(rawImports, cwd) : rawImports;
+  /**
+   * @type {import('../cli/packageJson').PackageJson.ExportConditions}
+   */
+  const newImports = {};
+
+  await Promise.all(
+    bundles.map(async ({ type, dir }) => {
+      const outExtension = getOutExtension(type, {
+        isFlat,
+        packageType: resolvedPackageType,
+      });
+      const typeOutExtension = getOutExtension(type, {
+        isFlat,
+        isType: true,
+        packageType: resolvedPackageType,
+      });
+      // need to maintain the order of imports
+      for (const key of Object.keys(originalImports)) {
+        const importPath = originalImports[key];
+        if (!importPath) {
+          newImports[key] = null;
+          continue;
+        }
+        // Bare specifiers (external packages, builtins) aren't local files to
+        // rewrite, so leave them as-is. Assigning per bundle is idempotent.
+        if (typeof importPath === 'string' && !importPath.startsWith('.')) {
+          newImports[key] = importPath;
+          continue;
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await createExportsFor({
+          importPath,
+          key,
+          cwd,
+          dir,
+          type,
+          newExports: newImports,
+          typeOutExtension,
+          outExtension,
+          addTypes,
+        });
+      }
+    }),
+  );
+
+  finalizeConditions(newImports, addTypes, 'import');
+
+  return newImports;
 }
 
 /**

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -318,6 +318,51 @@ describe('createPackageExports', () => {
       });
     });
 
+    it('omits a sibling condition for stems its glob does not match', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+      /**
+       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+       */
+      const bundles = [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ];
+
+      await Promise.all([
+        createFile(path.join(cwd, 'src/Alert.ts')),
+        createFile(path.join(cwd, 'src/Button.ts')),
+        // Only Alert has a node variant.
+        createFile(path.join(cwd, 'src/node/Alert.ts')),
+      ]);
+
+      const { exports: packageExports } = await createPackageExports({
+        exports: {
+          './*': { node: './src/node/*.ts', default: './src/*.ts' },
+        },
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      });
+
+      // Alert keeps its node condition.
+      expect(packageExports['./Alert']).toEqual({
+        node: {
+          import: './node/Alert.js',
+          require: './node/Alert.cjs',
+          default: './node/Alert.js',
+        },
+        default: { import: './Alert.js', require: './Alert.cjs', default: './Alert.js' },
+      });
+      // Button has no node variant, so the node condition is dropped rather than
+      // pointing at a non-existent source (which would fail the build).
+      expect(packageExports['./Button']).toEqual({
+        default: { import: './Button.js', require: './Button.cjs', default: './Button.js' },
+      });
+    });
+
     it('enumerates a wildcard directory pattern', async () => {
       const cwd = await makeTempDir();
       const outputDir = path.join(cwd, 'build');
@@ -801,6 +846,40 @@ describe('createPackageExports leaf rewriting', () => {
     });
 
     expect(packageExports['./theme.css']).toBe('./theme.css');
+  });
+
+  it('preserves a user-authored default alongside import/require conditions', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+    /**
+     * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+     */
+    const bundles = [
+      { type: 'esm', dir: '.' },
+      { type: 'cjs', dir: '.' },
+    ];
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/esm.ts')),
+      createFile(path.join(cwd, 'src/fallback.ts')),
+    ]);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        './x': { import: './src/esm.ts', default: './src/fallback.ts' },
+      },
+      bundles,
+      outputDir,
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    // The synthesized default must not clobber the user's `default` branch.
+    expect(packageExports['./x']).toEqual({
+      import: { import: './esm.js', require: './esm.cjs', default: './esm.js' },
+      default: { import: './fallback.js', require: './fallback.cjs', default: './fallback.js' },
+    });
   });
 });
 

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -29,20 +29,22 @@ describe('createPackageExports', () => {
     ]);
 
     // Pass cjs before esm to verify the key order is still 'import' then 'require'
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         '.': './src/index.ts',
         './feature': './src/feature.ts',
       },
-      bundles: [
-        { type: 'cjs', dir: '.' },
-        { type: 'esm', dir: '.' },
-      ],
-      outputDir,
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles: [
+          { type: 'cjs', dir: '.' },
+          { type: 'esm', dir: '.' },
+        ],
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(Object.keys(/** @type {Record<string, unknown>} */ (packageExports['.']))).toEqual([
       'import',
@@ -86,18 +88,20 @@ describe('createPackageExports', () => {
       exports: packageExports,
       main,
       types,
-    } = await createPackageExports({
-      exports: {
+    } = await createPackageExports(
+      {
         '.': './src/index.ts',
         './feature': './src/feature.ts',
       },
-      bundles,
-      outputDir,
-      cwd,
-      addTypes: true,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles,
+        outputDir,
+        cwd,
+        addTypes: true,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(main).toBe('./index.cjs');
     expect(types).toBe('./index.d.cts');
@@ -123,17 +127,19 @@ describe('createPackageExports', () => {
       exports: packageExports2,
       main: main2,
       types: types2,
-    } = await createPackageExports({
-      exports: {
+    } = await createPackageExports(
+      {
         '.': './src/index.ts',
         './feature': './src/feature.ts',
       },
-      bundles: [bundles[1]], // only CJS bundle
-      outputDir,
-      cwd,
-      addTypes: true,
-      isFlat: true,
-    });
+      {
+        bundles: [bundles[1]], // only CJS bundle
+        outputDir,
+        cwd,
+        addTypes: true,
+        isFlat: true,
+      },
+    );
 
     expect(main2).toBe('./index.js');
     expect(types2).toBe('./index.d.ts');
@@ -181,17 +187,19 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'TextField.d.cts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
         },
-        bundles,
-        outputDir,
-        cwd,
-        addTypes: true,
-        isFlat: true,
-        packageType: 'module',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          addTypes: true,
+          isFlat: true,
+          packageType: 'module',
+        },
+      );
 
       expect(packageExports['./Button']).toEqual({
         import: { types: './Button.d.ts', default: './Button.js' },
@@ -227,17 +235,19 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'Button.d.mts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
         },
-        bundles,
-        outputDir,
-        cwd,
-        addTypes: true,
-        isFlat: true,
-        packageType: 'commonjs',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          addTypes: true,
+          isFlat: true,
+          packageType: 'commonjs',
+        },
+      );
 
       expect(packageExports['./Button']).toEqual({
         import: { types: './Button.d.mts', default: './Button.mjs' },
@@ -257,17 +267,19 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'Button.d.ts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        addTypes: true,
-        isFlat: true,
-        packageType: 'commonjs',
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          addTypes: true,
+          isFlat: true,
+          packageType: 'commonjs',
+        },
+      );
 
       expect(packageExports['./Button']).toEqual({
         require: { types: './Button.d.ts', default: './Button.js' },
@@ -291,16 +303,18 @@ describe('createPackageExports', () => {
         createFile(path.join(cwd, 'src/node/Alert.ts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': { node: './src/node/*.ts', default: './src/*.ts' },
         },
-        bundles,
-        outputDir,
-        cwd,
-        isFlat: true,
-        packageType: 'module',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          isFlat: true,
+          packageType: 'module',
+        },
+      );
 
       // Every condition's source path is rewritten (no verbatim `./src/...`),
       // and conditions stay outer with the import/require split at the leaves.
@@ -336,16 +350,18 @@ describe('createPackageExports', () => {
         createFile(path.join(cwd, 'src/node/Alert.ts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': { node: './src/node/*.ts', default: './src/*.ts' },
         },
-        bundles,
-        outputDir,
-        cwd,
-        isFlat: true,
-        packageType: 'module',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          isFlat: true,
+          packageType: 'module',
+        },
+      );
 
       // Alert keeps its node condition.
       expect(packageExports['./Alert']).toEqual({
@@ -372,15 +388,17 @@ describe('createPackageExports', () => {
         createFile(path.join(cwd, 'src/menu/script.ts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*/script.ts',
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: true,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        },
+      );
 
       expect(packageExports['./tabs']).toEqual({
         require: './tabs/script.js',
@@ -399,15 +417,17 @@ describe('createPackageExports', () => {
 
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
-        const { exports: packageExports } = await createPackageExports({
-          exports: {
+        const { exports: packageExports } = await createPackageExports(
+          {
             './*': './src/*.ts',
           },
-          bundles: [{ type: 'cjs', dir: '.' }],
-          outputDir,
-          cwd,
-          isFlat: true,
-        });
+          {
+            bundles: [{ type: 'cjs', dir: '.' }],
+            outputDir,
+            cwd,
+            isFlat: true,
+          },
+        );
 
         expect(Object.keys(packageExports)).toEqual(['./package.json']);
         expect(warn).toHaveBeenCalled();
@@ -437,17 +457,19 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'Chip.cjs')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           '.': './src/index.ts',
           './*': './src/*.ts',
         },
-        bundles,
-        outputDir,
-        cwd,
-        isFlat: true,
-        packageType: 'module',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          isFlat: true,
+          packageType: 'module',
+        },
+      );
 
       // Explicit export still works
       expect(packageExports['.']).toBeDefined();
@@ -480,16 +502,18 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'utils/size.cjs')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './utils/*': './src/utils/*.ts',
         },
-        bundles,
-        outputDir,
-        cwd,
-        isFlat: true,
-        packageType: 'module',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          isFlat: true,
+          packageType: 'module',
+        },
+      );
 
       expect(packageExports['./utils/color']).toEqual({
         import: './utils/color.js',
@@ -510,15 +534,17 @@ describe('createPackageExports', () => {
       // Create the src directory but no .ts files in it
       createFile(path.join(cwd, 'src/.gitkeep'));
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: true,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        },
+      );
 
       // Only the default ./package.json entry should be present
       expect(Object.keys(packageExports)).toEqual(['./package.json']);
@@ -538,15 +564,17 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'Mango.js')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: true,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        },
+      );
 
       const exportKeys = Object.keys(packageExports).filter((k) => k !== './package.json');
       expect(exportKeys).toEqual(['./Apple', './Mango', './Zebra']);
@@ -576,17 +604,19 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'ButtonBase.cjs')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
           './Button*': null,
         },
-        bundles,
-        outputDir,
-        cwd,
-        isFlat: true,
-        packageType: 'module',
-      });
+        {
+          bundles,
+          outputDir,
+          cwd,
+          isFlat: true,
+          packageType: 'module',
+        },
+      );
 
       expect(packageExports['./Accordion']).toBeDefined();
       expect(packageExports['./Button']).toBeUndefined();
@@ -609,16 +639,18 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'Button.js')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
           './Alert*': null,
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: true,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        },
+      );
 
       const exportKeys = Object.keys(packageExports).filter((k) => k !== './package.json');
       expect(exportKeys).toEqual(['./Button']);
@@ -633,16 +665,18 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'Button.js')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
           './internal/*': null,
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: true,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        },
+      );
 
       // Button is kept since it doesn't match the negation
       expect(packageExports['./Button']).toBeDefined();
@@ -659,16 +693,18 @@ describe('createPackageExports', () => {
         createFile(path.join(cwd, 'src/TextField.ts')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/*.ts',
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: false,
-        expand: false,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: false,
+          expand: false,
+        },
+      );
 
       // Glob should NOT be expanded to individual files
       expect(packageExports['./Button']).toBeUndefined();
@@ -689,15 +725,17 @@ describe('createPackageExports', () => {
         createFile(path.join(outputDir, 'index.js')),
       ]);
 
-      const { exports: packageExports } = await createPackageExports({
-        exports: {
+      const { exports: packageExports } = await createPackageExports(
+        {
           './*': './src/index.ts',
         },
-        bundles: [{ type: 'cjs', dir: '.' }],
-        outputDir,
-        cwd,
-        isFlat: true,
-      });
+        {
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        },
+      );
 
       // When the value has no *, the glob key is passed through as-is
       expect(packageExports['./*']).toBeDefined();
@@ -714,17 +752,19 @@ describe('createPackageExports', () => {
       createFile(path.join(outputDir, 'index.d.ts')),
     ]);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         '.': './src/index.ts',
       },
-      bundles: [{ type: 'cjs', dir: '.' }],
-      outputDir,
-      cwd,
-      addTypes: true,
-      isFlat: true,
-      packageType: 'commonjs',
-    });
+      {
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        addTypes: true,
+        isFlat: true,
+        packageType: 'commonjs',
+      },
+    );
 
     // Single CJS bundle should have both require and default pointing to the same files
     expect(packageExports['.']).toEqual({
@@ -757,16 +797,18 @@ describe('createPackageExports leaf rewriting', () => {
       createFile(path.join(cwd, 'src/node/feature.ts')),
     ]);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         './feature': { node: './src/node/feature.ts', default: './src/feature.ts' },
       },
-      bundles,
-      outputDir,
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(packageExports['./feature']).toEqual({
       node: {
@@ -791,16 +833,18 @@ describe('createPackageExports leaf rewriting', () => {
       createFile(path.join(outputDir, 'vendor/legacy.js')),
     ]);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         './logo': './assets/logo.svg',
         './legacy': './vendor/legacy.js',
       },
-      bundles: [{ type: 'cjs', dir: '.' }],
-      outputDir,
-      cwd,
-      isFlat: true,
-    });
+      {
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      },
+    );
 
     // Already present in the published output: emitted unchanged.
     expect(packageExports['./logo']).toBe('./assets/logo.svg');
@@ -813,15 +857,17 @@ describe('createPackageExports leaf rewriting', () => {
 
     await createFile(path.join(cwd, 'src/index.ts'));
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         './entry': 'src/index.ts',
       },
-      bundles: [{ type: 'cjs', dir: '.' }],
-      outputDir,
-      cwd,
-      isFlat: true,
-    });
+      {
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      },
+    );
 
     expect(packageExports['./entry']).toEqual({
       require: './index.js',
@@ -835,15 +881,17 @@ describe('createPackageExports leaf rewriting', () => {
 
     await createFile(path.join(cwd, 'src/theme.css'));
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         './theme.css': './src/theme.css',
       },
-      bundles: [{ type: 'cjs', dir: '.' }],
-      outputDir,
-      cwd,
-      isFlat: true,
-    });
+      {
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      },
+    );
 
     expect(packageExports['./theme.css']).toBe('./theme.css');
   });
@@ -864,16 +912,18 @@ describe('createPackageExports leaf rewriting', () => {
       createFile(path.join(cwd, 'src/fallback.ts')),
     ]);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         './x': { import: './src/esm.ts', default: './src/fallback.ts' },
       },
-      bundles,
-      outputDir,
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles,
+        outputDir,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     // The synthesized default must not clobber the user's `default` branch.
     expect(packageExports['./x']).toEqual({
@@ -906,8 +956,7 @@ describe('createPackageExports resolution semantics', () => {
     const outputDir = path.join(cwd, 'build');
     await seedWorkedExample(cwd);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: workedExampleExports,
+    const { exports: packageExports } = await createPackageExports(workedExampleExports, {
       bundles: [{ type: 'cjs', dir: '.' }],
       outputDir,
       cwd,
@@ -935,8 +984,7 @@ describe('createPackageExports resolution semantics', () => {
     const outputDir = path.join(cwd, 'build');
     await seedWorkedExample(cwd);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: workedExampleExports,
+    const { exports: packageExports } = await createPackageExports(workedExampleExports, {
       bundles: [{ type: 'cjs', dir: '.' }],
       outputDir,
       cwd,
@@ -964,17 +1012,19 @@ describe('createPackageExports resolution semantics', () => {
       createFile(path.join(cwd, 'src/override.ts')),
     ]);
 
-    const { exports: packageExports } = await createPackageExports({
-      exports: {
+    const { exports: packageExports } = await createPackageExports(
+      {
         // Exact key collides with what `./*` would expand to, but points elsewhere.
         './Other': './src/override.ts',
         './*': './src/*.ts',
       },
-      bundles: [{ type: 'cjs', dir: '.' }],
-      outputDir,
-      cwd,
-      isFlat: true,
-    });
+      {
+        bundles: [{ type: 'cjs', dir: '.' }],
+        outputDir,
+        cwd,
+        isFlat: true,
+      },
+    );
 
     // The exact key keeps its own target rather than the pattern's stem.
     expect(packageExports['./Other']).toEqual({
@@ -1002,8 +1052,7 @@ describe('createPackageBin', () => {
 
     await Promise.all([createFile(path.join(cwd, 'src/cli.ts'))]);
 
-    let bin = await createPackageBin({
-      bin: './src/cli.ts',
+    let bin = await createPackageBin('./src/cli.ts', {
       bundles,
       cwd,
       isFlat: true,
@@ -1012,8 +1061,7 @@ describe('createPackageBin', () => {
 
     expect(bin).toBe('./cli.js');
 
-    bin = await createPackageBin({
-      bin: './src/cli.ts',
+    bin = await createPackageBin('./src/cli.ts', {
       bundles: [bundles[1]], // only CJS bundle
       cwd,
       isFlat: true,
@@ -1021,8 +1069,7 @@ describe('createPackageBin', () => {
 
     expect(bin).toBe('./cli.js');
 
-    bin = await createPackageBin({
-      bin: './src/cli.ts',
+    bin = await createPackageBin('./src/cli.ts', {
       bundles, // only CJS bundle
       cwd,
       isFlat: true,
@@ -1037,8 +1084,7 @@ describe('createPackageImports', () => {
   it('returns undefined when there is no imports field', async () => {
     const cwd = await makeTempDir();
 
-    const imports = await createPackageImports({
-      imports: undefined,
+    const imports = await createPackageImports(undefined, {
       bundles: [{ type: 'esm', dir: '.' }],
       cwd,
       isFlat: true,
@@ -1052,15 +1098,17 @@ describe('createPackageImports', () => {
     const cwd = await makeTempDir();
 
     await expect(
-      createPackageImports({
-        imports: /** @type {any} */ ({
+      createPackageImports(
+        /** @type {any} */ ({
           'internal/utils': './src/internal/utils.ts',
         }),
-        bundles: [{ type: 'esm', dir: '.' }],
-        cwd,
-        isFlat: true,
-        packageType: 'module',
-      }),
+        {
+          bundles: [{ type: 'esm', dir: '.' }],
+          cwd,
+          isFlat: true,
+          packageType: 'module',
+        },
+      ),
     ).rejects.toThrow('must start with "#"');
   });
 
@@ -1083,16 +1131,18 @@ describe('createPackageImports', () => {
       createFile(path.join(outputDir, 'internal/utils.d.cts')),
     ]);
 
-    const imports = await createPackageImports({
-      imports: {
+    const imports = await createPackageImports(
+      {
         '#internal/utils': './src/internal/utils.ts',
       },
-      bundles,
-      cwd,
-      addTypes: true,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles,
+        cwd,
+        addTypes: true,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(imports).toEqual({
       '#internal/utils': {
@@ -1113,19 +1163,21 @@ describe('createPackageImports', () => {
       createFile(path.join(outputDir, 'internal/utils.cjs')),
     ]);
 
-    const imports = await createPackageImports({
-      imports: {
+    const imports = await createPackageImports(
+      {
         '#internal/utils': './src/internal/utils.ts',
       },
-      // Pass cjs before esm to verify the key order is still 'import' then 'require'
-      bundles: [
-        { type: 'cjs', dir: '.' },
-        { type: 'esm', dir: '.' },
-      ],
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        // Pass cjs before esm to verify the key order is still 'import' then 'require'
+        bundles: [
+          { type: 'cjs', dir: '.' },
+          { type: 'esm', dir: '.' },
+        ],
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(
       Object.keys(/** @type {Record<string, unknown>} */ (imports?.['#internal/utils'])),
@@ -1135,18 +1187,20 @@ describe('createPackageImports', () => {
   it('passes bare specifiers through unchanged', async () => {
     const cwd = await makeTempDir();
 
-    const imports = await createPackageImports({
-      imports: {
+    const imports = await createPackageImports(
+      {
         '#error-formatter': '@custom/error-formatter',
       },
-      bundles: [
-        { type: 'esm', dir: '.' },
-        { type: 'cjs', dir: '.' },
-      ],
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles: [
+          { type: 'esm', dir: '.' },
+          { type: 'cjs', dir: '.' },
+        ],
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(imports).toEqual({
       '#error-formatter': '@custom/error-formatter',
@@ -1164,15 +1218,17 @@ describe('createPackageImports', () => {
       createFile(path.join(outputDir, 'internal/bar.js')),
     ]);
 
-    const imports = await createPackageImports({
-      imports: {
+    const imports = await createPackageImports(
+      {
         '#internal/*': './src/internal/*.ts',
       },
-      bundles: [{ type: 'esm', dir: '.' }],
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles: [{ type: 'esm', dir: '.' }],
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(imports).toEqual({
       '#internal/bar': { import: './internal/bar.js', default: './internal/bar.js' },
@@ -1195,18 +1251,20 @@ describe('createPackageImports', () => {
       createFile(path.join(cwd, 'src/internal/node/utils.ts')),
     ]);
 
-    const imports = await createPackageImports({
-      imports: {
+    const imports = await createPackageImports(
+      {
         '#internal/utils': {
           node: './src/internal/node/utils.ts',
           default: './src/internal/utils.ts',
         },
       },
-      bundles,
-      cwd,
-      isFlat: true,
-      packageType: 'module',
-    });
+      {
+        bundles,
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
 
     expect(imports).toEqual({
       '#internal/utils': {

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { makeTempDir } from './testUtils.mjs';
 import { createPackageBin, createPackageExports, createPackageImports } from './build.mjs';
@@ -275,7 +275,7 @@ describe('createPackageExports', () => {
       });
     });
 
-    it('expands glob patterns with mui-src object values', async () => {
+    it('rewrites source paths inside sibling conditions when expanding globs', async () => {
       const cwd = await makeTempDir();
       const outputDir = path.join(cwd, 'build');
       /**
@@ -288,14 +288,12 @@ describe('createPackageExports', () => {
 
       await Promise.all([
         createFile(path.join(cwd, 'src/Alert.ts')),
-
-        createFile(path.join(outputDir, 'Alert.js')),
-        createFile(path.join(outputDir, 'Alert.cjs')),
+        createFile(path.join(cwd, 'src/node/Alert.ts')),
       ]);
 
       const { exports: packageExports } = await createPackageExports({
         exports: {
-          './*': { 'mui-src': './src/*.ts' },
+          './*': { node: './src/node/*.ts', default: './src/*.ts' },
         },
         bundles,
         outputDir,
@@ -304,47 +302,73 @@ describe('createPackageExports', () => {
         packageType: 'module',
       });
 
+      // Every condition's source path is rewritten (no verbatim `./src/...`),
+      // and conditions stay outer with the import/require split at the leaves.
       expect(packageExports['./Alert']).toEqual({
-        import: './Alert.js',
-        require: './Alert.cjs',
-        default: './Alert.js',
+        node: {
+          import: './node/Alert.js',
+          require: './node/Alert.cjs',
+          default: './node/Alert.js',
+        },
+        default: {
+          import: './Alert.js',
+          require: './Alert.cjs',
+          default: './Alert.js',
+        },
       });
     });
 
-    it('preserves extra conditions from mui-src object values', async () => {
+    it('enumerates a wildcard directory pattern', async () => {
       const cwd = await makeTempDir();
       const outputDir = path.join(cwd, 'build');
-      /**
-       * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
-       */
-      const bundles = [
-        { type: 'esm', dir: '.' },
-        { type: 'cjs', dir: '.' },
-      ];
 
       await Promise.all([
-        createFile(path.join(cwd, 'src/Alert.ts')),
-
-        createFile(path.join(outputDir, 'Alert.js')),
-        createFile(path.join(outputDir, 'Alert.cjs')),
+        createFile(path.join(cwd, 'src/tabs/script.ts')),
+        createFile(path.join(cwd, 'src/menu/script.ts')),
       ]);
 
       const { exports: packageExports } = await createPackageExports({
         exports: {
-          './*': { 'mui-src': './src/*.ts', node: './src/node/*.ts' },
+          './*': './src/*/script.ts',
         },
-        bundles,
+        bundles: [{ type: 'cjs', dir: '.' }],
         outputDir,
         cwd,
         isFlat: true,
-        packageType: 'module',
       });
 
-      expect(packageExports['./Alert']).toEqual({
-        import: { node: './src/node/*.ts', default: './Alert.js' },
-        require: { node: './src/node/*.ts', default: './Alert.cjs' },
-        default: './Alert.js',
+      expect(packageExports['./tabs']).toEqual({
+        require: './tabs/script.js',
+        default: './tabs/script.js',
       });
+      expect(packageExports['./menu']).toEqual({
+        require: './menu/script.js',
+        default: './menu/script.js',
+      });
+    });
+
+    it('warns and produces nothing when a glob matches no files', async () => {
+      const cwd = await makeTempDir();
+      const outputDir = path.join(cwd, 'build');
+      createFile(path.join(cwd, 'src/.gitkeep'));
+
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { exports: packageExports } = await createPackageExports({
+          exports: {
+            './*': './src/*.ts',
+          },
+          bundles: [{ type: 'cjs', dir: '.' }],
+          outputDir,
+          cwd,
+          isFlat: true,
+        });
+
+        expect(Object.keys(packageExports)).toEqual(['./package.json']);
+        expect(warn).toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+      }
     });
 
     it('mixes glob and non-glob exports', async () => {
@@ -581,7 +605,7 @@ describe('createPackageExports', () => {
       expect(packageExports['./internal/*']).toBeNull();
     });
 
-    it('does not expand glob patterns when isFlat is false', async () => {
+    it('does not expand glob patterns when expand is false', async () => {
       const cwd = await makeTempDir();
       const outputDir = path.join(cwd, 'build');
 
@@ -598,6 +622,7 @@ describe('createPackageExports', () => {
         outputDir,
         cwd,
         isFlat: false,
+        expand: false,
       });
 
       // Glob should NOT be expanded to individual files
@@ -666,6 +691,221 @@ describe('createPackageExports', () => {
         types: './index.d.ts',
         default: './index.js',
       },
+    });
+  });
+});
+
+describe('createPackageExports leaf rewriting', () => {
+  it('rewrites a standard conditions object (conditions-outer)', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+    /**
+     * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+     */
+    const bundles = [
+      { type: 'esm', dir: '.' },
+      { type: 'cjs', dir: '.' },
+    ];
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/feature.ts')),
+      createFile(path.join(cwd, 'src/node/feature.ts')),
+    ]);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        './feature': { node: './src/node/feature.ts', default: './src/feature.ts' },
+      },
+      bundles,
+      outputDir,
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(packageExports['./feature']).toEqual({
+      node: {
+        import: './node/feature.js',
+        require: './node/feature.cjs',
+        default: './node/feature.js',
+      },
+      default: {
+        import: './feature.js',
+        require: './feature.cjs',
+        default: './feature.js',
+      },
+    });
+  });
+
+  it('passes through paths that are not under src/ verbatim', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await Promise.all([
+      createFile(path.join(outputDir, 'assets/logo.svg')),
+      createFile(path.join(outputDir, 'vendor/legacy.js')),
+    ]);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        './logo': './assets/logo.svg',
+        './legacy': './vendor/legacy.js',
+      },
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      isFlat: true,
+    });
+
+    // Already present in the published output: emitted unchanged.
+    expect(packageExports['./logo']).toBe('./assets/logo.svg');
+    expect(packageExports['./legacy']).toBe('./vendor/legacy.js');
+  });
+
+  it('treats src/ without a leading ./ as a source path', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await createFile(path.join(cwd, 'src/index.ts'));
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        './entry': 'src/index.ts',
+      },
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      isFlat: true,
+    });
+
+    expect(packageExports['./entry']).toEqual({
+      require: './index.js',
+      default: './index.js',
+    });
+  });
+
+  it('rewrites the prefix of a non-JS asset under src/ without an extension swap', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await createFile(path.join(cwd, 'src/theme.css'));
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        './theme.css': './src/theme.css',
+      },
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      isFlat: true,
+    });
+
+    expect(packageExports['./theme.css']).toBe('./theme.css');
+  });
+});
+
+describe('createPackageExports resolution semantics', () => {
+  /**
+   * Seeds the worked example with files so the shallow and deep patterns match.
+   * @param {string} cwd
+   */
+  async function seedWorkedExample(cwd) {
+    await Promise.all([
+      createFile(path.join(cwd, 'src/foo/x.ts')),
+      createFile(path.join(cwd, 'src/foo/bar/baz/z.ts')),
+    ]);
+  }
+
+  const workedExampleExports = {
+    './foo/*': './src/foo/*.ts',
+    './foo/bar/*': null,
+    './foo/bar/baz/*': './src/foo/bar/baz/*.ts',
+  };
+
+  it('enumerates with Node-faithful, non-cascading negation (expand: true)', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+    await seedWorkedExample(cwd);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: workedExampleExports,
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      isFlat: true,
+    });
+
+    // ./foo/x resolves (matched only by the shallow pattern)
+    expect(packageExports['./foo/x']).toEqual({
+      require: './foo/x.js',
+      default: './foo/x.js',
+    });
+    // ./foo/bar/baz/z resolves even though it sits under the null'd ./foo/bar/*
+    expect(packageExports['./foo/bar/baz/z']).toEqual({
+      require: './foo/bar/baz/z.js',
+      default: './foo/bar/baz/z.js',
+    });
+    // nothing whose most-specific match is the null is emitted as a concrete entry
+    expect(packageExports['./foo/bar/z']).toBeUndefined();
+    // the null pattern is carried through to keep blocking its subtree at runtime
+    expect(packageExports['./foo/bar/*']).toBeNull();
+  });
+
+  it('keeps patterns and the null verbatim (expand: false)', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+    await seedWorkedExample(cwd);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: workedExampleExports,
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      isFlat: true,
+      expand: false,
+    });
+
+    expect(packageExports['./foo/*']).toEqual({
+      require: './foo/*.js',
+      default: './foo/*.js',
+    });
+    expect(packageExports['./foo/bar/baz/*']).toEqual({
+      require: './foo/bar/baz/*.js',
+      default: './foo/bar/baz/*.js',
+    });
+    expect(packageExports['./foo/bar/*']).toBeNull();
+  });
+
+  it('lets an exact key win over a matching pattern', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/Other.ts')),
+      createFile(path.join(cwd, 'src/override.ts')),
+    ]);
+
+    const { exports: packageExports } = await createPackageExports({
+      exports: {
+        // Exact key collides with what `./*` would expand to, but points elsewhere.
+        './Other': './src/override.ts',
+        './*': './src/*.ts',
+      },
+      bundles: [{ type: 'cjs', dir: '.' }],
+      outputDir,
+      cwd,
+      isFlat: true,
+    });
+
+    // The exact key keeps its own target rather than the pattern's stem.
+    expect(packageExports['./Other']).toEqual({
+      require: './override.js',
+      default: './override.js',
+    });
+    // The pattern still expands its other matches.
+    expect(packageExports['./override']).toEqual({
+      require: './override.js',
+      default: './override.js',
     });
   });
 });
@@ -858,6 +1098,50 @@ describe('createPackageImports', () => {
     expect(imports).toEqual({
       '#internal/bar': { import: './internal/bar.js', default: './internal/bar.js' },
       '#internal/foo': { import: './internal/foo.js', default: './internal/foo.js' },
+    });
+  });
+
+  it('rewrites every condition of a conditions object (conditions-outer)', async () => {
+    const cwd = await makeTempDir();
+    /**
+     * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+     */
+    const bundles = [
+      { type: 'esm', dir: '.' },
+      { type: 'cjs', dir: '.' },
+    ];
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/internal/utils.ts')),
+      createFile(path.join(cwd, 'src/internal/node/utils.ts')),
+    ]);
+
+    const imports = await createPackageImports({
+      imports: {
+        '#internal/utils': {
+          node: './src/internal/node/utils.ts',
+          default: './src/internal/utils.ts',
+        },
+      },
+      bundles,
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(imports).toEqual({
+      '#internal/utils': {
+        node: {
+          import: './internal/node/utils.js',
+          require: './internal/node/utils.cjs',
+          default: './internal/node/utils.js',
+        },
+        default: {
+          import: './internal/utils.js',
+          require: './internal/utils.cjs',
+          default: './internal/utils.js',
+        },
+      },
     });
   });
 });

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { makeTempDir } from './testUtils.mjs';
-import { createPackageBin, createPackageExports } from './build.mjs';
+import { createPackageBin, createPackageExports, createPackageImports } from './build.mjs';
 
 /**
  * @param {string} filePath
@@ -711,5 +711,153 @@ describe('createPackageBin', () => {
     });
 
     expect(bin).toBe('./cli.mjs');
+  });
+});
+
+describe('createPackageImports', () => {
+  it('returns undefined when there is no imports field', async () => {
+    const cwd = await makeTempDir();
+
+    const imports = await createPackageImports({
+      imports: undefined,
+      bundles: [{ type: 'esm', dir: '.' }],
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(imports).toBeUndefined();
+  });
+
+  it('throws when an import key does not start with "#"', async () => {
+    const cwd = await makeTempDir();
+
+    await expect(
+      createPackageImports({
+        imports: /** @type {any} */ ({
+          'internal/utils': './src/internal/utils.ts',
+        }),
+        bundles: [{ type: 'esm', dir: '.' }],
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      }),
+    ).rejects.toThrow('must start with "#"');
+  });
+
+  it('rewrites internal subpath imports for a dual bundle module package', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+    /**
+     * @type {{ type: import('./build.mjs').BundleType; dir: string }[]}
+     */
+    const bundles = [
+      { type: 'esm', dir: '.' },
+      { type: 'cjs', dir: '.' },
+    ];
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/internal/utils.ts')),
+      createFile(path.join(outputDir, 'internal/utils.js')),
+      createFile(path.join(outputDir, 'internal/utils.cjs')),
+      createFile(path.join(outputDir, 'internal/utils.d.ts')),
+      createFile(path.join(outputDir, 'internal/utils.d.cts')),
+    ]);
+
+    const imports = await createPackageImports({
+      imports: {
+        '#internal/utils': './src/internal/utils.ts',
+      },
+      bundles,
+      cwd,
+      addTypes: true,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(imports).toEqual({
+      '#internal/utils': {
+        import: { types: './internal/utils.d.ts', default: './internal/utils.js' },
+        require: { types: './internal/utils.d.cts', default: './internal/utils.cjs' },
+        default: { types: './internal/utils.d.ts', default: './internal/utils.js' },
+      },
+    });
+  });
+
+  it('puts import before require regardless of bundle array order', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/internal/utils.ts')),
+      createFile(path.join(outputDir, 'internal/utils.js')),
+      createFile(path.join(outputDir, 'internal/utils.cjs')),
+    ]);
+
+    const imports = await createPackageImports({
+      imports: {
+        '#internal/utils': './src/internal/utils.ts',
+      },
+      // Pass cjs before esm to verify the key order is still 'import' then 'require'
+      bundles: [
+        { type: 'cjs', dir: '.' },
+        { type: 'esm', dir: '.' },
+      ],
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(
+      Object.keys(/** @type {Record<string, unknown>} */ (imports?.['#internal/utils'])),
+    ).toEqual(['import', 'require', 'default']);
+  });
+
+  it('passes bare specifiers through unchanged', async () => {
+    const cwd = await makeTempDir();
+
+    const imports = await createPackageImports({
+      imports: {
+        '#error-formatter': '@custom/error-formatter',
+      },
+      bundles: [
+        { type: 'esm', dir: '.' },
+        { type: 'cjs', dir: '.' },
+      ],
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(imports).toEqual({
+      '#error-formatter': '@custom/error-formatter',
+    });
+  });
+
+  it('expands glob patterns in import keys and values', async () => {
+    const cwd = await makeTempDir();
+    const outputDir = path.join(cwd, 'build');
+
+    await Promise.all([
+      createFile(path.join(cwd, 'src/internal/foo.ts')),
+      createFile(path.join(cwd, 'src/internal/bar.ts')),
+      createFile(path.join(outputDir, 'internal/foo.js')),
+      createFile(path.join(outputDir, 'internal/bar.js')),
+    ]);
+
+    const imports = await createPackageImports({
+      imports: {
+        '#internal/*': './src/internal/*.ts',
+      },
+      bundles: [{ type: 'esm', dir: '.' }],
+      cwd,
+      isFlat: true,
+      packageType: 'module',
+    });
+
+    expect(imports).toEqual({
+      '#internal/bar': { import: './internal/bar.js', default: './internal/bar.js' },
+      '#internal/foo': { import: './internal/foo.js', default: './internal/foo.js' },
+    });
   });
 });


### PR DESCRIPTION
The build tool generates the package.json `exports` field but was deleting the `imports` field. This regenerates `imports` the same way, so packages can use internal `#`-subpath imports pointing at source files.

## Changes

- **`build.mjs`**: Extracted the condition-rebuilding logic from `createPackageExports` into a shared `finalizeConditions()` helper. Added `createPackageImports()`, which mirrors `createPackageExports` (reusing `expandExportGlobs`/`createExportsFor`/`finalizeConditions`) minus the `.`/`package.json`/`main`/`types` index handling that only applies to public exports. Keys are validated to start with `#`; bare specifiers (e.g. external packages) are passed through unchanged.
- **`cmdBuild.mjs`**: `writePackageJson` now regenerates `imports` (in parallel with `exports`) instead of deleting it.
- **`build.test.mjs`**: Tests for subpath rewrite, condition ordering, bare-specifier passthrough, glob expansion, the `#`-prefix validation, and the no-imports case.