### PR TITLE
[code-infra] Validate git tag exists on remote before creating

### DIFF
--- a/packages/code-infra/src/cli/cmdPublish.mjs
+++ b/packages/code-infra/src/cli/cmdPublish.mjs
@@ -23,7 +23,7 @@ import {
   publishPackages,
   validatePublishDependencies,
 } from '../utils/pnpm.mjs';
-import { getCurrentGitSha, getRepositoryInfo } from '../utils/git.mjs';
+import { getCurrentGitSha, getRepositoryInfo, remoteGitTagExists } from '../utils/git.mjs';
 
 const isCI = envCI().isCi;
 
@@ -365,7 +365,13 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       console.log(`✅ Published ${pkg.name}@${pkg.version}`);
     });
 
-    await createGitTag(version, dryRun);
+    // Tag the root version when it's new. Arbitrary package publishes that don't
+    // bump the root version don't create a new tag, so skip in that case.
+    if (await remoteGitTagExists(`v${version}`)) {
+      console.log(`ℹ️  Git tag v${version} already exists, skipping tag creation.`);
+    } else {
+      await createGitTag(version, dryRun);
+    }
 
     // Create GitHub release or git tag after successful npm publishing
     if (githubRelease && githubReleaseData) {

--- a/packages/code-infra/src/utils/git.mjs
+++ b/packages/code-infra/src/utils/git.mjs
@@ -73,3 +73,14 @@ export async function getCurrentGitSha() {
   const result = await $`git rev-parse HEAD`;
   return result.stdout.trim();
 }
+
+/**
+ * Check whether a tag already exists on the origin remote
+ * @param {string} tagName - Tag name to check (e.g. `v1.2.3`)
+ * @param {string} [cwd=process.cwd()]
+ * @returns {Promise<boolean>} True if the tag exists on origin
+ */
+export async function remoteGitTagExists(tagName, cwd = process.cwd()) {
+  const { stdout } = await $({ cwd })`git ls-remote --tags origin refs/tags/${tagName}`;
+  return stdout.trim().length > 0;
+}


### PR DESCRIPTION
This helps us in setting up the arbitrary partial publishing of packages where we don't care about the actual release process (that involves a new changelog entry and a root package bump).
This will smooth the release setup in base-ui for @base-ui/utils and other repos as well. Check the error logs here - https://github.com/mui/base-ui/actions/runs/27366384353/job/80866911687