### PR TITLE
[code-infra] Rework Dependabot dedupe to honor minimumReleaseAge

### DIFF
--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -18,6 +18,12 @@ name: Dedupe Dependabot PRs
 #   4. push the rewritten lockfile back to the PR branch.
 # This mirrors Renovate, which honors `minimumReleaseAge` during resolution and
 # so never floats collateral deps to fresh versions in the first place.
+#
+# Edge case: if a *targeted* patch is itself younger than `minimumReleaseAge`,
+# even the targeted update can't resolve it. `pnpm code-infra release-age-exclude`
+# adds a version-scoped `minimumReleaseAgeExclude` entry for exactly that
+# `name@version` (so only the deliberately-adopted version bypasses the gate),
+# and `--prune` drops such entries once their version matures.
 
 on:
   pull_request:
@@ -63,7 +69,13 @@ jobs:
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
-      - name: Rebuild lockfile from master with only the advisory bumps
+      # Needed for the `code-infra` CLI below. The branch's lockfile is internally
+      # consistent and frozen install does no re-resolution, so it won't trip
+      # `minimumReleaseAge`.
+      - name: Install dependencies
+        if: ${{ steps.meta.outputs.dependency-names != '' }}
+        run: pnpm install --frozen-lockfile
+      - name: Rebuild lockfile from the base branch with only the advisory bumps
         if: ${{ steps.meta.outputs.dependency-names != '' }}
         # Pass metadata via env to keep it out of the shell (injection-safe).
         env:
@@ -83,6 +95,12 @@ jobs:
             exit 0
           fi
           echo "Re-applying: ${specs[*]}"
+          # If a target is itself younger than minimumReleaseAge, add a
+          # version-scoped exemption so the update (and CI's dedupe --check) can
+          # resolve it; --prune drops exemptions whose versions have matured.
+          # No-op when every target is already mature.
+          pnpm code-infra release-age-exclude "${specs[@]}" --prune
+          pnpm exec prettier --write pnpm-workspace.yaml
           # Discard Dependabot's whole-tree resolution by restoring the base
           # branch's lockfile, then re-apply just the targeted bumps on top of it.
           git fetch --no-tags --depth=1 origin "$BASE_REF"
@@ -91,17 +109,18 @@ jobs:
           # --lockfile-only: we only need the lockfile.
           pnpm update "${specs[@]}" --depth Infinity --lockfile-only
           pnpm dedupe --lockfile-only
-      - name: Commit & push if the lockfile changed
+      - name: Commit & push if anything changed
         if: ${{ steps.meta.outputs.dependency-names != '' }}
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           # The rebuild step stages the base branch's lockfile into the index, so
           # compare the final result against the PR branch tip (HEAD) — not the
-          # index — to decide whether anything actually changed.
-          git add pnpm-lock.yaml
-          if git diff --cached --quiet HEAD -- pnpm-lock.yaml; then
-            echo "No lockfile changes"
+          # index — to decide whether anything actually changed. `pnpm-workspace.yaml`
+          # is included because release-age-exclude may have edited it.
+          git add pnpm-workspace.yaml pnpm-lock.yaml
+          if git diff --cached --quiet HEAD -- pnpm-workspace.yaml pnpm-lock.yaml; then
+            echo "No changes"
             exit 0
           fi
           git config user.name "github-actions[bot]"

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -48,9 +48,11 @@ jobs:
     # Dependabot-triggered `pull_request` runs default to a read-only token but
     # respect this `permissions:` key (GitHub change, 2021-10-06). Scoped to the
     # job so non-matching PRs never see an elevated token. `contents: write` is
-    # for pushing the rewritten lockfile.
+    # for pushing the rewritten lockfile; `pull-requests: read` is required by
+    # `dependabot/fetch-metadata`.
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Read Dependabot metadata
         id: meta
@@ -85,11 +87,21 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           # Build a "<name>@<version>" spec for every dependency the PR bumps.
-          # `pnpm update` accepts multiple specs, so grouped PRs work too. Pin
-          # the exact versions Dependabot chose so we don't overshoot to a newer
-          # (possibly too-fresh) release.
-          mapfile -t specs < <(printf '%s' "$UPDATED_DEPENDENCIES" \
-            | jq -r '.[] | select(.newVersion != null and .newVersion != "") | "\(.dependencyName)@\(.newVersion)"')
+          # `pnpm update` accepts multiple specs, so grouped PRs are handled too.
+          # Pin the exact versions Dependabot chose so we don't overshoot to a
+          # newer (possibly too-fresh) release. Use command substitution (with the
+          # shell's `pipefail`) rather than process substitution so a `jq` parse
+          # failure fails the step instead of silently yielding an empty no-op.
+          if ! specs_raw=$(printf '%s' "$UPDATED_DEPENDENCIES" \
+            | jq -r '.[] | select(.newVersion != null and .newVersion != "") | "\(.dependencyName)@\(.newVersion)"'); then
+            echo "Failed to parse Dependabot metadata" >&2
+            exit 1
+          fi
+          mapfile -t specs <<< "$specs_raw"
+          # A here-string built from empty input yields one empty element.
+          if [ ${#specs[@]} -eq 1 ] && [ -z "${specs[0]}" ]; then
+            specs=()
+          fi
           if [ ${#specs[@]} -eq 0 ]; then
             echo "No versioned dependency updates in metadata; nothing to re-apply"
             exit 0

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -9,9 +9,10 @@ name: Dedupe Dependabot PRs
 #
 # Plain `pnpm dedupe` can't fix this: pnpm refuses the too-fresh versions and
 # won't downgrade them. Instead this workflow rebuilds the lockfile from master
-# and re-applies only the advisory bump:
+# and re-applies only the bumps the PR actually intends:
 #   1. reset `pnpm-lock.yaml` to master (a policy-compliant, mature baseline),
-#   2. `pnpm update <dep>@<new-version>` to apply just the targeted bump,
+#   2. `pnpm update <dep>@<new-version> …` (one spec per bumped dependency,
+#      read from Dependabot's metadata) to apply just the targeted bumps,
 #   3. `pnpm dedupe` so the result passes the gate,
 #   4. push the rewritten lockfile back to the PR branch.
 # This mirrors Renovate, which honors `minimumReleaseAge` during resolution and
@@ -48,49 +49,58 @@ jobs:
         id: meta
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Check out Dependabot branch
-        # Only a single-dependency bump can be re-applied as one `pnpm update`.
-        # Grouped/multi-dependency PRs are skipped (security advisories are
-        # single-dependency, so this covers the case that matters).
-        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
+        if: ${{ steps.meta.outputs.dependency-names != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up pnpm
-        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
+        if: ${{ steps.meta.outputs.dependency-names != '' }}
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - name: Set up Node
-        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
+        if: ${{ steps.meta.outputs.dependency-names != '' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
-      - name: Rebuild lockfile from master with only the advisory bump
-        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
+      - name: Rebuild lockfile from master with only the advisory bumps
+        if: ${{ steps.meta.outputs.dependency-names != '' }}
         # Pass metadata via env to keep it out of the shell (injection-safe).
         env:
-          DEP_NAME: ${{ steps.meta.outputs.dependency-names }}
-          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+          UPDATED_DEPENDENCIES: ${{ steps.meta.outputs.updated-dependencies-json }}
         run: |
+          # Build a "<name>@<version>" spec for every dependency the PR bumps.
+          # `pnpm update` accepts multiple specs, so grouped PRs work too. Pin
+          # the exact versions Dependabot chose so we don't overshoot to a newer
+          # (possibly too-fresh) release.
+          mapfile -t specs < <(printf '%s' "$UPDATED_DEPENDENCIES" \
+            | jq -r '.[] | select(.newVersion != null and .newVersion != "") | "\(.dependencyName)@\(.newVersion)"')
+          if [ ${#specs[@]} -eq 0 ]; then
+            echo "No versioned dependency updates in metadata; nothing to re-apply"
+            exit 0
+          fi
+          echo "Re-applying: ${specs[*]}"
           # Discard Dependabot's whole-tree resolution by restoring master's
-          # lockfile, then re-apply just the targeted bump on top of it.
+          # lockfile, then re-apply just the targeted bumps on top of it.
           git fetch --no-tags --depth=1 origin master
           git checkout FETCH_HEAD -- pnpm-lock.yaml
-          # Pin the exact version Dependabot chose so we don't overshoot to a
-          # newer (possibly too-fresh) release. --depth Infinity so transitive
-          # deps are updated too. --lockfile-only: we only need the lockfile.
-          pnpm update "$DEP_NAME@$NEW_VERSION" --depth Infinity --lockfile-only
+          # --depth Infinity so transitive deps are updated too.
+          # --lockfile-only: we only need the lockfile.
+          pnpm update "${specs[@]}" --depth Infinity --lockfile-only
           pnpm dedupe --lockfile-only
       - name: Commit & push if the lockfile changed
-        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
+        if: ${{ steps.meta.outputs.dependency-names != '' }}
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if git diff --quiet -- pnpm-lock.yaml; then
+          # The rebuild step stages master's lockfile into the index, so compare
+          # the final result against the branch tip (HEAD) — not the index — to
+          # decide whether anything actually changed.
+          git add pnpm-lock.yaml
+          if git diff --cached --quiet HEAD -- pnpm-lock.yaml; then
             echo "No lockfile changes"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pnpm-lock.yaml
           git commit -m "Rebuild lockfile honoring minimumReleaseAge"
           git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -1,9 +1,21 @@
 name: Dedupe Dependabot PRs
 
-# Dependabot bumps `pnpm-lock.yaml` without running `pnpm dedupe`, so its PRs
-# fail the orb's `pnpm dedupe --check` gate. This is the Dependabot-side
-# analogue of Renovate's `postUpdateOptions: ["pnpmDedupe"]`: dedupe the branch
-# and push the result back so the check passes.
+# Dependabot regenerates the *entire* `pnpm-lock.yaml` and resolves every
+# package to its newest in-range version, ignoring this repo's
+# `minimumReleaseAge` policy (set in `pnpm-workspace.yaml`). That floats
+# unrelated transitive deps to releases that are too fresh, so the orb's
+# `pnpm dedupe --check` gate — which *does* honor `minimumReleaseAge` — rejects
+# the branch with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.
+#
+# Plain `pnpm dedupe` can't fix this: pnpm refuses the too-fresh versions and
+# won't downgrade them. Instead this workflow rebuilds the lockfile from master
+# and re-applies only the advisory bump:
+#   1. reset `pnpm-lock.yaml` to master (a policy-compliant, mature baseline),
+#   2. `pnpm update <dep>@<new-version>` to apply just the targeted bump,
+#   3. `pnpm dedupe` so the result passes the gate,
+#   4. push the rewritten lockfile back to the PR branch.
+# This mirrors Renovate, which honors `minimumReleaseAge` during resolution and
+# so never floats collateral deps to fresh versions in the first place.
 
 on:
   pull_request:
@@ -20,34 +32,56 @@ jobs:
     # Gate on the PR *author* (not `github.actor`) so the job still runs when a
     # maintainer reopens/synchronizes the PR. `user.login` can't be spoofed.
     # The `github.actor` guard skips the follow-up `synchronize` event this
-    # workflow's own dedupe push creates (where the author is still
+    # workflow's own lockfile push creates (where the author is still
     # `dependabot[bot]` but the actor is `github-actions[bot]`), avoiding a
     # redundant rerun. On `opened` the actor is `dependabot[bot]`, so it runs.
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
     # Dependabot-triggered `pull_request` runs default to a read-only token but
     # respect this `permissions:` key (GitHub change, 2021-10-06). Scoped to the
-    # job so non-matching PRs never see an elevated token.
+    # job so non-matching PRs never see an elevated token. `contents: write` is
+    # for pushing the rewritten lockfile.
     permissions:
       contents: write
     steps:
+      - name: Read Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
       - name: Check out Dependabot branch
+        # Only a single-dependency bump can be re-applied as one `pnpm update`.
+        # Grouped/multi-dependency PRs are skipped (security advisories are
+        # single-dependency, so this covers the case that matters).
+        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up pnpm
+        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - name: Set up Node
+        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: 'package.json'
           cache: 'pnpm'
-      # --ignore-scripts: don't run the bumped dependency's lifecycle scripts
-      # just to rewrite the lockfile.
-      - name: Run dedupe
-        run: pnpm dedupe --ignore-scripts
+      - name: Rebuild lockfile from master with only the advisory bump
+        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
+        # Pass metadata via env to keep it out of the shell (injection-safe).
+        env:
+          DEP_NAME: ${{ steps.meta.outputs.dependency-names }}
+          NEW_VERSION: ${{ steps.meta.outputs.new-version }}
+        run: |
+          # Discard Dependabot's whole-tree resolution by restoring master's
+          # lockfile, then re-apply just the targeted bump on top of it.
+          git fetch --no-tags --depth=1 origin master
+          git checkout FETCH_HEAD -- pnpm-lock.yaml
+          # Pin the exact version Dependabot chose so we don't overshoot to a
+          # newer (possibly too-fresh) release. --depth Infinity so transitive
+          # deps are updated too. --lockfile-only: we only need the lockfile.
+          pnpm update "$DEP_NAME@$NEW_VERSION" --depth Infinity --lockfile-only
+          pnpm dedupe --lockfile-only
       - name: Commit & push if the lockfile changed
-        # Pass the head ref via env to keep it out of the shell (injection-safe).
+        if: ${{ steps.meta.outputs.new-version != '' && !contains(steps.meta.outputs.dependency-names, ',') }}
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
@@ -58,5 +92,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml
-          git commit -m "Run pnpm dedupe"
+          git commit -m "Rebuild lockfile honoring minimumReleaseAge"
           git push origin "HEAD:$HEAD_REF"

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -8,9 +8,10 @@ name: Dedupe Dependabot PRs
 # the branch with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`.
 #
 # Plain `pnpm dedupe` can't fix this: pnpm refuses the too-fresh versions and
-# won't downgrade them. Instead this workflow rebuilds the lockfile from master
-# and re-applies only the bumps the PR actually intends:
-#   1. reset `pnpm-lock.yaml` to master (a policy-compliant, mature baseline),
+# won't downgrade them. Instead this workflow rebuilds the lockfile from the
+# PR's base branch and re-applies only the bumps the PR actually intends:
+#   1. reset `pnpm-lock.yaml` to the base branch (a policy-compliant, mature
+#      baseline),
 #   2. `pnpm update <dep>@<new-version> …` (one spec per bumped dependency,
 #      read from Dependabot's metadata) to apply just the targeted bumps,
 #   3. `pnpm dedupe` so the result passes the gate,
@@ -67,6 +68,9 @@ jobs:
         # Pass metadata via env to keep it out of the shell (injection-safe).
         env:
           UPDATED_DEPENDENCIES: ${{ steps.meta.outputs.updated-dependencies-json }}
+          # The branch the PR targets (not hardcoded master) so this still works
+          # if Dependabot is ever pointed at another branch via `target-branch`.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           # Build a "<name>@<version>" spec for every dependency the PR bumps.
           # `pnpm update` accepts multiple specs, so grouped PRs work too. Pin
@@ -79,9 +83,9 @@ jobs:
             exit 0
           fi
           echo "Re-applying: ${specs[*]}"
-          # Discard Dependabot's whole-tree resolution by restoring master's
-          # lockfile, then re-apply just the targeted bumps on top of it.
-          git fetch --no-tags --depth=1 origin master
+          # Discard Dependabot's whole-tree resolution by restoring the base
+          # branch's lockfile, then re-apply just the targeted bumps on top of it.
+          git fetch --no-tags --depth=1 origin "$BASE_REF"
           git checkout FETCH_HEAD -- pnpm-lock.yaml
           # --depth Infinity so transitive deps are updated too.
           # --lockfile-only: we only need the lockfile.
@@ -92,9 +96,9 @@ jobs:
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          # The rebuild step stages master's lockfile into the index, so compare
-          # the final result against the branch tip (HEAD) — not the index — to
-          # decide whether anything actually changed.
+          # The rebuild step stages the base branch's lockfile into the index, so
+          # compare the final result against the PR branch tip (HEAD) — not the
+          # index — to decide whether anything actually changed.
           git add pnpm-lock.yaml
           if git diff --cached --quiet HEAD -- pnpm-lock.yaml; then
             echo "No lockfile changes"

--- a/packages/code-infra/src/cli/cmdReleaseAgeExclude.mjs
+++ b/packages/code-infra/src/cli/cmdReleaseAgeExclude.mjs
@@ -39,7 +39,9 @@ async function getPublishTimes(packageName) {
  * and CI's `pnpm dedupe --check` reject. The only pnpm-native escape is a
  * `minimumReleaseAgeExclude` entry; scoping it to the exact `name@version` keeps
  * every other version of that package under the age gate. Such entries become
- * redundant once the version matures, so `--prune` cleans them up.
+ * redundant once the version matures, so `--prune` cleans them up — but only the
+ * ones this command added (tagged with a marker comment), never a hand-added
+ * exemption.
  *
  * Only the `spec`s passed in are ever exempted — i.e. the packages Dependabot is
  * deliberately bumping (from its `updated-dependencies` metadata). Collateral

--- a/packages/code-infra/src/cli/cmdReleaseAgeExclude.mjs
+++ b/packages/code-infra/src/cli/cmdReleaseAgeExclude.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+import { $ } from 'execa';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { parseDocument } from 'yaml';
+import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
+import {
+  readMinimumReleaseAge,
+  isVersionTooFresh,
+  parseReleaseAgeExclusion,
+  getReleaseAgeExclude,
+  addReleaseAgeExclusions,
+  pruneReleaseAgeExclusions,
+} from '../utils/pnpm.mjs';
+
+/**
+ * @typedef {Object} Args
+ * @property {string[]} [spec] - `name@version` specifiers to exempt if too fresh
+ * @property {boolean} [prune] - Also remove matured versioned exemptions
+ * @property {boolean} [check] - Write nothing; exit non-zero if a change is needed
+ */
+
+/**
+ * Fetch the registry's `version -> publish time` map for a package.
+ * @param {string} packageName
+ * @returns {Promise<Record<string, string>>}
+ */
+async function getPublishTimes(packageName) {
+  const result = await $`pnpm view ${packageName} time --json`;
+  return JSON.parse(result.stdout);
+}
+
+/**
+ * Dependabot ignores pnpm's `minimumReleaseAge`, so a security PR can pin a
+ * patch that is still too fresh for the policy — which both `pnpm update` here
+ * and CI's `pnpm dedupe --check` reject. The only pnpm-native escape is a
+ * `minimumReleaseAgeExclude` entry; scoping it to the exact `name@version` keeps
+ * every other version of that package under the age gate. Such entries become
+ * redundant once the version matures, so `--prune` cleans them up.
+ *
+ * Only the `spec`s passed in are ever exempted — i.e. the packages Dependabot is
+ * deliberately bumping (from its `updated-dependencies` metadata). Collateral
+ * deps Dependabot floats as a side effect are *not* passed here; the calling
+ * workflow drops them by rebuilding the lockfile from the base branch.
+ *
+ * Limitation: a version-scoped exemption covers only the named version. If a
+ * fresh target also requires freshly-published *dependencies* (e.g. a monorepo
+ * publishing siblings in lockstep), pnpm rejects those too (pnpm/pnpm#11068) and
+ * the run fails loudly — a maintainer then waits or extends the exclude. This
+ * matches the state of the art: Renovate respects pnpm's `minimumReleaseAge` and
+ * hits the same wall (renovatebot/renovate#39168, #38766).
+ *
+ * @param {Args} args
+ * @returns {Promise<void>}
+ */
+async function handler(args) {
+  const specs = (args.spec ?? []).map(String);
+
+  const workspaceDir = (await findWorkspaceDir(process.cwd())) ?? process.cwd();
+  const workspaceYamlPath = path.join(workspaceDir, 'pnpm-workspace.yaml');
+  const doc = parseDocument(await fs.readFile(workspaceYamlPath, 'utf8'));
+
+  const minAgeMinutes = readMinimumReleaseAge(doc);
+  if (minAgeMinutes === null) {
+    console.log('No minimumReleaseAge configured; nothing to do.');
+    return;
+  }
+  const now = Date.now();
+
+  // Add a versioned exemption for any target whose pinned version is too fresh.
+  const tooFresh = [];
+  for (const spec of specs) {
+    const { name, versions } = parseReleaseAgeExclusion(spec);
+    if (versions.length !== 1) {
+      throw new Error(`Expected a "name@version" spec, received: ${spec}`);
+    }
+    const [version] = versions;
+    // eslint-disable-next-line no-await-in-loop -- registry lookups are cheap and serial keeps logs readable
+    const times = await getPublishTimes(name);
+    if (isVersionTooFresh(times[version], now, minAgeMinutes)) {
+      tooFresh.push(`${name}@${version}`);
+    }
+  }
+  const added = addReleaseAgeExclusions(doc, tooFresh);
+
+  // Optionally drop exemptions whose versions have all matured.
+  /** @type {string[]} */
+  let removed = [];
+  if (args.prune) {
+    const uniqueNames = [
+      ...new Set(
+        getReleaseAgeExclude(doc)
+          .map(parseReleaseAgeExclusion)
+          .filter((entry) => entry.versions.length > 0)
+          .map((entry) => entry.name),
+      ),
+    ];
+    /** @type {Map<string, Record<string, string>>} */
+    const timesByName = new Map();
+    await Promise.all(
+      uniqueNames.map(async (name) => {
+        timesByName.set(name, await getPublishTimes(name));
+      }),
+    );
+    removed = pruneReleaseAgeExclusions(doc, (name, versions) => {
+      const times = timesByName.get(name) ?? {};
+      return versions.every(
+        (version) =>
+          Boolean(times[version]) && !isVersionTooFresh(times[version], now, minAgeMinutes),
+      );
+    });
+  }
+
+  if (added.length === 0 && removed.length === 0) {
+    console.log('minimumReleaseAgeExclude already up to date.');
+    return;
+  }
+
+  if (args.check) {
+    if (added.length > 0) {
+      console.error(`Would add to minimumReleaseAgeExclude: ${added.join(', ')}`);
+    }
+    if (removed.length > 0) {
+      console.error(`Would remove from minimumReleaseAgeExclude: ${removed.join(', ')}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  await fs.writeFile(workspaceYamlPath, doc.toString());
+  if (added.length > 0) {
+    console.log(`Added to minimumReleaseAgeExclude: ${added.join(', ')}`);
+  }
+  if (removed.length > 0) {
+    console.log(`Removed from minimumReleaseAgeExclude: ${removed.join(', ')}`);
+  }
+}
+
+export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
+  command: 'release-age-exclude [spec...]',
+  describe:
+    "Exempt too-fresh security bumps from pnpm's minimumReleaseAge by adding versioned minimumReleaseAgeExclude entries (and optionally pruning matured ones)",
+  builder: (yargs) => {
+    return yargs
+      .positional('spec', {
+        type: 'string',
+        array: true,
+        describe: '"name@version" specifiers to exempt when younger than minimumReleaseAge',
+      })
+      .option('prune', {
+        type: 'boolean',
+        default: false,
+        describe: 'Remove versioned exemptions whose versions have all matured',
+      })
+      .option('check', {
+        type: 'boolean',
+        default: false,
+        describe: 'Write nothing; exit non-zero if any entry would be added or removed',
+      });
+  },
+  handler,
+});

--- a/packages/code-infra/src/cli/index.mjs
+++ b/packages/code-infra/src/cli/index.mjs
@@ -14,6 +14,7 @@ import cmdNetlifyIgnore from './cmdNetlifyIgnore.mjs';
 import cmdPublish from './cmdPublish.mjs';
 import cmdPublishCanary from './cmdPublishCanary.mjs';
 import cmdPublishNewPackage from './cmdPublishNewPackage.mjs';
+import cmdReleaseAgeExclude from './cmdReleaseAgeExclude.mjs';
 import cmdSetVersionOverrides from './cmdSetVersionOverrides.mjs';
 import cmdVale from './cmdVale.mjs';
 import cmdValidateBuiltTypes from './cmdValidateBuiltTypes.mjs';
@@ -47,6 +48,7 @@ await yargs(hideBin(process.argv))
   .command(cmdPublish)
   .command(cmdPublishCanary)
   .command(cmdPublishNewPackage)
+  .command(cmdReleaseAgeExclude)
   .command(cmdSetVersionOverrides)
   .command(cmdVale)
   .command(cmdValidateBuiltTypes)

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -5,7 +5,7 @@ import { $ } from 'execa';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as semver from 'semver';
-import { parseDocument, isMap, isSeq, YAMLSeq } from 'yaml';
+import { parseDocument, isMap, isSeq, isScalar, YAMLSeq, Scalar } from 'yaml';
 
 /**
  * @typedef {Object} PrivatePackage
@@ -543,6 +543,14 @@ export function isVersionTooFresh(publishedAtIso, nowMs, minAgeMinutes) {
   return ageMinutes < minAgeMinutes;
 }
 
+// Token embedded in the trailing comment of every exemption this automation
+// adds, so pruning can recognise its own entries and never remove a versioned
+// exemption a human added by hand.
+export const RELEASE_AGE_EXCLUDE_MARKER = 'release-age-exclude';
+
+// The full end-of-line comment written next to an auto-added exemption.
+const RELEASE_AGE_EXCLUDE_COMMENT = ` auto-added by code-infra ${RELEASE_AGE_EXCLUDE_MARKER}; pruned once matured`;
+
 /**
  * Read the `minimumReleaseAgeExclude` list from a parsed document.
  *
@@ -559,7 +567,9 @@ export function getReleaseAgeExclude(doc) {
 
 /**
  * Append versioned exclusions to `minimumReleaseAgeExclude`, creating the list
- * if needed and skipping entries that are already present. Mutates `doc`.
+ * if needed and skipping entries that are already present. Each added entry gets
+ * a trailing marker comment so `pruneReleaseAgeExclusions` only ever removes
+ * entries this automation owns. Mutates `doc`.
  *
  * @param {import('yaml').Document} doc
  * @param {string[]} specs - `name@version` entries to add
@@ -579,7 +589,9 @@ export function addReleaseAgeExclusions(doc, specs) {
   const added = [];
   for (const spec of specs) {
     if (!existing.has(spec)) {
-      node.add(spec);
+      const item = new Scalar(spec);
+      item.comment = RELEASE_AGE_EXCLUDE_COMMENT;
+      node.add(item);
       existing.add(spec);
       added.push(spec);
     }
@@ -588,10 +600,12 @@ export function addReleaseAgeExclusions(doc, specs) {
 }
 
 /**
- * Remove versioned `minimumReleaseAgeExclude` entries for which `isMatured`
- * returns true. Bare names/globs (entries with no explicit version) are never
- * removed. Mutates `doc`. Removing a matured entry is behavior-neutral — the
- * version already clears the age gate on its own.
+ * Remove matured versioned `minimumReleaseAgeExclude` entries that this
+ * automation added (identified by their trailing marker comment). Entries
+ * without the marker — bare globs like `@mui/internal-*`, or versioned
+ * exemptions a human added by hand — are never touched, even if matured.
+ * Mutates `doc`. Removing a matured entry is behavior-neutral: the version
+ * already clears the age gate on its own.
  *
  * @param {import('yaml').Document} doc
  * @param {(name: string, versions: string[]) => boolean} isMatured
@@ -602,18 +616,23 @@ export function pruneReleaseAgeExclusions(doc, isMatured) {
   if (!isSeq(node)) {
     return [];
   }
-  const entries = /** @type {unknown[]} */ (node.toJSON()).map((entry) => String(entry));
   /** @type {string[]} */
   const removed = [];
-  /** @type {Set<number>} */
-  const removeIndexes = new Set();
-  entries.forEach((entry, index) => {
+  node.items = node.items.filter((item) => {
+    if (
+      !isScalar(item) ||
+      typeof item.comment !== 'string' ||
+      !item.comment.includes(RELEASE_AGE_EXCLUDE_MARKER)
+    ) {
+      return true;
+    }
+    const entry = String(item.value);
     const { name, versions } = parseReleaseAgeExclusion(entry);
     if (versions.length > 0 && isMatured(name, versions)) {
       removed.push(entry);
-      removeIndexes.add(index);
+      return false;
     }
+    return true;
   });
-  node.items = node.items.filter((_item, index) => !removeIndexes.has(index));
   return removed;
 }

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -5,7 +5,7 @@ import { $ } from 'execa';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as semver from 'semver';
-import { parseDocument, isMap } from 'yaml';
+import { parseDocument, isMap, isSeq, YAMLSeq } from 'yaml';
 
 /**
  * @typedef {Object} PrivatePackage
@@ -479,4 +479,141 @@ export async function findDependencyVersionFromSpec(packageSpec, dependency) {
  */
 export function semverMax(a, b) {
   return semver.gt(a, b) ? a : b;
+}
+
+/**
+ * @typedef {Object} ReleaseAgeExclusion
+ * @property {string} name - Package name (or glob, e.g. `@mui/internal-*`)
+ * @property {string[]} versions - Explicit versions the entry pins, in order;
+ *   empty when the entry is a bare name/glob with no `@version`.
+ */
+
+/**
+ * Parse a `minimumReleaseAgeExclude` entry into its package name and explicit
+ * versions. pnpm allows bare names/globs (`@mui/internal-*`), a single pinned
+ * version (`vite@8.0.16`), or a `||`-joined disjunction (`webpack@4.4.0 || 5.1.0`).
+ *
+ * @param {string} entry
+ * @returns {ReleaseAgeExclusion}
+ */
+export function parseReleaseAgeExclusion(entry) {
+  const trimmed = entry.trim();
+  // For scoped names the leading `@` is part of the name, so start the search
+  // for the name/version separator after it.
+  const separatorIndex = trimmed.indexOf('@', trimmed.startsWith('@') ? 1 : 0);
+  if (separatorIndex === -1) {
+    return { name: trimmed, versions: [] };
+  }
+  const name = trimmed.slice(0, separatorIndex);
+  const versions = trimmed
+    .slice(separatorIndex + 1)
+    .split('||')
+    .map((version) => version.trim())
+    .filter(Boolean);
+  return { name, versions };
+}
+
+/**
+ * Read the `minimumReleaseAge` policy (in minutes) from a parsed
+ * pnpm-workspace.yaml document.
+ *
+ * @param {import('yaml').Document} doc
+ * @returns {number | null} The configured value, or null when unset.
+ */
+export function readMinimumReleaseAge(doc) {
+  const value = doc.get('minimumReleaseAge');
+  return typeof value === 'number' ? value : null;
+}
+
+/**
+ * Whether a published version is younger than the minimum release age. A missing
+ * or unparseable publish time is treated as *not* too fresh (mature), so callers
+ * never block or prune on incomplete data.
+ *
+ * @param {string | undefined} publishedAtIso - ISO timestamp from the registry
+ * @param {number} nowMs - Current time in ms (e.g. `Date.now()`)
+ * @param {number} minAgeMinutes - The `minimumReleaseAge` policy, in minutes
+ * @returns {boolean}
+ */
+export function isVersionTooFresh(publishedAtIso, nowMs, minAgeMinutes) {
+  if (!publishedAtIso) {
+    return false;
+  }
+  const ageMinutes = (nowMs - Date.parse(publishedAtIso)) / 60_000;
+  return ageMinutes < minAgeMinutes;
+}
+
+/**
+ * Read the `minimumReleaseAgeExclude` list from a parsed document.
+ *
+ * @param {import('yaml').Document} doc
+ * @returns {string[]}
+ */
+export function getReleaseAgeExclude(doc) {
+  const node = doc.get('minimumReleaseAgeExclude');
+  if (!isSeq(node)) {
+    return [];
+  }
+  return /** @type {unknown[]} */ (node.toJSON()).map((entry) => String(entry));
+}
+
+/**
+ * Append versioned exclusions to `minimumReleaseAgeExclude`, creating the list
+ * if needed and skipping entries that are already present. Mutates `doc`.
+ *
+ * @param {import('yaml').Document} doc
+ * @param {string[]} specs - `name@version` entries to add
+ * @returns {string[]} The entries actually added.
+ */
+export function addReleaseAgeExclusions(doc, specs) {
+  if (specs.length === 0) {
+    return [];
+  }
+  const current = doc.get('minimumReleaseAgeExclude');
+  const node = isSeq(current) ? current : new YAMLSeq();
+  if (node !== current) {
+    doc.set('minimumReleaseAgeExclude', node);
+  }
+  const existing = new Set(getReleaseAgeExclude(doc));
+  /** @type {string[]} */
+  const added = [];
+  for (const spec of specs) {
+    if (!existing.has(spec)) {
+      node.add(spec);
+      existing.add(spec);
+      added.push(spec);
+    }
+  }
+  return added;
+}
+
+/**
+ * Remove versioned `minimumReleaseAgeExclude` entries for which `isMatured`
+ * returns true. Bare names/globs (entries with no explicit version) are never
+ * removed. Mutates `doc`. Removing a matured entry is behavior-neutral — the
+ * version already clears the age gate on its own.
+ *
+ * @param {import('yaml').Document} doc
+ * @param {(name: string, versions: string[]) => boolean} isMatured
+ * @returns {string[]} The entries actually removed.
+ */
+export function pruneReleaseAgeExclusions(doc, isMatured) {
+  const node = doc.get('minimumReleaseAgeExclude');
+  if (!isSeq(node)) {
+    return [];
+  }
+  const entries = /** @type {unknown[]} */ (node.toJSON()).map((entry) => String(entry));
+  /** @type {string[]} */
+  const removed = [];
+  /** @type {Set<number>} */
+  const removeIndexes = new Set();
+  entries.forEach((entry, index) => {
+    const { name, versions } = parseReleaseAgeExclusion(entry);
+    if (versions.length > 0 && isMatured(name, versions)) {
+      removed.push(entry);
+      removeIndexes.add(index);
+    }
+  });
+  node.items = node.items.filter((_item, index) => !removeIndexes.has(index));
+  return removed;
 }

--- a/packages/code-infra/src/utils/pnpm.test.mjs
+++ b/packages/code-infra/src/utils/pnpm.test.mjs
@@ -2,12 +2,19 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { describe, it, expect } from 'vitest';
 
+import { parseDocument } from 'yaml';
 import { makeTempDir } from './testUtils.mjs';
 import {
   checkPublishDependencies,
   readPackageJson,
   writePackageJson,
   writeOverridesToWorkspace,
+  parseReleaseAgeExclusion,
+  readMinimumReleaseAge,
+  isVersionTooFresh,
+  getReleaseAgeExclude,
+  addReleaseAgeExclusions,
+  pruneReleaseAgeExclusions,
 } from './pnpm.mjs';
 
 /**
@@ -727,5 +734,135 @@ describe('writeOverridesToWorkspace', () => {
 
       expect(await readWorkspaceYaml(cwd)).toContain('foo: 1.2.3');
     });
+  });
+});
+
+describe('parseReleaseAgeExclusion', () => {
+  it('splits a plain name@version', () => {
+    expect(parseReleaseAgeExclusion('vite@8.0.16')).toEqual({ name: 'vite', versions: ['8.0.16'] });
+  });
+
+  it('keeps the leading @ of a scoped name as part of the name', () => {
+    expect(parseReleaseAgeExclusion('@babel/core@7.29.6')).toEqual({
+      name: '@babel/core',
+      versions: ['7.29.6'],
+    });
+  });
+
+  it('parses a || disjunction into multiple versions', () => {
+    expect(parseReleaseAgeExclusion('webpack@4.47.0 || 5.102.1')).toEqual({
+      name: 'webpack',
+      versions: ['4.47.0', '5.102.1'],
+    });
+  });
+
+  it('treats a bare glob as having no versions', () => {
+    expect(parseReleaseAgeExclusion('@mui/internal-*')).toEqual({
+      name: '@mui/internal-*',
+      versions: [],
+    });
+  });
+});
+
+describe('readMinimumReleaseAge', () => {
+  it('reads a numeric value', () => {
+    expect(readMinimumReleaseAge(parseDocument('minimumReleaseAge: 4320\n'))).toBe(4320);
+  });
+
+  it('returns null when unset', () => {
+    expect(readMinimumReleaseAge(parseDocument('packages:\n  - a\n'))).toBeNull();
+  });
+});
+
+describe('isVersionTooFresh', () => {
+  const now = Date.parse('2026-06-17T00:00:00.000Z');
+  const minAge = 4320; // 3 days in minutes
+
+  it('is true for a version published within the window', () => {
+    expect(isVersionTooFresh('2026-06-15T00:00:00.000Z', now, minAge)).toBe(true);
+  });
+
+  it('is false for a version older than the window', () => {
+    expect(isVersionTooFresh('2026-06-01T00:00:00.000Z', now, minAge)).toBe(false);
+  });
+
+  it('is false exactly at the boundary', () => {
+    // 3 days = 4320 minutes before now
+    expect(isVersionTooFresh('2026-06-14T00:00:00.000Z', now, minAge)).toBe(false);
+  });
+
+  it('treats a missing publish time as mature', () => {
+    expect(isVersionTooFresh(undefined, now, minAge)).toBe(false);
+  });
+});
+
+describe('addReleaseAgeExclusions', () => {
+  it('appends new versioned entries to an existing list', () => {
+    const doc = parseDocument("minimumReleaseAgeExclude:\n  - '@mui/internal-*'\n");
+    const added = addReleaseAgeExclusions(doc, ['vite@8.0.16']);
+
+    expect(added).toEqual(['vite@8.0.16']);
+    expect(getReleaseAgeExclude(doc)).toEqual(['@mui/internal-*', 'vite@8.0.16']);
+  });
+
+  it('creates the list when it does not exist', () => {
+    const doc = parseDocument('minimumReleaseAge: 4320\n');
+    addReleaseAgeExclusions(doc, ['vite@8.0.16']);
+
+    expect(getReleaseAgeExclude(doc)).toEqual(['vite@8.0.16']);
+  });
+
+  it('skips entries already present and reports only what changed', () => {
+    const doc = parseDocument("minimumReleaseAgeExclude:\n  - 'vite@8.0.16'\n");
+    const added = addReleaseAgeExclusions(doc, ['vite@8.0.16', '@babel/core@7.29.6']);
+
+    expect(added).toEqual(['@babel/core@7.29.6']);
+    expect(getReleaseAgeExclude(doc)).toEqual(['vite@8.0.16', '@babel/core@7.29.6']);
+  });
+
+  it('is a no-op for an empty spec list', () => {
+    const doc = parseDocument("minimumReleaseAgeExclude:\n  - 'vite@8.0.16'\n");
+    expect(addReleaseAgeExclusions(doc, [])).toEqual([]);
+    expect(getReleaseAgeExclude(doc)).toEqual(['vite@8.0.16']);
+  });
+});
+
+describe('pruneReleaseAgeExclusions', () => {
+  it('removes matured versioned entries and keeps fresh ones', () => {
+    const doc = parseDocument(
+      ['minimumReleaseAgeExclude:', "  - 'vite@8.0.16'", "  - '@babel/core@7.29.6'", ''].join('\n'),
+    );
+    const removed = pruneReleaseAgeExclusions(doc, (_name, versions) =>
+      versions.includes('8.0.16'),
+    );
+
+    expect(removed).toEqual(['vite@8.0.16']);
+    expect(getReleaseAgeExclude(doc)).toEqual(['@babel/core@7.29.6']);
+  });
+
+  it('never removes bare-name/glob entries', () => {
+    const doc = parseDocument(
+      ['minimumReleaseAgeExclude:', "  - '@mui/internal-*'", "  - 'vite@8.0.16'", ''].join('\n'),
+    );
+    // Predicate returns true for everything; the glob must still survive.
+    const removed = pruneReleaseAgeExclusions(doc, () => true);
+
+    expect(removed).toEqual(['vite@8.0.16']);
+    expect(getReleaseAgeExclude(doc)).toEqual(['@mui/internal-*']);
+  });
+
+  it('only removes when every version in a disjunction has matured', () => {
+    const doc = parseDocument("minimumReleaseAgeExclude:\n  - 'webpack@4.47.0 || 5.102.1'\n");
+    const removed = pruneReleaseAgeExclusions(doc, (_name, versions) =>
+      versions.every((version) => version === '4.47.0'),
+    );
+
+    expect(removed).toEqual([]);
+    expect(getReleaseAgeExclude(doc)).toEqual(['webpack@4.47.0 || 5.102.1']);
+  });
+
+  it('is a no-op when there is no exclusion list', () => {
+    const doc = parseDocument('minimumReleaseAge: 4320\n');
+    expect(pruneReleaseAgeExclusions(doc, () => true)).toEqual([]);
   });
 });

--- a/packages/code-infra/src/utils/pnpm.test.mjs
+++ b/packages/code-infra/src/utils/pnpm.test.mjs
@@ -15,6 +15,7 @@ import {
   getReleaseAgeExclude,
   addReleaseAgeExclusions,
   pruneReleaseAgeExclusions,
+  RELEASE_AGE_EXCLUDE_MARKER,
 } from './pnpm.mjs';
 
 /**
@@ -825,13 +826,25 @@ describe('addReleaseAgeExclusions', () => {
     expect(addReleaseAgeExclusions(doc, [])).toEqual([]);
     expect(getReleaseAgeExclude(doc)).toEqual(['vite@8.0.16']);
   });
+
+  it('marks each added entry with an end-of-line marker comment', () => {
+    const doc = parseDocument('minimumReleaseAge: 4320\n');
+    addReleaseAgeExclusions(doc, ['vite@8.0.16']);
+
+    const serialized = doc.toString();
+    expect(serialized).toContain('vite@8.0.16');
+    // The marker is on the same line as the entry it owns.
+    const line = serialized.split('\n').find((text) => text.includes('vite@8.0.16'));
+    expect(line).toContain(`# `);
+    expect(line).toContain(RELEASE_AGE_EXCLUDE_MARKER);
+  });
 });
 
 describe('pruneReleaseAgeExclusions', () => {
-  it('removes matured versioned entries and keeps fresh ones', () => {
-    const doc = parseDocument(
-      ['minimumReleaseAgeExclude:', "  - 'vite@8.0.16'", "  - '@babel/core@7.29.6'", ''].join('\n'),
-    );
+  it('removes matured marked entries and keeps fresh ones', () => {
+    const doc = parseDocument('minimumReleaseAge: 4320\n');
+    addReleaseAgeExclusions(doc, ['vite@8.0.16', '@babel/core@7.29.6']);
+
     const removed = pruneReleaseAgeExclusions(doc, (_name, versions) =>
       versions.includes('8.0.16'),
     );
@@ -841,18 +854,30 @@ describe('pruneReleaseAgeExclusions', () => {
   });
 
   it('never removes bare-name/glob entries', () => {
-    const doc = parseDocument(
-      ['minimumReleaseAgeExclude:', "  - '@mui/internal-*'", "  - 'vite@8.0.16'", ''].join('\n'),
-    );
-    // Predicate returns true for everything; the glob must still survive.
+    const doc = parseDocument("minimumReleaseAgeExclude:\n  - '@mui/internal-*'\n");
+    addReleaseAgeExclusions(doc, ['vite@8.0.16']);
+
+    // Predicate returns true for everything; the unmarked glob must still survive.
     const removed = pruneReleaseAgeExclusions(doc, () => true);
 
     expect(removed).toEqual(['vite@8.0.16']);
     expect(getReleaseAgeExclude(doc)).toEqual(['@mui/internal-*']);
   });
 
+  it('never removes a versioned entry that lacks the marker (added by hand)', () => {
+    // No trailing marker comment — a human added this one.
+    const doc = parseDocument("minimumReleaseAgeExclude:\n  - 'vite@8.0.16'\n");
+
+    const removed = pruneReleaseAgeExclusions(doc, () => true);
+
+    expect(removed).toEqual([]);
+    expect(getReleaseAgeExclude(doc)).toEqual(['vite@8.0.16']);
+  });
+
   it('only removes when every version in a disjunction has matured', () => {
-    const doc = parseDocument("minimumReleaseAgeExclude:\n  - 'webpack@4.47.0 || 5.102.1'\n");
+    const doc = parseDocument('minimumReleaseAge: 4320\n');
+    addReleaseAgeExclusions(doc, ['webpack@4.47.0 || 5.102.1']);
+
     const removed = pruneReleaseAgeExclusions(doc, (_name, versions) =>
       versions.every((version) => version === '4.47.0'),
     );


### PR DESCRIPTION
## Problem

Dependabot security PRs fail `ci/circleci: test_static`, and the original auto-dedupe workflow (#1550) doesn't fix it. The cause isn't the bumped package — it's that Dependabot regenerates the *entire* `pnpm-lock.yaml`, resolving every package to its newest in-range version while ignoring this repo's `minimumReleaseAge` policy. That floats unrelated transitive deps (e.g. `@vitest/utils` 4.1.8 → a 2-day-old 4.1.9), and the orb's `pnpm dedupe --check` gate — which *does* honor `minimumReleaseAge` — rejects the branch with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`. Plain `pnpm dedupe` can't fix it: pnpm refuses the too-fresh version and won't downgrade it.

## Fix

Rebuild the lockfile from the PR's base branch and re-apply only the bumps the PR actually intends:

1. reset `pnpm-lock.yaml` to the base branch (`pull_request.base.ref`) — a policy-compliant, mature baseline
2. `pnpm update <dep>@<new-version> …` for each bumped dependency (read from `dependabot/fetch-metadata`), pinned to the exact version Dependabot chose. Multiple specs are applied in one `pnpm update`, so **grouped/multi-dependency PRs are handled**
3. `pnpm dedupe` so the result passes the gate
4. push the rewritten lockfile back to the branch

This mirrors Renovate, which honors `minimumReleaseAge` during resolution and so never floats collateral deps to fresh versions. Collateral floats are discarded by the reset; only the intended targets are re-applied.

### Too-fresh security targets

If a *targeted* patch is itself younger than `minimumReleaseAge`, even the targeted update can't resolve it (and CI would reject it too). A new `code-infra release-age-exclude` command adds a **version-scoped** `minimumReleaseAgeExclude` entry for exactly that `name@version`, so only the deliberately-adopted version bypasses the gate — every other version stays under it. Each auto-added entry carries a marker comment; `--prune` removes those (and only those) once their version matures. This is the approach Renovate itself has only *proposed* (renovatebot/renovate#39168, #38766) — it currently hits the same wall.

Known limitation: a version-scoped exemption covers only the named version. If a fresh target also pulls in freshly-published *dependencies* (pnpm/pnpm#11068), the run fails loudly and a maintainer waits or extends the exclude — no worse than Renovate.

## Tests

`@mui/internal-code-infra` unit tests cover the freshness boundary, exclusion add/dedupe/marker, and marker-scoped prune (globs and hand-added entries are never removed).