### PR TITLE
[renovate] Run Prettier after security updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -78,6 +78,9 @@ jobs:
           RENOVATE_AUTODISCOVER: 'false' # the matrix is the fan-out now, not autodiscover
           RENOVATE_ONBOARDING: 'false' # never open onboarding PRs
           RENOVATE_REQUIRE_CONFIG: 'required' # skip installed repos without a Renovate config
+          # Allowlist for postUpgradeTasks commands (globalOnly, can't be set in repo config).
+          # Matches the Prettier pass in renovate/default.json. Anchored to avoid command injection.
+          RENOVATE_ALLOWED_COMMANDS: '["^pnpm exec prettier --write [\\w./ -]+$"]'
           RENOVATE_USERNAME: 'code-infra-renovate[bot]'
           RENOVATE_GIT_AUTHOR: 'code-infra-renovate[bot] <290386390+code-infra-renovate[bot]@users.noreply.github.com>'
           LOG_LEVEL: debug

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -98,10 +98,9 @@
       "minimumReleaseAge": null
     },
     {
-      "description": "Do not delay security fixes with Minimum Release Age",
+      "description": "Run Prettier on security update branches",
       "matchDatasources": ["npm"],
       "isVulnerabilityAlert": true,
-      "minimumReleaseAge": null,
       "postUpgradeTasks": {
         "commands": ["pnpm exec prettier --write pnpm-workspace.yaml package.json"],
         "fileFilters": ["**/*"],

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -98,6 +98,17 @@
       "minimumReleaseAge": null
     },
     {
+      "description": "Do not delay security fixes with Minimum Release Age",
+      "matchDatasources": ["npm"],
+      "isVulnerabilityAlert": true,
+      "minimumReleaseAge": null,
+      "postUpgradeTasks": {
+        "commands": ["pnpm exec prettier --write pnpm-workspace.yaml package.json"],
+        "fileFilters": ["**/*"],
+        "executionMode": "branch"
+      }
+    },
+    {
       "matchDepTypes": ["peerDependencies"],
       "rangeStrategy": "widen"
     },


### PR DESCRIPTION

Runs Prettier after Renovate applies security updates, so vuln-fix PRs land formatted.

- `renovate/default.json`: `postUpgradeTasks` (prettier `--write` on `pnpm-workspace.yaml` + `package.json`) scoped to an `isVulnerabilityAlert` rule.
- `.github/workflows/renovate.yml`: `RENOVATE_ALLOWED_COMMANDS` allowlist (globalOnly, can't live in repo config) with an anchored regex matching only that command.

See also https://github.com/renovatebot/renovate/discussions/44158


> [!NOTE]
> Needs a real run to confirm `prettier` resolves from `node_modules` in the Renovate runner; may need `pnpm dlx prettier` instead. Non-matching commands are skipped with a WARN, not fatal — safe to merge first.