### PR TITLE
[code-infra] Auto-dedupe Dependabot PRs to pass CI

### DIFF
--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -1,0 +1,52 @@
+name: Dedupe Dependabot PRs
+
+# Dependabot bumps `pnpm-lock.yaml` without running `pnpm dedupe`, so its PRs
+# fail the orb's `pnpm dedupe --check` gate. This is the Dependabot-side
+# analogue of Renovate's `postUpdateOptions: ["pnpmDedupe"]`: dedupe the branch
+# and push the result back so the check passes.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Dependabot-triggered `pull_request` runs default to a read-only token but
+# respect this `permissions:` key (GitHub change, 2021-10-06), so this grants
+# the `GITHUB_TOKEN` write access to push the dedupe commit.
+permissions:
+  contents: write
+
+concurrency:
+  group: dependabot-dedupe-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dedupe:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Dependabot branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+      # --ignore-scripts: don't run the bumped dependency's lifecycle scripts
+      # just to rewrite the lockfile.
+      - name: Run dedupe
+        run: pnpm dedupe --ignore-scripts
+      - name: Commit & push if the lockfile changed
+        run: |
+          if git diff --quiet -- pnpm-lock.yaml; then
+            echo "No lockfile changes"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pnpm-lock.yaml
+          git commit -m "Run pnpm dedupe"
+          git push

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -9,11 +9,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Dependabot-triggered `pull_request` runs default to a read-only token but
-# respect this `permissions:` key (GitHub change, 2021-10-06), so this grants
-# the `GITHUB_TOKEN` write access to push the dedupe commit.
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: dependabot-dedupe-${{ github.event.pull_request.number }}
@@ -21,8 +17,15 @@ concurrency:
 
 jobs:
   dedupe:
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    # Gate on the PR *author* (not `github.actor`) so the job still runs when a
+    # maintainer reopens/synchronizes the PR. `user.login` can't be spoofed.
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
+    # Dependabot-triggered `pull_request` runs default to a read-only token but
+    # respect this `permissions:` key (GitHub change, 2021-10-06). Scoped to the
+    # job so non-matching PRs never see an elevated token.
+    permissions:
+      contents: write
     steps:
       - name: Check out Dependabot branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -40,13 +43,16 @@ jobs:
       - name: Run dedupe
         run: pnpm dedupe --ignore-scripts
       - name: Commit & push if the lockfile changed
+        # Pass the head ref via env to keep it out of the shell (injection-safe).
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if git diff --quiet -- pnpm-lock.yaml; then
             echo "No lockfile changes"
             exit 0
           fi
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml
           git commit -m "Run pnpm dedupe"
-          git push
+          git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -19,7 +19,7 @@ jobs:
   dedupe:
     # Gate on the PR *author* (not `github.actor`) so the job still runs when a
     # maintainer reopens/synchronizes the PR. `user.login` can't be spoofed.
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     # Dependabot-triggered `pull_request` runs default to a read-only token but
     # respect this `permissions:` key (GitHub change, 2021-10-06). Scoped to the

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -19,6 +19,10 @@ jobs:
   dedupe:
     # Gate on the PR *author* (not `github.actor`) so the job still runs when a
     # maintainer reopens/synchronizes the PR. `user.login` can't be spoofed.
+    # The `github.actor` guard skips the follow-up `synchronize` event this
+    # workflow's own dedupe push creates (where the author is still
+    # `dependabot[bot]` but the actor is `github-actions[bot]`), avoiding a
+    # redundant rerun. On `opened` the actor is `dependabot[bot]`, so it runs.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     # Dependabot-triggered `pull_request` runs default to a read-only token but


### PR DESCRIPTION
## Problem

Renovate can't remediate **transitive** dependency vulnerabilities (e.g. GHSA-gv7w-rqvm-qjhr for `esbuild`, which is in no `package.json`, only `pnpm-lock.yaml`). Its only transitive-remediation mechanism (`transitiveRemediation`) was npm@6-only and has been dropped, with no pnpm support. So we keep Dependabot for security PRs (already configured security-only in `.github/dependabot.yml`).

But Dependabot bumps the lockfile **without** running `pnpm dedupe`, so its PRs fail the orb's `pnpm dedupe --check` gate (`.circleci/orbs/code-infra.yml`). Renovate PRs pass because `renovate/default.json` sets `postUpdateOptions: ["pnpmDedupe"]`; Dependabot has no equivalent.

Skipping the check for Dependabot branches isn't viable: `pnpm dedupe --check` validates the whole lockfile, not the diff, so a non-deduped lockfile merged to `master` would fail the check on *every* later deps PR.

## Fix

A small workflow that dedupes Dependabot PR branches and pushes the result back — the Dependabot-side analogue of Renovate's `postUpdateOptions: ["pnpmDedupe"]`.

Since the 2021-10-06 GitHub change, Dependabot-triggered `pull_request` runs respect the `permissions:` key, so `permissions: contents: write` grants the default `GITHUB_TOKEN` push access — no App token or `pull_request_target` needed. The pushed commit re-triggers CircleCI (the actual gate) which then passes; `GITHUB_TOKEN` pushes don't re-trigger Actions, so no loop.