### PR TITLE
[code-infra] Replace ssh2-promise with ssh2 in code-infra-dashboard

### DIFF
--- a/apps/code-infra-dashboard/package.json
+++ b/apps/code-infra-dashboard/package.json
@@ -28,7 +28,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "semver": "^7.8.0",
-    "ssh2-promise": "^1.0.3",
+    "ssh2": "^1.17.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -38,6 +38,7 @@
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@types/semver": "7.7.1",
+    "@types/ssh2": "1.15.5",
     "baseline-browser-mapping": "2.10.29",
     "typescript": "5.9.3"
   },

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/store.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/store.ts
@@ -1,5 +1,6 @@
 import { unstable_cache } from 'next/cache';
 import type { RowDataPacket } from 'mysql2';
+import type { ClientChannel } from 'ssh2';
 import type { KpiResult } from '../types';
 import { getEnvOrError, successResult } from './utils';
 
@@ -26,26 +27,31 @@ async function fetchOverdueRatioInternal(): Promise<KpiResult> {
   } = process.env;
 
   // Dynamic imports for server-only modules
-  const [{ default: SSH2Promise }, mysql] = await Promise.all([
-    import('ssh2-promise'),
-    import('mysql2/promise'),
-  ]);
+  const [{ Client }, mysql] = await Promise.all([import('ssh2'), import('mysql2/promise')]);
 
-  const ssh = new SSH2Promise({
-    host: BASTION_HOST,
-    port: 22,
-    username: BASTION_USERNAME,
-    privateKey: sshKey.replace(/\\n/g, '\n'),
+  const ssh = new Client();
+  await new Promise<void>((resolve, reject) => {
+    ssh
+      .on('ready', () => resolve())
+      .on('error', reject)
+      .connect({
+        host: BASTION_HOST,
+        port: 22,
+        username: BASTION_USERNAME,
+        privateKey: sshKey.replace(/\\n/g, '\n'),
+      });
   });
 
-  const tunnel = await ssh.addTunnel({
-    remoteAddr: STORE_PRODUCTION_READ_HOST,
-    remotePort: 3306,
+  // Forward a channel through the bastion to the database and hand it to mysql2
+  // directly as its socket, so no local TCP port needs to be opened.
+  const stream = await new Promise<ClientChannel>((resolve, reject) => {
+    ssh.forwardOut('127.0.0.1', 0, STORE_PRODUCTION_READ_HOST!, 3306, (err, channel) =>
+      err ? reject(err) : resolve(channel),
+    );
   });
 
   const connection = await mysql.createConnection({
-    host: 'localhost',
-    port: tunnel.localPort,
+    stream,
     user: STORE_PRODUCTION_READ_USERNAME,
     password,
     database: STORE_PRODUCTION_READ_DATABASE,
@@ -117,7 +123,7 @@ FROM
   `);
 
   await connection.end();
-  await ssh.close();
+  ssh.end();
 
   const ratio = rows[0]?.ratio;
   if (ratio == null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,9 +190,9 @@ importers:
       semver:
         specifier: ^7.8.0
         version: 7.8.0
-      ssh2-promise:
-        specifier: ^1.0.3
-        version: 1.0.3
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -215,6 +215,9 @@ importers:
       '@types/semver':
         specifier: 7.7.1
         version: 7.7.1
+      '@types/ssh2':
+        specifier: 1.15.5
+        version: 1.15.5
       baseline-browser-mapping:
         specifier: 2.10.29
         version: 2.10.29


### PR DESCRIPTION
Replaces `ssh2-promise` with the underlying `ssh2` in the code-infra-dashboard store KPI fetcher. `ssh2-promise` pulls `@heroku/socksv5`, which is the sole source of the vulnerable `ip-address` (GHSA-v2v4-37r5-5v8g); plain `ssh2` has no such dependency.

The SSH bastion → MySQL tunnel is reimplemented with ssh2's `Client.forwardOut`, feeding the channel straight into mysql2's `stream` option (no local TCP port). Behaviour is unchanged.

Note: the `ip-address` alert clears once `tools-public` also drops `ssh2-promise`, which happens with the (separate) toolpad removal. Toolpad is intentionally left untouched here.