### PR TITLE
Fix invalid isVulnerabilityAlert matcher in Renovate preset

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -85,7 +85,12 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "addLabels": ["security"]
+    "addLabels": ["security"],
+    "postUpgradeTasks": {
+      "commands": ["pnpm exec prettier --write pnpm-workspace.yaml package.json"],
+      "fileFilters": ["**/*"],
+      "executionMode": "branch"
+    }
   },
   "packageRules": [
     {
@@ -96,16 +101,6 @@
         "⚠️ Renovate's pinning functionality [does not currently](https://github.com/renovatebot/renovate/discussions/39058) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s)."
       ],
       "minimumReleaseAge": null
-    },
-    {
-      "description": "Run Prettier on security update branches",
-      "matchDatasources": ["npm"],
-      "isVulnerabilityAlert": true,
-      "postUpgradeTasks": {
-        "commands": ["pnpm exec prettier --write pnpm-workspace.yaml package.json"],
-        "fileFilters": ["**/*"],
-        "executionMode": "branch"
-      }
     },
     {
       "matchDepTypes": ["peerDependencies"],


### PR DESCRIPTION
`isVulnerabilityAlert` is not a valid `packageRules` matcher, so the "Run Prettier on security update branches" rule was ignored as a matcher and applied to **every npm-datasource dependency** — mishandling regular updates as security updates (e.g. `minimumReleaseAgeExclude` entries appearing on non-security PRs like `date-fns`).

Diagnosed by the Renovate maintainer in renovatebot/renovate#44286. Applying their recommended fix:

- Delete the invalid `packageRule`.
- Move its `postUpgradeTasks` (the Prettier pass) into the top-level `vulnerabilityAlerts` object, which is correctly scoped to security updates only.

The `RENOVATE_ALLOWED_COMMANDS` allowlist already in the workflow keeps the Prettier task functional under its new home, now correctly limited to vulnerability alerts.

Validated with `renovate-config-validator` (the two remaining `group:` extend warnings are pre-existing and unrelated).