### PR TITLE
[code-infra] Disable no-shadow temporarily

### DIFF
--- a/packages/code-infra/src/eslint/baseConfig.mjs
+++ b/packages/code-infra/src/eslint/baseConfig.mjs
@@ -141,7 +141,8 @@ export function createBaseConfig({
             'no-unassigned-vars': 'off',
           },
         },
-        // @TODO: Remove this once fixed in upstream tseslint-plugin
+        // @TODO: Remove this once @typescript-eslint/no-shadow supports wrapped functions
+        //   See https://github.com/eslint/eslint/pull/20982 (once merged also needs port to `typescript-eslint`)
         {
           name: 'Disabled tseslint-plugins',
           rules: {

--- a/packages/code-infra/src/eslint/baseConfig.mjs
+++ b/packages/code-infra/src/eslint/baseConfig.mjs
@@ -141,6 +141,13 @@ export function createBaseConfig({
             'no-unassigned-vars': 'off',
           },
         },
+        // @TODO: Remove this once fixed in upstream tseslint-plugin
+        {
+          name: 'Disabled tseslint-plugins',
+          rules: {
+            '@typescript-eslint/no-shadow': 'off',
+          },
+        },
       ]),
     },
     {


### PR DESCRIPTION


Temporarily disables the `@typescript-eslint/no-shadow` rule in the shared base ESLint config until the upstream issue in `tseslint-plugin` is fixed.
