### PR TITLE
[ci] Re-run the required PR label check on synchronize

### DIFF
--- a/.github/workflows/check-if-pr-has-label.yml
+++ b/.github/workflows/check-if-pr-has-label.yml
@@ -2,9 +2,6 @@ name: Check if PR has label
 
 on:
   pull_request:
-    # `synchronize` re-runs the check on every push so this required status stays present on the
-    # latest commit. Without it the check only lands on a SHA when a label event fires, so a PR can
-    # be blocked by a stale/missing required check after pushing commits with no label change.
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions: {}

--- a/.github/workflows/check-if-pr-has-label.yml
+++ b/.github/workflows/check-if-pr-has-label.yml
@@ -2,7 +2,10 @@ name: Check if PR has label
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled]
+    # `synchronize` re-runs the check on every push so this required status stays present on the
+    # latest commit. Without it the check only lands on a SHA when a label event fires, so a PR can
+    # be blocked by a stale/missing required check after pushing commits with no label change.
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 permissions: {}
 


### PR DESCRIPTION
`test-label-applied` (from `check-if-pr-has-label.yml`) is a **required** status check, but its workflow only fired on label events (`opened/reopened/labeled/unlabeled`) — not on `synchronize`.

Because required checks are evaluated per-commit, after pushing commits with no label change the check goes stale/missing on the head SHA and blocks merge