### PR TITLE
[renovate] Forward CI=true to postUpgradeTasks env

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -81,6 +81,10 @@ jobs:
           # Allowlist for postUpgradeTasks commands (globalOnly, can't be set in repo config).
           # Matches the Prettier pass in renovate/default.json. Anchored to avoid command injection.
           RENOVATE_ALLOWED_COMMANDS: '["^pnpm exec prettier --write [\\w./ -]+$"]'
+          # Forward CI=true (set by the runner) into postUpgradeTasks child processes. Renovate
+          # filters their env to an allowlist, stripping CI; without it, `pnpm exec` on pnpm 11
+          # aborts the non-interactive node_modules purge (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
+          RENOVATE_ALLOWED_ENV: '["CI"]'
           RENOVATE_USERNAME: 'code-infra-renovate[bot]'
           RENOVATE_GIT_AUTHOR: 'code-infra-renovate[bot] <290386390+code-infra-renovate[bot]@users.noreply.github.com>'
           LOG_LEVEL: debug


### PR DESCRIPTION
Renovate jobs on security-update branches fail in CI when the post-upgrade Prettier task runs:

```
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY: Aborted removal of modules directory due to no TTY
```

`pnpm@11`'s `pnpm exec` runs a deps-status check that wants to purge an out-of-sync `node_modules`, and refuses to do so non-interactively unless `CI=true`. The GitHub runner already sets `CI=true`, but Renovate filters the env it forwards to `postUpgradeTasks` child processes down to a fixed allowlist that strips `CI` — so the purge aborts.

`RENOVATE_ALLOWED_ENV` extends that allowlist (it adds, it does not replace the base vars), letting the runner's real `CI=true` flow through to the `pnpm exec prettier …` process.

Example failing run: https://github.com/mui/mui-public/actions/runs/27974855286