### PR TITLE
[security] Remediate Dependabot alerts for transitive deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,24 +69,24 @@
     "@typescript-eslint/eslint-plugin": "^8.59.3",
     "@typescript-eslint/parser": "^8.59.3",
     "@typescript/native-preview": "^7.0.0-dev.20260514.1",
-    "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^10.4.0",
     "jsdom": "^28.1.0",
     "lerna": "^9.0.7",
     "prettier": "3.8.3",
     "pretty-quick": "^4.2.2",
     "semver": "^7.8.0",
-    "tsx": "^4.21.0",
-    "vitest": "^4.1.6"
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-constant-elements": "7.27.1",
-    "@vitest/browser-playwright": "4.1.6",
+    "@vitest/browser-playwright": "4.1.9",
+    "@vitest/coverage-v8": "^4.1.9",
     "baseline-browser-mapping": "2.10.29",
     "eslint-plugin-n": "17.24.0",
     "pkg-pr-new": "0.0.72",
     "playwright": "1.60.0",
-    "stylelint": "17.11.0"
+    "stylelint": "17.11.0",
+    "vitest": "^4.1.9"
   },
   "packageManager": "pnpm@11.1.2",
   "engines": {

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -35,7 +35,7 @@
     "@types/env-ci": "3.1.4",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
-    "vitest": "4.1.6"
+    "vitest": "4.1.9"
   },
   "publishConfig": {
     "access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,12 @@ settings:
 overrides:
   '@types/eslint': npm:eslint@^9.39.4
   undici-types: 6.25.0
+  undici@6: ^6.27.0
+  undici@7: ^7.28.0
+  form-data@4: ^4.0.6
+  tar@7: ^7.5.16
+  js-yaml@4: ^4.2.0
+  tmp: ^0.2.7
 
 importers:
 
@@ -57,9 +63,6 @@ importers:
       '@typescript/native-preview':
         specifier: ^7.0.0-dev.20260514.1
         version: 7.0.0-dev.20260517.1
-      '@vitest/coverage-v8':
-        specifier: ^4.1.6
-        version: 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.7.0)
@@ -81,16 +84,16 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
-      vitest:
-        specifier: ^4.1.6
-        version: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
     devDependencies:
       '@babel/plugin-transform-react-constant-elements':
         specifier: 7.27.1
         version: 7.27.1(@babel/core@7.29.7)
       '@vitest/browser-playwright':
-        specifier: 4.1.6
-        version: 4.1.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
+        specifier: 4.1.9
+        version: 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.9
+        version: 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       baseline-browser-mapping:
         specifier: 2.10.29
         version: 2.10.29
@@ -106,6 +109,9 @@ importers:
       stylelint:
         specifier: 17.11.0
         version: 17.11.0(typescript@6.0.3)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/code-infra-dashboard:
     dependencies:
@@ -392,7 +398,7 @@ importers:
         version: 6.0.2(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/browser-playwright':
         specifier: '>=4.1'
-        version: 4.1.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
+        version: 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
       env-ci:
         specifier: ^11.2.0
         version: 11.2.0
@@ -419,8 +425,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
       vitest:
-        specifier: 4.1.6
-        version: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: 4.1.9
+        version: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
     publishDirectory: build
 
   packages/bundle-size-checker:
@@ -551,7 +557,7 @@ importers:
         version: 7.0.0-dev.20260517.1
       '@vitest/eslint-plugin':
         specifier: ^1.6.17
-        version: 1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.6)
+        version: 1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.9)
       babel-plugin-optimize-clsx:
         specifier: ^2.6.2
         version: 2.6.2
@@ -635,7 +641,7 @@ importers:
         version: 16.2.0
       html-validate:
         specifier: ^10.17.0
-        version: 10.17.0(jest-diff@30.2.0)(vitest@4.1.6)
+        version: 10.17.0(jest-diff@30.2.0)(vitest@4.1.9)
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
@@ -1022,7 +1028,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       vitest-fail-on-console:
         specifier: ^0.10.1
-        version: 0.10.1(@vitest/utils@4.1.9)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
+        version: 0.10.1(@vitest/utils@4.1.9)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
     devDependencies:
       '@playwright/test':
         specifier: 1.60.0
@@ -1076,11 +1082,11 @@ importers:
         specifier: 19.2.14
         version: 19.2.14
       '@vitest/browser-playwright':
-        specifier: 4.1.6
-        version: 4.1.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
+        specifier: 4.1.9
+        version: 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
       vitest:
-        specifier: 4.1.6
-        version: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+        specifier: 4.1.9
+        version: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -4484,22 +4490,22 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/browser-playwright@4.1.6':
-    resolution: {integrity: sha512-4csoeyl/qwHyxU2zNL0++WaoDr8YJDXOQPwWPNJoTZ+QzcdO3INYKgF5Zfz730Io7zbkuv914aZmfQ+QE+1Hvw==}
+  '@vitest/browser-playwright@4.1.9':
+    resolution: {integrity: sha512-Bq1rOGf9waevzG3EOkO/dene6bvKTUsZMVg8S1i+WH3JcMjuXEjiahP9rAqZRELUqjBySOJsvvSWqK/B3wjKQw==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.6
+      vitest: 4.1.9
 
-  '@vitest/browser@4.1.6':
-    resolution: {integrity: sha512-ynsspTubXGSpa58JFJ24xIQt4z4A25epSbugEyaTmmrV1//Wec9EgE/LtoaC6yxUrXi5P7erGHRrkdZIHaVQuA==}
+  '@vitest/browser@4.1.9':
+    resolution: {integrity: sha512-j1BKtWmPcqpMhmx/L9EPLgAJpCb0zKfwoWLmqBbxaogCXHjOwHFSEoHCBfnGtx93xKQwilZ26m+UOsHqHMkRNg==}
     peerDependencies:
-      vitest: 4.1.6
+      vitest: 4.1.9
 
-  '@vitest/coverage-v8@4.1.6':
-    resolution: {integrity: sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==}
+  '@vitest/coverage-v8@4.1.9':
+    resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
     peerDependencies:
-      '@vitest/browser': 4.1.6
-      vitest: 4.1.6
+      '@vitest/browser': 4.1.9
+      vitest: 4.1.9
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -4520,11 +4526,11 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@4.1.6':
-    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
-  '@vitest/mocker@4.1.6':
-    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -4534,23 +4540,17 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.6':
-    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
-
   '@vitest/pretty-format@4.1.9':
     resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/runner@4.1.6':
-    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
 
-  '@vitest/snapshot@4.1.6':
-    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
-  '@vitest/spy@4.1.6':
-    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
-
-  '@vitest/utils@4.1.6':
-    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
 
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
@@ -6123,8 +6123,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   format-util@1.0.5:
@@ -6384,6 +6384,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
@@ -6914,8 +6918,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@28.1.0:
@@ -9028,8 +9032,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   terser-webpack-plugin@5.6.1:
@@ -9125,10 +9129,6 @@ packages:
   tldts@7.0.17:
     resolution: {integrity: sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==}
     hasBin: true
-
-  tmp@0.2.6:
-    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
-    engines: {node: '>=14.14'}
 
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
@@ -9301,12 +9301,12 @@ packages:
   undici-types@6.25.0:
     resolution: {integrity: sha512-vOw74RVVYFtnooUkZPxsY1GuuNNupSrCcANIAaDekpZ/Dp1sBuLLl5n2UCKpzxgmOwD66S4Jj24MrhmcDG+0vw==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -9513,20 +9513,20 @@ packages:
       vite: '>=4.5.2'
       vitest: '>=0.26.2'
 
-  vitest@4.1.6:
-    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.6
-      '@vitest/browser-preview': 4.1.6
-      '@vitest/browser-webdriverio': 4.1.6
-      '@vitest/coverage-istanbul': 4.1.6
-      '@vitest/coverage-v8': 4.1.6
-      '@vitest/ui': 4.1.6
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -9868,17 +9868,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.8
       '@octokit/request-error': 7.1.0
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -11347,7 +11347,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -13710,29 +13710,29 @@ snapshots:
     optionalDependencies:
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-playwright@4.1.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)':
+  '@vitest/browser-playwright@4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
-      '@vitest/browser': 4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
-      '@vitest/mocker': 4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)':
+  '@vitest/browser@4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/utils': 4.1.6
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -13740,10 +13740,10 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)':
+  '@vitest/coverage-v8@4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.9
       ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
@@ -13752,11 +13752,11 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
+      '@vitest/browser': 4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
 
-  '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.6)':
+  '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.9)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.4
       '@typescript-eslint/utils': 8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)
@@ -13764,54 +13764,44 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.6':
+  '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.6
+      '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.6':
-    dependencies:
-      tinyrainbow: 3.1.0
-
   '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.6':
+  '@vitest/runner@4.1.9':
     dependencies:
-      '@vitest/utils': 4.1.6
+      '@vitest/utils': 4.1.9
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.6':
+  '@vitest/snapshot@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.6': {}
-
-  '@vitest/utils@4.1.6':
-    dependencies:
-      '@vitest/pretty-format': 4.1.6
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+  '@vitest/spy@4.1.9': {}
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -14119,7 +14109,7 @@ snapshots:
   axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -14633,7 +14623,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -14642,7 +14632,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -14651,7 +14641,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -14978,7 +14968,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -15049,11 +15039,11 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -15213,7 +15203,7 @@ snapshots:
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.3(eslint@10.4.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@10.4.0(jiti@2.7.0))
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-core-module: 2.16.1
       is-glob: 4.0.3
       minimatch: 3.1.5
@@ -15241,7 +15231,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 10.4.0(jiti@2.7.0)
-      hasown: 2.0.2
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
       minimatch: 3.1.5
@@ -15321,7 +15311,7 @@ snapshots:
       es-iterator-helpers: 1.2.1
       eslint: 10.4.0(jiti@2.7.0)
       estraverse: 5.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       minimatch: 3.1.5
       object.entries: 1.1.9
@@ -15708,12 +15698,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   format-util@1.0.5: {}
@@ -15750,7 +15740,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -15777,7 +15767,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-pkg-repo@4.2.1:
@@ -15981,6 +15971,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   hast-util-from-html@2.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -16133,7 +16127,7 @@ snapshots:
 
   html-tags@5.1.0: {}
 
-  html-validate@10.17.0(jest-diff@30.2.0)(vitest@4.1.6):
+  html-validate@10.17.0(jest-diff@30.2.0)(vitest@4.1.9):
     dependencies:
       '@html-validate/stylish': 5.2.0
       '@sidvind/better-ajv-errors': 5.0.0(ajv@8.18.0)
@@ -16145,7 +16139,7 @@ snapshots:
       semver: 7.8.0
     optionalDependencies:
       jest-diff: 30.2.0
-      vitest: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
 
   html-void-elements@3.0.0: {}
 
@@ -16258,7 +16252,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
@@ -16314,7 +16308,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -16399,7 +16393,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-set@2.0.3: {}
 
@@ -16528,7 +16522,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -16549,7 +16543,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -16679,7 +16673,7 @@ snapshots:
       inquirer: 12.9.6(@types/node@22.19.0)
       is-ci: 3.0.1
       jest-diff: 30.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       libnpmaccess: 10.0.3
       libnpmpublish: 11.1.2
       load-json-file: 6.2.0
@@ -16702,7 +16696,7 @@ snapshots:
       slash: 3.0.0
       ssri: 12.0.0
       string-width: 4.2.3
-      tar: 7.5.11
+      tar: 7.5.16
       through: 2.3.8
       tinyglobby: 0.2.12
       typescript: 5.9.3
@@ -17634,7 +17628,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.0.0
       semver: 7.8.0
-      tar: 7.5.11
+      tar: 7.5.16
       tinyglobby: 0.2.17
       which: 6.0.0
     transitivePeerDependencies:
@@ -17835,7 +17829,7 @@ snapshots:
       figures: 3.2.0
       flat: 5.0.2
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-constants: 1.0.0
       function-bind: 1.1.2
       get-caller-file: 2.0.5
@@ -17886,7 +17880,7 @@ snapshots:
       strip-bom: 3.0.0
       supports-color: 7.2.0
       tar-stream: 2.2.0
-      tmp: 0.2.6
+      tmp: 0.2.7
       tree-kill: 1.2.2
       tsconfig-paths: 4.2.0
       tslib: 2.8.1
@@ -18096,7 +18090,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 4.0.0
       ssri: 12.0.0
-      tar: 7.5.11
+      tar: 7.5.16
     transitivePeerDependencies:
       - supports-color
 
@@ -18118,7 +18112,7 @@ snapshots:
       promise-retry: 2.0.1
       sigstore: 4.0.0
       ssri: 13.0.0
-      tar: 7.5.11
+      tar: 7.5.16
     transitivePeerDependencies:
       - supports-color
 
@@ -19498,7 +19492,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.11:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -19564,8 +19558,6 @@ snapshots:
   tldts@7.0.17:
     dependencies:
       tldts-core: 7.0.17
-
-  tmp@0.2.6: {}
 
   tmp@0.2.7: {}
 
@@ -19731,9 +19723,9 @@ snapshots:
 
   undici-types@6.25.0: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -19981,22 +19973,22 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.9)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6):
+  vitest-fail-on-console@0.10.1(@vitest/utils@4.1.9)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9):
     dependencies:
       '@vitest/utils': 4.1.9
       chalk: 5.6.2
       vite: 8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0)
-      vitest: 4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
 
-  vitest@4.1.6(@types/node@22.19.0)(@vitest/browser-playwright@4.1.6)(@vitest/coverage-v8@4.1.6)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@22.19.0)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@28.1.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -20012,8 +20004,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.0
-      '@vitest/browser-playwright': 4.1.6(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.6)
-      '@vitest/coverage-v8': 4.1.6(@vitest/browser@4.1.6)(vitest@4.1.6)
+      '@vitest/browser-playwright': 4.1.9(playwright@1.60.0)(vite@8.0.16(@types/node@22.19.0)(esbuild@0.27.1)(jiti@2.7.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.9)
+      '@vitest/coverage-v8': 4.1.9(@vitest/browser@4.1.9)(vitest@4.1.9)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,15 @@ overrides:
   # undici-types@6.21.0 dropped provenance attestation (present in earlier and later versions),
   # which triggers trustPolicy: no-downgrade. Force to latest 6.x which has provenance.
   undici-types: '6.25.0'
+  # Security: force patched versions of transitive-only dependencies flagged by Dependabot.
+  # These are pulled in by build/test tooling (lerna, nx, jsdom, eslint, @actions/*) and are
+  # not declared in any package.json, so they can only be remediated via overrides.
+  undici@6: '^6.27.0'
+  undici@7: '^7.28.0'
+  form-data@4: '^4.0.6'
+  tar@7: '^7.5.16'
+  js-yaml@4: '^4.2.0'
+  tmp: '^0.2.7'
 engineStrict: true
 strictDepBuilds: true
 allowBuilds:

--- a/test/performance/package.json
+++ b/test/performance/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@mui/internal-benchmark": "workspace:*",
     "@types/react": "19.2.14",
-    "@vitest/browser-playwright": "4.1.6",
-    "vitest": "4.1.6"
+    "@vitest/browser-playwright": "4.1.9",
+    "vitest": "4.1.9"
   }
 }


### PR DESCRIPTION
## What

Closes the open [Dependabot alerts](https://github.com/mui/mui-public/security/dependabot). All of them are **transitive-only** dependencies (present only in `pnpm-lock.yaml`, not declared in any `package.json`), which is why neither bot remediated them automatically:

- **Renovate** `vulnerabilityAlerts` only patches deps that have a range to bump *in a manifest* — there's nothing to target for transitive-only deps.
- **Dependabot** version PRs are intentionally disabled (`open-pull-requests-limit: 0`), and its security updates can't bump pnpm transitive deps that aren't reachable via a direct parent.
- A plain `pnpm update` is a no-op here for the same reason.

## Changes

- **`pnpm-workspace.yaml`** — add `overrides` forcing patched versions of the transitive-only deps:
  - `undici@6 → ^6.27.0`, `undici@7 → ^7.28.0`
  - `form-data@4 → ^4.0.6`
  - `tar@7 → ^7.5.16`
  - `js-yaml@4 → ^4.2.0`
  - `tmp → ^0.2.7`
- **vitest family → 4.1.9** (`vitest`, `@vitest/browser-playwright`, `@vitest/coverage-v8`) across root, `test/performance`, and `packages/benchmark` — clears the critical `@vitest/browser` advisory (fixed in 4.1.8) and keeps the versions aligned. (pnpm relocated root `vitest`/`@vitest/coverage-v8` to `devDependencies`, which is where they belong.)

All patched versions are >9 days old, so no `minimumReleaseAge` exclusion is needed.

## Verification

`pnpm release:build`, `pnpm typescript`, `pnpm eslint`, and `pnpm test --run` (5176 tests) all pass. No vulnerable versions remain in the lockfile.

https://claude.ai/code/session_01TrgmzVutB1AXzLG5k4umgP