### PR TITLE
[docs-infra] Set relative tsconfig path for next.js config

### DIFF
--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -261,6 +261,7 @@ export function withDeploymentConfig<T extends NextConfig>(nextConfig: T): T {
     typescript: {
       // Motivated by https://github.com/vercel/next.js/issues/7687
       ignoreBuildErrors: true,
+      tsconfigPath: './tsconfig.json',
       ...nextConfig.typescript,
     },
   };


### PR DESCRIPTION
All our docs are already in this format where tsconfig.json lives next to the next.config file.