### PR TITLE
[code-infra] Update pnpm canary filtering

### DIFF
--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -84,9 +84,7 @@ export async function getWorkspacePackages(options = {}) {
    * @returns {Promise<PnpmListResultItem[]>}
    */
   const listPackages = async (filterArg) => {
-    const result = options.cwd
-      ? await $({ cwd: options.cwd })`pnpm ls -r --json --depth -1 ${filterArg}`
-      : await $`pnpm ls -r --json --depth -1 ${filterArg}`;
+    const result = await $({ cwd: options.cwd })`pnpm ls -r --json --depth -1 ${filterArg}`;
     return JSON.parse(result.stdout);
   };
 

--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -78,18 +78,35 @@ import { parseDocument, isMap } from 'yaml';
 export async function getWorkspacePackages(options = {}) {
   const { sinceRef = null, publicOnly = false, nonPublishedOnly = false, filter = [] } = options;
 
-  // Build command with conditional filter
-  const filterArg = sinceRef ? ['--filter', `...[${sinceRef}]`] : [];
-  if (filter.length > 0) {
-    filter.forEach((f) => {
-      filterArg.push('--filter', f);
-    });
+  /**
+   * Run `pnpm ls` with the given --filter args and return the parsed list.
+   * @param {string[]} filterArg
+   * @returns {Promise<PnpmListResultItem[]>}
+   */
+  const listPackages = async (filterArg) => {
+    const result = options.cwd
+      ? await $({ cwd: options.cwd })`pnpm ls -r --json --depth -1 ${filterArg}`
+      : await $`pnpm ls -r --json --depth -1 ${filterArg}`;
+    return JSON.parse(result.stdout);
+  };
+
+  // pnpm ORs --filter args, so intersect "matches filter" with "changed since ref"
+  // in JS. The `[ref]` selector (no `...`) excludes dependents of changed packages.
+  const patternFilterArg = filter.flatMap((f) => ['--filter', f]);
+  const [candidatePackages, changedPackages] = await Promise.all([
+    listPackages(patternFilterArg),
+    // null when no sinceRef (skip the constraint); [] when nothing changed.
+    sinceRef ? listPackages(['--filter', `[${sinceRef}]`]) : Promise.resolve(null),
+  ]);
+  let packageData = candidatePackages;
+  if (changedPackages) {
+    // sinceRef given but nothing changed → no packages, regardless of filter.
+    if (changedPackages.length === 0) {
+      return [];
+    }
+    const changedPaths = new Set(changedPackages.map((pkg) => pkg.path));
+    packageData = packageData.filter((pkg) => changedPaths.has(pkg.path));
   }
-  const result = options.cwd
-    ? await $({ cwd: options.cwd })`pnpm ls -r --json --depth -1 ${filterArg}`
-    : await $`pnpm ls -r --json --depth -1 ${filterArg}`;
-  /** @type {PnpmListResultItem[]} */
-  const packageData = JSON.parse(result.stdout);
 
   // Filter packages based on options
   const filteredPackages = packageData.flatMap((pkg) => {


### PR DESCRIPTION
pnpm's filter arg "OR"s the packages if there are multiple arguments provided. When we run canary publishing on core repo, the final filters are `--filter "...[canary]" --filter="./packages-internal/*"` which means all packages that have changed or all packages in packages-internal directory. But we want to the AND case of all internal packages that have changed since the last canary.
This also fails to push the canary tag back to the repo since it detected total 20 packages but only 5 were published.

Failing example run - https://github.com/mui/material-ui/actions/runs/27762619406/job/82140766405

So updated the code to do the extra filtering.