### PR TITLE
[docs-infra] Revert "Pin StackBlitz demo vite to v7 and plugin-react to v5"

### DIFF
--- a/packages/docs-infra/src/useDemo/exportVariant.test.ts
+++ b/packages/docs-infra/src/useDemo/exportVariant.test.ts
@@ -28,7 +28,7 @@ describe('exportVariant', () => {
       expect(packageJson.private).toBe(true);
       expect(packageJson.dependencies.react).toBe('latest');
       expect(packageJson.dependencies['react-dom']).toBe('latest');
-      expect(packageJson.devDependencies.vite).toBe('^7');
+      expect(packageJson.devDependencies.vite).toBe('latest');
       expect(packageJsonContent.metadata).toBe(true);
     } else {
       throw new Error('Expected package.json to be an object with source property');
@@ -243,7 +243,7 @@ describe('exportVariant', () => {
       expect(packageJson.dependencies.react).toBe('latest'); // Should keep defaults
       expect(packageJson.devDependencies.jest).toBe('^29.0.0');
       expect(packageJson.devDependencies['custom-dev-tool']).toBe('latest');
-      expect(packageJson.devDependencies.vite).toBe('^7'); // Should keep defaults
+      expect(packageJson.devDependencies.vite).toBe('latest'); // Should keep defaults
     }
   });
 

--- a/packages/docs-infra/src/useDemo/exportVariant.ts
+++ b/packages/docs-infra/src/useDemo/exportVariant.ts
@@ -512,10 +512,8 @@ export function exportVariant(
     },
     devDependencies: {
       ...(!isFramework && {
-        // Pinned to major versions instead of `latest` to work around
-        // https://github.com/stackblitz/webcontainer-core/issues/2104
-        '@vitejs/plugin-react': '^5',
-        vite: '^7',
+        '@vitejs/plugin-react': 'latest',
+        vite: 'latest',
       }),
       ...(useTypescript && {
         typescript: 'latest',


### PR DESCRIPTION
Reverts mui/mui-public#1527

See https://github.com/stackblitz/webcontainer-core/issues/2104#issuecomment-4766334034