### PR TITLE
[docs-infra] Fix flaky test_unit via shared vitest cleanup setup

### DIFF
--- a/packages/docs-infra/src/ChunkProvider/usePreload.test.tsx
+++ b/packages/docs-infra/src/ChunkProvider/usePreload.test.tsx
@@ -2,13 +2,10 @@
  * @vitest-environment jsdom
  */
 import * as React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { renderHook, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { usePreload } from './usePreload';
 import { PreloadProvider } from './PreloadProvider';
-
-afterEach(cleanup);
 
 describe('usePreload', () => {
   it('dedups by key within a provider: the factory runs once and the promise is shared', async () => {

--- a/packages/docs-infra/src/ChunkProvider/user.spec.tsx
+++ b/packages/docs-infra/src/ChunkProvider/user.spec.tsx
@@ -6,14 +6,12 @@
  * when a chunk is preloaded.
  */
 import * as React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { ChunkProvider } from './ChunkProvider';
 import { createCoordinatedLazy } from '../CoordinatedLazy/createCoordinatedLazy';
 import type { ChunkContentProps, StreamSource } from '../CoordinatedLazy/types';
 import { createSettleGate } from '../useCoordinated/createSettleGate';
-
-afterEach(cleanup);
 
 interface Point {
   v: number;

--- a/packages/docs-infra/src/CodeHighlighter/CodeHighlighterClient.test.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/CodeHighlighterClient.test.tsx
@@ -9,9 +9,8 @@
  * suppression, holdGate - are unit-tested in CoordinatedLazy/useCoordinatedSwap.)
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach, vi } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, renderHook, screen, waitFor, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, renderHook, screen, waitFor, act } from '@testing-library/react';
 import { CoordinatedContentContext } from '../CoordinatedLazy/CoordinatedContentContext';
 import { CodeContext, type CodeContext as CodeContextValue } from '../CodeProvider/CodeContext';
 import { CodeControllerContext } from '../CodeControllerContext';
@@ -20,8 +19,6 @@ import { CodeHighlighterContext } from './CodeHighlighterContext';
 import { useCodeFallback } from './useCodeFallback';
 import * as resolveFallbackCriticalModule from './resolveFallbackCritical';
 import type { Code, ContentLoadingProps } from './types';
-
-afterEach(cleanup);
 
 const hast = { type: 'root' as const, children: [{ type: 'text' as const, value: 'x' }] };
 const readyCode = { Default: { source: { hast } } } as unknown as Code;

--- a/packages/docs-infra/src/CodeHighlighter/useGrammarsReady.test.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/useGrammarsReady.test.tsx
@@ -5,9 +5,8 @@
  * disabled, when there is nothing to wait for, or when the scopes are already
  * registered (warm); otherwise `false` until the grammars load, then `true`.
  */
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto cleanup is a no-op here.
-import { renderHook, cleanup, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useGrammarsReady } from './useGrammarsReady';
 import { ensureGrammars } from '../pipeline/parseSource/grammarCache';
 import { resetStarryNight } from '../pipeline/parseSource/parseSource';
@@ -15,8 +14,6 @@ import { resetStarryNight } from '../pipeline/parseSource/parseSource';
 beforeEach(() => {
   resetStarryNight();
 });
-
-afterEach(cleanup);
 
 describe('useGrammarsReady', () => {
   it('is true synchronously when disabled', () => {

--- a/packages/docs-infra/src/CodeHighlighter/useSpeculativeCodePreload.test.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/useSpeculativeCodePreload.test.tsx
@@ -10,13 +10,10 @@
  * accurate, so a precomputed/code-free block preloads nothing.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach, vi } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
 import { CodeContext, type CodeContext as CodeContextValue } from '../CodeProvider/CodeContext';
 import { useSpeculativeCodePreload } from './useSpeculativeCodePreload';
-
-afterEach(cleanup);
 
 function makeLoaders() {
   return {

--- a/packages/docs-infra/src/CodeHighlighter/useSpeculativeEditingPreload.test.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/useSpeculativeEditingPreload.test.tsx
@@ -9,13 +9,10 @@
  * nothing.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach, vi } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
 import { CodeContext, type CodeContext as CodeContextValue } from '../CodeProvider/CodeContext';
 import { useSpeculativeEditingPreload } from './useSpeculativeEditingPreload';
-
-afterEach(cleanup);
 
 function setup(
   props: { enabled: boolean; editActivation?: 'eager' | 'interaction'; activated?: boolean },

--- a/packages/docs-infra/src/CodeHighlighter/useSpeculativeGrammarPreload.test.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/useSpeculativeGrammarPreload.test.tsx
@@ -7,9 +7,8 @@
  * highlight client-side (disabled — e.g. fully precomputed) loads nothing.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach, beforeEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto cleanup is a no-op here.
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
 import { useSpeculativeGrammarPreload } from './useSpeculativeGrammarPreload';
 import { areGrammarsRegistered } from '../pipeline/parseSource/grammarCache';
 import { resetStarryNight } from '../pipeline/parseSource/parseSource';
@@ -17,8 +16,6 @@ import { resetStarryNight } from '../pipeline/parseSource/parseSource';
 beforeEach(() => {
   resetStarryNight();
 });
-
-afterEach(cleanup);
 
 function setup(props: { scopes: string[]; enabled: boolean }) {
   function Speculative() {

--- a/packages/docs-infra/src/CodeHighlighter/useSpeculativeUseCodePreload.test.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/useSpeculativeUseCodePreload.test.tsx
@@ -8,13 +8,10 @@
  * transform. A block without transforms never prefetches it.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach, vi } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
 import { CodeContext, type CodeContext as CodeContextValue } from '../CodeProvider/CodeContext';
 import { useSpeculativeUseCodePreload } from './useSpeculativeUseCodePreload';
-
-afterEach(cleanup);
 
 function setup(props: { hasTransforms: boolean }, loaders: Partial<CodeContextValue>) {
   function Speculative() {

--- a/packages/docs-infra/src/CodeHighlighter/user.spec.tsx
+++ b/packages/docs-infra/src/CodeHighlighter/user.spec.tsx
@@ -24,10 +24,8 @@
  * component's user cases; keep them readable over clever.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach, beforeAll } from 'vitest';
-// Manual cleanup: the root vitest config does not set `globals: true`, so RTL's
-// automatic `afterEach(cleanup)` is a no-op here.
-import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { CodeHighlighterClient } from './CodeHighlighterClient';
 import { useCode } from '../useCode';
 import { CodeControllerContext } from '../CodeControllerContext';
@@ -36,8 +34,6 @@ import { parseControlledCode } from './parseControlledCode';
 import { createParseSource } from '../pipeline/parseSource';
 import { preloadSourceEditingEngine } from '../useCode/useSourceEditing';
 import type { Code, ContentProps, ControlledCode, HastRoot, ParseSource } from './types';
-
-afterEach(cleanup);
 
 let parseSource: ParseSource;
 

--- a/packages/docs-infra/src/CodeProvider/CodeProvider.test.tsx
+++ b/packages/docs-infra/src/CodeProvider/CodeProvider.test.tsx
@@ -7,13 +7,10 @@
  * function (no fetch). The small synchronous parsers stay eager direct fns.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
 import { CodeProvider } from './CodeProvider';
 import { useCodeContext, type CodeContext as CodeContextValue } from './CodeContext';
-
-afterEach(cleanup);
 
 /** Renders a probe under `wrapper` and returns the captured CodeContext value. */
 function renderUnder(wrapper: (children: React.ReactNode) => React.ReactElement) {

--- a/packages/docs-infra/src/CodeProvider/CodeProviderLazy.preloadGrammars.test.tsx
+++ b/packages/docs-infra/src/CodeProvider/CodeProviderLazy.preloadGrammars.test.tsx
@@ -5,9 +5,8 @@
  * a language/scope list warms exactly those on mount; `'all'` warms everything.
  */
 import * as React from 'react';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto cleanup is a no-op here.
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
 import { CodeProviderLazy } from './CodeProviderLazy';
 import { areGrammarsRegistered } from '../pipeline/parseSource/grammarCache';
 import { resetStarryNight } from '../pipeline/parseSource/parseSource';
@@ -15,8 +14,6 @@ import { resetStarryNight } from '../pipeline/parseSource/parseSource';
 beforeEach(() => {
   resetStarryNight();
 });
-
-afterEach(cleanup);
 
 describe('CodeProviderLazy preloadGrammars', () => {
   it('registers no grammars by default (fully lazy)', async () => {

--- a/packages/docs-infra/src/CodeProvider/CodeProviderLazy.test.tsx
+++ b/packages/docs-infra/src/CodeProvider/CodeProviderLazy.test.tsx
@@ -8,13 +8,10 @@
  * fetch. The small synchronous parsers stay eager.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
 import { CodeProviderLazy } from './CodeProviderLazy';
 import { useCodeContext, type CodeContext as CodeContextValue } from './CodeContext';
-
-afterEach(cleanup);
 
 /** Renders a probe under `wrapper` and returns the captured CodeContext value. */
 function renderUnder(wrapper: (children: React.ReactNode) => React.ReactElement) {

--- a/packages/docs-infra/src/CoordinatedLazy/LazyContent.test.tsx
+++ b/packages/docs-infra/src/CoordinatedLazy/LazyContent.test.tsx
@@ -2,14 +2,11 @@
  * @vitest-environment jsdom
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, screen, waitFor, act, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { LazyContent } from './LazyContent';
 import { CoordinatedContentContext } from './CoordinatedContentContext';
 import { createSettleGate } from '../useCoordinated/createSettleGate';
-
-afterEach(cleanup);
 
 function Hello({ name }: { name: string }) {
   return <div data-testid="hello">Hello {name}</div>;

--- a/packages/docs-infra/src/CoordinatedLazy/awaitContent.test.tsx
+++ b/packages/docs-infra/src/CoordinatedLazy/awaitContent.test.tsx
@@ -7,13 +7,10 @@
  * code highlighter uses to lazy-load its content component.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, screen, act, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { CoordinatedLazy } from './CoordinatedLazy';
 import { LazyContent } from './LazyContent';
-
-afterEach(cleanup);
 
 function FullContent() {
   return <div data-testid="content">full</div>;

--- a/packages/docs-infra/src/CoordinatedLazy/createCoordinatedLazy.user.spec.tsx
+++ b/packages/docs-infra/src/CoordinatedLazy/createCoordinatedLazy.user.spec.tsx
@@ -8,14 +8,12 @@
  * covered in the unit tests, since a DOM cannot run async server components.)
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, act, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import { createCoordinatedLazy } from './createCoordinatedLazy';
 import type { ChunkContentProps, ChunkLoadingProps, StreamSource } from './types';
 import { ChunkProvider } from '../ChunkProvider';
 import { createSettleGate } from '../useCoordinated/createSettleGate';
-
-afterEach(cleanup);
 
 interface Point {
   v: number;

--- a/packages/docs-infra/src/CoordinatedLazy/useChunk.test.ts
+++ b/packages/docs-infra/src/CoordinatedLazy/useChunk.test.ts
@@ -9,13 +9,10 @@
  * Each test builds its `config` ONCE (a stable reference) — `useChunk`'s load
  * effect is keyed on `config`, so an inline config would reload every render.
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`.
-import { renderHook, waitFor, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { useChunk } from './useChunk';
 import type { CreateChunkConfig } from './types';
-
-afterEach(cleanup);
 
 function dataConfig(
   load: (options: undefined, signal: AbortSignal) => Promise<string>,

--- a/packages/docs-infra/src/CoordinatedLazy/useCoordinatedFallback.test.tsx
+++ b/packages/docs-infra/src/CoordinatedLazy/useCoordinatedFallback.test.tsx
@@ -2,14 +2,11 @@
  * @vitest-environment jsdom
  */
 import * as React from 'react';
-import { describe, it, expect, vi, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { useCoordinatedFallback } from './useCoordinatedFallback';
 import { CoordinatedFallbackContext } from './CoordinatedFallbackContext';
 import type { CoordinatedFallbackContextValue } from './types';
-
-afterEach(cleanup);
 
 function Harness({ hoistData }: { hoistData?: Record<string, unknown> }) {
   const { data, isNested } = useCoordinatedFallback(hoistData);

--- a/packages/docs-infra/src/CoordinatedLazy/useCoordinatedSwap.test.tsx
+++ b/packages/docs-infra/src/CoordinatedLazy/useCoordinatedSwap.test.tsx
@@ -1,13 +1,10 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { renderHook, act, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 import { useCoordinatedSwap } from './useCoordinatedSwap';
 import { createSettleGate } from '../useCoordinated/createSettleGate';
-
-afterEach(cleanup);
 
 /** Flush the gate's deferred settle-check microtask, inside act. */
 async function flush(): Promise<void> {

--- a/packages/docs-infra/src/CoordinatedLazy/user.spec.tsx
+++ b/packages/docs-infra/src/CoordinatedLazy/user.spec.tsx
@@ -6,14 +6,12 @@
  * `useCoordinatedSwap.test.tsx` / `useCoordinatedFallback.test.tsx`.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, act, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { CoordinatedLazy } from './CoordinatedLazy';
 import { useCoordinatedFallback } from './useCoordinatedFallback';
 import { useCoordinatedContent } from './CoordinatedContentContext';
 import { createSettleGate } from '../useCoordinated/createSettleGate';
-
-afterEach(cleanup);
 
 function Loading() {
   return <div data-testid="loading">loading</div>;

--- a/packages/docs-infra/src/abstractCreateStream/user.spec.tsx
+++ b/packages/docs-infra/src/abstractCreateStream/user.spec.tsx
@@ -6,13 +6,11 @@
  * `precompute` or fall back to the config's loaders.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, act, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
 import { createStreamFactory } from './abstractCreateStream';
 import { ChunkProvider } from '../ChunkProvider';
 import type { ChunkContentProps, StreamSource } from '../CoordinatedLazy/types';
-
-afterEach(cleanup);
 
 interface Point {
   v: number;

--- a/packages/docs-infra/src/useCoordinated/useSettleGate.test.tsx
+++ b/packages/docs-infra/src/useCoordinated/useSettleGate.test.tsx
@@ -1,13 +1,10 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { renderHook, act, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 import { useSettleGate } from './useSettleGate';
 import { createSettleGate } from './createSettleGate';
-
-afterEach(cleanup);
 
 /** Flush the microtask the gate uses to defer its settle check, inside act. */
 async function flush(): Promise<void> {

--- a/packages/docs-infra/src/useStream/useStream.test.tsx
+++ b/packages/docs-infra/src/useStream/useStream.test.tsx
@@ -2,13 +2,10 @@
  * @vitest-environment jsdom
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-// eslint-disable-next-line testing-library/no-manual-cleanup -- root vitest config does not set `globals: true`, so RTL's auto `afterEach(cleanup)` is a no-op here.
-import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { useStream } from './useStream';
 import type { StreamSource } from './types';
-
-afterEach(cleanup);
 
 interface Deferred<T> {
   promise: Promise<T>;

--- a/packages/docs-infra/src/useStream/useStreamController.user.spec.tsx
+++ b/packages/docs-infra/src/useStream/useStreamController.user.spec.tsx
@@ -6,14 +6,12 @@
  * streaming completion modes.
  */
 import * as React from 'react';
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { useStreamController } from './useStreamController';
 import type { UseStreamControllerOptions } from './types';
 import { useCoordinatedGate } from '../CoordinatedLazy/CoordinatedGateContext';
 import { useSettleGate } from '../useCoordinated/useSettleGate';
-
-afterEach(cleanup);
 
 /** A stand-in chunk that registers with the ambient (controller) gate and settles when told. */
 function FakeChunk({ settled }: { settled: boolean }) {

--- a/packages/docs-infra/vitest.config.mts
+++ b/packages/docs-infra/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Files keep their per-file `@vitest-environment jsdom` pragmas, so `environment` is left
+    // at the default here on purpose (most tests in this package run in Node).
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/packages/docs-infra/vitest.setup.ts
+++ b/packages/docs-infra/vitest.setup.ts
@@ -1,0 +1,13 @@
+import { afterEach } from 'vitest';
+// Import from `/pure` so React Testing Library does not also auto-register its own `afterEach`
+// cleanup. The root vitest config does not set `globals: true`, so we register it explicitly
+// here once for every test file in the package.
+// eslint-disable-next-line import/extensions
+import { cleanup } from '@testing-library/react/pure.js';
+
+// Unmount any rendered React trees after each test. Without this, a hook/component left mounted
+// keeps work queued in React's scheduler; that work can flush (via `setImmediate`) after Vitest
+// tears down the jsdom environment, throwing "ReferenceError: window is not defined" and failing
+// an otherwise-green run. `cleanup()` is a no-op when nothing is mounted, so it is safe in the
+// package's Node-only test files too.
+afterEach(cleanup);


### PR DESCRIPTION
Fixes a flaky `test_unit`: tests pass but an unhandled `ReferenceError: window is not defined` (React scheduler flushing after jsdom teardown) intermittently fails the run.

`docs-infra` had no vitest config, so RTL's auto-cleanup never ran and each test had to call `afterEach(cleanup)` by hand — which `useCode/user.spec.ts` didn't, leaving hooks mounted with pending async `setState`s.

Adds a package-level vitest config + setup file that registers `afterEach(cleanup)` once for every test, unmounting trees so no scheduler work survives teardown.

Verified by reproducing the exact failure in a controlled test (error without cleanup, clean with it).