### PR TITLE
[code-infra] Test imports field with bare-specifier conditions

### DIFF
--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -1281,4 +1281,77 @@ describe('createPackageImports', () => {
       },
     });
   });
+
+  it('passes a conditions object of bare specifiers through unchanged, preserving condition order', async () => {
+    const cwd = await makeTempDir();
+
+    const imports = await createPackageImports(
+      {
+        '#mui/TransitionGroupContext': {
+          node: 'react-transition-group/cjs/TransitionGroupContext.js',
+          browser: 'react-transition-group/esm/TransitionGroupContext.js',
+          default: 'react-transition-group/esm/TransitionGroupContext.js',
+        },
+      },
+      {
+        bundles: [
+          { type: 'esm', dir: '.' },
+          { type: 'cjs', dir: '.' },
+        ],
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
+
+    expect(imports).toEqual({
+      '#mui/TransitionGroupContext': {
+        node: 'react-transition-group/cjs/TransitionGroupContext.js',
+        browser: 'react-transition-group/esm/TransitionGroupContext.js',
+        default: 'react-transition-group/esm/TransitionGroupContext.js',
+      },
+    });
+    expect(Object.keys(imports['#mui/TransitionGroupContext'])).toEqual([
+      'node',
+      'browser',
+      'default',
+    ]);
+  });
+
+  it('passes a nested import/require/default object of bare specifiers through unchanged', async () => {
+    const cwd = await makeTempDir();
+
+    const imports = await createPackageImports(
+      {
+        '#mui/TransitionGroupContext': {
+          node: 'react-transition-group/cjs/TransitionGroupContext.js',
+          default: {
+            import: 'react-transition-group/esm/TransitionGroupContext.js',
+            require: 'react-transition-group/cjs/TransitionGroupContext.js',
+            default: 'react-transition-group/esm/TransitionGroupContext.js',
+          },
+        },
+      },
+      {
+        bundles: [
+          { type: 'esm', dir: '.' },
+          { type: 'cjs', dir: '.' },
+        ],
+        cwd,
+        isFlat: true,
+        packageType: 'module',
+      },
+    );
+
+    expect(imports).toEqual({
+      '#mui/TransitionGroupContext': {
+        node: 'react-transition-group/cjs/TransitionGroupContext.js',
+        default: {
+          import: 'react-transition-group/esm/TransitionGroupContext.js',
+          require: 'react-transition-group/cjs/TransitionGroupContext.js',
+          default: 'react-transition-group/esm/TransitionGroupContext.js',
+        },
+      },
+    });
+  });
 });

--- a/packages/code-infra/src/utils/build.test.mjs
+++ b/packages/code-infra/src/utils/build.test.mjs
@@ -1311,11 +1311,11 @@ describe('createPackageImports', () => {
         default: 'react-transition-group/esm/TransitionGroupContext.js',
       },
     });
-    expect(Object.keys(imports['#mui/TransitionGroupContext'])).toEqual([
-      'node',
-      'browser',
-      'default',
-    ]);
+    expect(
+      Object.keys(
+        /** @type {Record<string, unknown>} */ (imports?.['#mui/TransitionGroupContext']),
+      ),
+    ).toEqual(['node', 'browser', 'default']);
   });
 
   it('passes a nested import/require/default object of bare specifiers through unchanged', async () => {


### PR DESCRIPTION
Adds test coverage for `createPackageImports` handling subpath `imports` entries whose condition leaves are bare specifiers pointing at external package files (not internal source paths).

Motivated by [mui/material-ui#48645 (comment)](https://github.com/mui/material-ui/pull/48645#issuecomment-4707269493), which proposes mapping `#mui/TransitionGroupContext` to per-condition external files, e.g.:

```json
"#mui/TransitionGroupContext": {
  "node": "react-transition-group/cjs/TransitionGroupContext.js",
  "browser": "react-transition-group/esm/TransitionGroupContext.js",
  "default": "react-transition-group/esm/TransitionGroupContext.js"
}
```

The build already supports this — it emits the mapping verbatim — but it wasn't covered. Existing tests only exercised a flat bare specifier and a conditions-outer object with *internal source paths*. Two cases are added:

- A conditions-outer object of bare specifiers, asserting passthrough **and** condition-key order preservation (Node's condition matching is order-sensitive).
- A nested `import`/`require`/`default` object of bare specifiers, which exercises the `sortExportConditions` path and confirms the specifiers aren't rewritten or reordered.