### PR TITLE
[renovate] Use customEnvVariables to set CI=true for postUpgradeTasks

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -81,10 +81,11 @@ jobs:
           # Allowlist for postUpgradeTasks commands (globalOnly, can't be set in repo config).
           # Matches the Prettier pass in renovate/default.json. Anchored to avoid command injection.
           RENOVATE_ALLOWED_COMMANDS: '["^pnpm exec prettier --write [\\w./ -]+$"]'
-          # Forward CI=true (set by the runner) into postUpgradeTasks child processes. Renovate
-          # filters their env to an allowlist, stripping CI; without it, `pnpm exec` on pnpm 11
+          # Inject CI=true into postUpgradeTasks child processes. Without it, `pnpm exec` on pnpm 11
           # aborts the non-interactive node_modules purge (ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY).
-          RENOVATE_ALLOWED_ENV: '["CI"]'
+          # customEnvVariables (not allowedEnv) is required: Renovate runs in a Docker container that
+          # the runner's CI=true never enters, so there is nothing for allowedEnv to forward.
+          RENOVATE_CUSTOM_ENV_VARIABLES: '{"CI":"true"}'
           RENOVATE_USERNAME: 'code-infra-renovate[bot]'
           RENOVATE_GIT_AUTHOR: 'code-infra-renovate[bot] <290386390+code-infra-renovate[bot]@users.noreply.github.com>'
           LOG_LEVEL: debug


### PR DESCRIPTION
Follow-up to #1574, which did not fix the issue.

#1574 added `RENOVATE_ALLOWED_ENV: '["CI"]'`, but the security-branch Prettier task still aborts:

```
ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY: Aborted removal of modules directory due to no TTY
```

Root cause of the miss: `allowedEnv` *forwards an existing* env var from Renovate's process. But Renovate runs inside a Docker container (`renovatebot/github-action` does `docker run --env …`), and **`CI` is not in that `--env` list** — the runner's `CI=true` never enters the container, so there is nothing for `allowedEnv` to forward. (Confirmed in [run 28015776340](https://github.com/mui/mui-public/actions/runs/28015776340/job/82919615717): `allowedEnv: ["CI"]` is in the resolved config, yet the post-upgrade command's env has no `CI` and the purge still aborts.)

`customEnvVariables` instead **defines** the value inside Renovate and injects it into the post-upgrade child process — no dependency on `CI` existing in the container. The `RENOVATE_CUSTOM_ENV_VARIABLES` var itself is `RENOVATE_`-prefixed, so the action does pass it into the container.

This replaces the ineffective `RENOVATE_ALLOWED_ENV` line from #1574.