### PR TITLE
[code-infra] Add babelDisplayNamePlugin option to mui-name-matches-component-name

### DIFF
--- a/packages/babel-plugin-display-name/README.md
+++ b/packages/babel-plugin-display-name/README.md
@@ -50,3 +50,11 @@ Enables generation of displayNames for certain called functions.
   ]
 }
 ```
+
+## Related ESLint rule
+
+When a project compiles with this plugin, the `mui/material-ui-name-matches-component-name` rule
+(in `@mui/internal-code-infra`) can be configured with `{ babelDisplayNamePlugin: true }`. This lets
+`forwardRef`/`memo` components use an anonymous or arrow render function (avoiding `no-shadow`) while
+still validating their theming `name` against the variable name that this plugin uses for the injected
+`displayName`.

--- a/packages/code-infra/src/eslint/mui/rules/mui-name-matches-component-name.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/mui-name-matches-component-name.mjs
@@ -3,6 +3,13 @@
  */
 const rule = {
   meta: {
+    docs: {
+      description:
+        'Enforces that the `name` passed to `useThemeProps`/`useDefaultProps` matches the component name. ' +
+        'When the `babelDisplayNamePlugin` option is enabled, components wrapped in `forwardRef`/`memo` ' +
+        'may use an anonymous or arrow render function and the component name is derived from the variable ' +
+        'name (matching the `displayName` injected by `@mui/internal-babel-plugin-display-name`).',
+    },
     messages: {
       nameMismatch: "Expected `name` to be 'Mui{{ componentName }}' but instead got '{{ name }}'.",
       noComponent: 'Unable to find component for this call.',
@@ -22,6 +29,9 @@ const rule = {
               type: 'string',
             },
           },
+          babelDisplayNamePlugin: {
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
       },
@@ -29,7 +39,58 @@ const rule = {
   },
   create(context) {
     const [options = {}] = context.options;
-    const { customHooks = [] } = options;
+    const { customHooks = [], babelDisplayNamePlugin = false } = options;
+
+    /**
+     * Resolves the method name of a call expression callee, handling both bare
+     * identifiers (`forwardRef`) and member expressions (`React.forwardRef`).
+     * Returns undefined when it cannot be determined statically.
+     * @param {import('estree').Expression | import('estree').Super} callee
+     */
+    function resolveCalleeMethodName(callee) {
+      if (callee.type === 'Identifier') {
+        return callee.name;
+      }
+      if (callee.type === 'MemberExpression' && callee.property.type === 'Identifier') {
+        return callee.property.name;
+      }
+      return undefined;
+    }
+
+    /**
+     * When `node` is the render/component function passed directly to a
+     * `forwardRef`/`memo` call that is assigned to a variable, returns the
+     * variable name. This mirrors the `displayName` injected by
+     * `@mui/internal-babel-plugin-display-name`. Returns null otherwise.
+     * @param {import('eslint').Rule.Node} node
+     */
+    function resolveWrappedComponentName(node) {
+      const call = node.parent;
+      if (
+        call == null ||
+        call.type !== 'CallExpression' ||
+        call.arguments[0] !== /** @type {import('estree').Expression} */ (node)
+      ) {
+        return null;
+      }
+      const methodName = resolveCalleeMethodName(call.callee);
+      if (methodName !== 'forwardRef' && methodName !== 'memo') {
+        return null;
+      }
+      // The call may be wrapped in a TSAsExpression before assignment.
+      let assigned = /** @type {import('eslint').Rule.Node} */ (call).parent;
+      if (assigned != null && assigned.type === 'TSAsExpression') {
+        assigned = assigned.parent;
+      }
+      if (
+        assigned != null &&
+        assigned.type === 'VariableDeclarator' &&
+        assigned.id.type === 'Identifier'
+      ) {
+        return assigned.id.name;
+      }
+      return null;
+    }
 
     /**
      * Resolves the name literal from the useThemeProps call.
@@ -92,9 +153,7 @@ const rule = {
           let parent = node.parent;
           while (parent != null) {
             if (parent.type === 'FunctionExpression' || parent.type === 'FunctionDeclaration') {
-              if (
-                customHooks.includes(/** @type {import('estree').Identifier} */ (parent.id).name)
-              ) {
+              if (parent.id && customHooks.includes(parent.id.name)) {
                 isCalledFromCustomHook = true;
               }
               break;
@@ -117,7 +176,16 @@ const rule = {
           let parent = node.parent;
           while (parent != null && componentName === null) {
             if (parent.type === 'FunctionExpression' || parent.type === 'FunctionDeclaration') {
-              componentName = /** @type {import('estree').Identifier} */ (parent.id).name;
+              // For `forwardRef`/`memo`-wrapped components compiled with the babel
+              // display-name plugin, the variable name wins over the inner function name.
+              const wrappedName = babelDisplayNamePlugin
+                ? resolveWrappedComponentName(parent)
+                : null;
+              if (wrappedName !== null) {
+                componentName = wrappedName;
+              } else {
+                componentName = /** @type {import('estree').Identifier} */ (parent.id).name;
+              }
             }
 
             if (
@@ -129,7 +197,16 @@ const rule = {
                 parent.init.type === 'TSAsExpression'
                   ? /** @type {import('estree').CallExpression} */ (parent.init.expression).callee
                   : parent.init.callee;
+              const methodName = resolveCalleeMethodName(parentCallee);
               if (
+                babelDisplayNamePlugin &&
+                parent.id.type === 'Identifier' &&
+                (methodName === 'forwardRef' || methodName === 'memo')
+              ) {
+                // Arrow/anonymous component wrapped in `forwardRef`/`memo`: the
+                // displayName comes from the variable name.
+                componentName = parent.id.name;
+              } else if (
                 /** @type {import('estree').Identifier} */ (parentCallee).name.includes(
                   /** @type {import('estree').Identifier} */ (parent.id).name,
                 )

--- a/packages/code-infra/src/eslint/mui/rules/mui-name-matches-component-name.test.mjs
+++ b/packages/code-infra/src/eslint/mui/rules/mui-name-matches-component-name.test.mjs
@@ -245,3 +245,66 @@ ruleTester.run('mui-name-matches-component-name', rule, {
     },
   ],
 });
+
+ruleTester.run('mui-name-matches-component-name (babelDisplayNamePlugin)', rule, {
+  valid: [
+    {
+      code: `
+        const DatePickerToolbar = React.forwardRef((inProps, ref) => {
+          useThemeProps({ props: inProps, name: 'MuiDatePickerToolbar' });
+        });
+      `,
+      options: [{ babelDisplayNamePlugin: true }],
+    },
+    {
+      code: `
+        const DatePickerToolbar = React.forwardRef(function (inProps, ref) {
+          useThemeProps({ props: inProps, name: 'MuiDatePickerToolbar' });
+        });
+      `,
+      options: [{ babelDisplayNamePlugin: true }],
+    },
+    {
+      code: `
+        const Foo = React.memo((props) => {
+          useThemeProps({ props, name: 'MuiFoo' });
+        });
+      `,
+      options: [{ babelDisplayNamePlugin: true }],
+    },
+    {
+      // bare-import wrapper form
+      code: `
+        const Foo = forwardRef((props, ref) => {
+          useThemeProps({ props, name: 'MuiFoo' });
+        });
+      `,
+      options: [{ babelDisplayNamePlugin: true }],
+    },
+    {
+      // named inner function differs but the variable name matches
+      code: `
+        const Foo = forwardRef(function Bar(props, ref) {
+          useThemeProps({ props, name: 'MuiFoo' });
+        });
+      `,
+      options: [{ babelDisplayNamePlugin: true }],
+    },
+  ],
+  invalid: [
+    {
+      // variable-name mismatch
+      code: `
+        const Foo = React.forwardRef((props, ref) => {
+          useThemeProps({ props, name: 'MuiBar' });
+        });
+      `,
+      options: [{ babelDisplayNamePlugin: true }],
+      errors: [
+        {
+          message: "Expected `name` to be 'MuiFoo' but instead got 'MuiBar'.",
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Adds an opt-in `babelDisplayNamePlugin` option to `mui/material-ui-name-matches-component-name`. When enabled, a component wrapped in `forwardRef`/`memo` derives its name from the variable, matching the `displayName` injected by `@mui/internal-babel-plugin-display-name`. This lets the render function be anonymous/arrow (avoiding the new `no-shadow` error) while still validating the theming `name`.

```js
'mui/material-ui-name-matches-component-name': ['error', { babelDisplayNamePlugin: true }]
```

```jsx
// good
const Foo = forwardRef((props, ref) => { useThemeProps({ props, name: 'MuiFoo' }); });
const Foo = React.memo((props) => { useThemeProps({ props, name: 'MuiFoo' }); });

// bad — name must be 'MuiFoo' to match the variable
const Foo = forwardRef((props, ref) => { useThemeProps({ props, name: 'MuiBar' }); });
```

The default (option off) behavior is unchanged.