### PR TITLE
[code-infra] Remove legacy ESLint workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,16 +37,6 @@
   },
   "pnpm": {
     "packageExtensions": {
-      "@eslint/config-helpers@*": {
-        "peerDependencies": {
-          "eslint": "*"
-        },
-        "peerDependenciesMeta": {
-          "eslint": {
-            "optional": true
-          }
-        }
-      },
       "eslint-plugin-react@*": {
         "peerDependencies": {
           "eslint": "^9.0.0 || ^10.0.0"

--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -73,7 +73,6 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@eslint/compat": "^2.1.0",
-    "@eslint/config-helpers": "^0.6.0",
     "@eslint/js": "^10.0.1",
     "@eslint/json": "^1.2.0",
     "@inquirer/confirm": "^6.0.13",

--- a/packages/code-infra/src/eslint/baseConfig.mjs
+++ b/packages/code-infra/src/eslint/baseConfig.mjs
@@ -1,7 +1,6 @@
 import { includeIgnoreFile, fixupConfigRules } from '@eslint/compat';
 import eslintJs from '@eslint/js';
-// TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
-import { defineConfig } from '@eslint/config-helpers';
+import { defineConfig } from 'eslint/config';
 import prettier from 'eslint-config-prettier/flat';
 import compatPlugin from 'eslint-plugin-compat';
 import importPlugin from 'eslint-plugin-import';

--- a/packages/code-infra/src/eslint/docsConfig.mjs
+++ b/packages/code-infra/src/eslint/docsConfig.mjs
@@ -1,6 +1,5 @@
 import nextjs from '@next/eslint-plugin-next';
-// TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
-import { defineConfig } from '@eslint/config-helpers';
+import { defineConfig } from 'eslint/config';
 import { EXTENSION_TS } from './extensions.mjs';
 
 /**

--- a/packages/code-infra/src/eslint/jsonConfig.mjs
+++ b/packages/code-infra/src/eslint/jsonConfig.mjs
@@ -1,5 +1,4 @@
-// TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
-import { defineConfig } from '@eslint/config-helpers';
+import { defineConfig } from 'eslint/config';
 import json from '@eslint/json';
 
 /**

--- a/packages/code-infra/src/eslint/mui/config.mjs
+++ b/packages/code-infra/src/eslint/mui/config.mjs
@@ -1,5 +1,4 @@
-// TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
-import { defineConfig } from '@eslint/config-helpers';
+import { defineConfig } from 'eslint/config';
 import { EXTENSION_DTS } from '../extensions.mjs';
 
 const restrictedMethods = ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'];

--- a/packages/code-infra/src/eslint/testConfig.mjs
+++ b/packages/code-infra/src/eslint/testConfig.mjs
@@ -1,8 +1,7 @@
 import mochaPlugin from 'eslint-plugin-mocha';
 import vitestPlugin from '@vitest/eslint-plugin';
 import testingLibrary from 'eslint-plugin-testing-library';
-// TODO: change back to 'eslint/config' once https://github.com/eslint/rewrite/issues/425 is fixed
-import { defineConfig } from '@eslint/config-helpers';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import * as tseslint from 'typescript-eslint';
 import { EXTENSION_TS } from './extensions.mjs';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,9 +550,6 @@ importers:
       '@eslint/compat':
         specifier: ^2.1.0
         version: 2.1.0(eslint@10.4.0(jiti@2.7.0))
-      '@eslint/config-helpers':
-        specifier: ^0.6.0
-        version: 0.6.0
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0(jiti@2.7.0))


### PR DESCRIPTION
The fix was released in https://github.com/eslint/rewrite/releases/tag/core-v1.2.1, which we already depend on. Now, we use the documented API https://eslint.org/docs/latest/use/configure/configuration-files

*(Context: I saw this in #1522)*