### PR TITLE
Migrate Zendesk KPI fetchers from API token to OAuth

### DIFF
--- a/apps/code-infra-dashboard/.env.example
+++ b/apps/code-infra-dashboard/.env.example
@@ -24,8 +24,5 @@ STORE_PRODUCTION_READ_USERNAME=username
 STORE_PRODUCTION_READ_PASSWORD=password
 STORE_PRODUCTION_READ_DATABASE=database
 HIBOB_TOKEN_READ_STANDARD=token
-# Zendesk OAuth client (client_credentials grant) — API tokens are being removed.
-# Create a confidential OAuth client in Zendesk Admin Center > Apps and
-# integrations > APIs > OAuth clients, then copy its id and secret here.
 ZENDESK_CLIENT_ID=client-id
 ZENDESK_CLIENT_SECRET=client-secret

--- a/apps/code-infra-dashboard/.env.example
+++ b/apps/code-infra-dashboard/.env.example
@@ -24,4 +24,8 @@ STORE_PRODUCTION_READ_USERNAME=username
 STORE_PRODUCTION_READ_PASSWORD=password
 STORE_PRODUCTION_READ_DATABASE=database
 HIBOB_TOKEN_READ_STANDARD=token
-ZENDESK=token
+# Zendesk OAuth client (client_credentials grant) — API tokens are being removed.
+# Create a confidential OAuth client in Zendesk Admin Center > Apps and
+# integrations > APIs > OAuth clients, then copy its id and secret here.
+ZENDESK_CLIENT_ID=client-id
+ZENDESK_CLIENT_SECRET=client-secret

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -40,9 +40,11 @@ async function getZendeskAuth(): Promise<string | KpiResult> {
     cache: 'no-store',
   });
 
-  const tokenError = checkHttpError(response, 'OAuth');
-  if (tokenError) {
-    return tokenError;
+  if (!response.ok) {
+    // Surface Zendesk's error body (e.g. {"error":"invalid_scope",...}) so the
+    // failing KPI shows why the token request was rejected.
+    const detail = await response.text();
+    return errorResult(`OAuth HTTP ${response.status}: ${detail}`);
   }
 
   const data: { access_token: string; expires_in: number } = await response.json();

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -43,8 +43,9 @@ async function getZendeskAuth(): Promise<string | KpiResult> {
 
   if (!response.ok) {
     // Surface Zendesk's error body (e.g. {"error":"invalid_scope",...}) so the
-    // failing KPI shows why the token request was rejected.
-    const detail = await response.text();
+    // failing KPI shows why the token request was rejected, truncated in case
+    // an upstream error returns a large HTML page.
+    const detail = (await response.text()).slice(0, 300);
     return errorResult(`OAuth HTTP ${response.status}: ${detail}`);
   }
 

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -1,5 +1,5 @@
 import type { KpiResult } from '../types';
-import { checkHttpError, errorResult, getEnvOrError, successResult } from './utils';
+import { checkHttpError, successResult } from './utils';
 
 const TOKEN_ENDPOINT = 'https://mui.zendesk.com/oauth/tokens';
 // Request a long-lived token (Zendesk allows up to just under 2 days) so it
@@ -14,24 +14,21 @@ let cachedToken: { header: string; expiresAt: number } | null = null;
  * grant. Zendesk is removing API tokens as an auth method, so we exchange an
  * OAuth client id/secret for a short-lived bearer token on demand.
  *
- * Returns the full `Authorization` header value, or a `KpiResult` error if
- * authentication is not configured or the token request fails. Pass
- * `forceRefresh` to bypass the cache and mint a fresh token, e.g. after a
- * request rejected the cached one.
+ * Returns the full `Authorization` header value. Throws if authentication is
+ * not configured or the token request fails — these are infrastructure/config
+ * problems, not per-KPI data errors, so they bubble up like any other network
+ * or parse failure in the fetchers. Pass `forceRefresh` to bypass the cache and
+ * mint a fresh token, e.g. after a request rejected the cached one.
  */
-async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult> {
+async function getZendeskAuth(forceRefresh = false): Promise<string> {
   if (!forceRefresh && cachedToken && cachedToken.expiresAt - EXPIRY_MARGIN_MS > Date.now()) {
     return cachedToken.header;
   }
 
-  const clientId = getEnvOrError('ZENDESK_CLIENT_ID');
-  if (typeof clientId !== 'string') {
-    return clientId;
-  }
-
-  const clientSecret = getEnvOrError('ZENDESK_CLIENT_SECRET');
-  if (typeof clientSecret !== 'string') {
-    return clientSecret;
+  const clientId = process.env.ZENDESK_CLIENT_ID;
+  const clientSecret = process.env.ZENDESK_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error('ZENDESK_CLIENT_ID / ZENDESK_CLIENT_SECRET not configured');
   }
 
   const response = await fetch(TOKEN_ENDPOINT, {
@@ -48,11 +45,10 @@ async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult>
   });
 
   if (!response.ok) {
-    // Surface Zendesk's error body (e.g. {"error":"invalid_scope",...}) so the
-    // failing KPI shows why the token request was rejected, truncated in case
-    // an upstream error returns a large HTML page.
+    // Surface Zendesk's error body (e.g. {"error":"invalid_scope",...}), truncated
+    // in case an upstream error returns a large HTML page.
     const detail = (await response.text()).slice(0, 300);
-    return errorResult(`OAuth HTTP ${response.status}: ${detail}`);
+    throw new Error(`Zendesk OAuth HTTP ${response.status}: ${detail}`);
   }
 
   const data: { access_token: string; expires_in: number } = await response.json();
@@ -68,15 +64,9 @@ async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult>
  * before our cached copy lapses. If the request comes back `401`, we force a
  * fresh token and retry once so a stale token self-heals instead of leaving
  * the KPI broken until the cache expires.
- *
- * Returns the `Response`, or a `KpiResult` error if authentication is not
- * configured or the token request fails.
  */
-async function zendeskFetch(url: string, forceRefresh = false): Promise<Response | KpiResult> {
+async function zendeskFetch(url: string, forceRefresh = false): Promise<Response> {
   const auth = await getZendeskAuth(forceRefresh);
-  if (typeof auth !== 'string') {
-    return auth;
-  }
 
   const response = await fetch(url, {
     headers: { Authorization: auth },
@@ -99,9 +89,6 @@ export async function fetchFirstReply(): Promise<KpiResult> {
   const metricsResponse = await zendeskFetch(
     `https://mui.zendesk.com/api/v2/ticket_metrics?start_time=${startTime}`,
   );
-  if (!(metricsResponse instanceof Response)) {
-    return metricsResponse;
-  }
 
   const metricsError = checkHttpError(metricsResponse, 'Metrics');
   if (metricsError) {
@@ -124,9 +111,6 @@ export async function fetchFirstReply(): Promise<KpiResult> {
   const ticketsResponse = await zendeskFetch(
     `https://mui.zendesk.com/api/v2/tickets/show_many?ids=${ticketIds}`,
   );
-  if (!(ticketsResponse instanceof Response)) {
-    return ticketsResponse;
-  }
 
   const ticketsError = checkHttpError(ticketsResponse, 'Tickets');
   if (ticketsError) {
@@ -170,9 +154,6 @@ export async function fetchSatisfactionScore(): Promise<KpiResult> {
   const response = await zendeskFetch(
     `https://mui.zendesk.com/api/v2/satisfaction_ratings?start_time=${startTime}&score=received`,
   );
-  if (!(response instanceof Response)) {
-    return response;
-  }
 
   const httpError = checkHttpError(response);
   if (httpError) {

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -56,23 +56,54 @@ async function getZendeskAuth(): Promise<string | KpiResult> {
   return header;
 }
 
-export async function fetchFirstReply(): Promise<KpiResult> {
+/**
+ * Performs an authenticated Zendesk API request. Because the OAuth token is
+ * cached for up to 24h, it can be revoked or invalidated server-side well
+ * before our cached copy lapses. If the request comes back `401`, we drop the
+ * cached token, mint a fresh one and retry once so a stale token self-heals
+ * instead of leaving the KPI broken until the cache expires.
+ *
+ * Returns the `Response`, or a `KpiResult` error if authentication is not
+ * configured or the token request fails.
+ */
+async function zendeskFetch(url: string): Promise<Response | KpiResult> {
   const auth = await getZendeskAuth();
   if (typeof auth !== 'string') {
     return auth;
   }
 
+  const response = await fetch(url, {
+    headers: { Authorization: auth },
+    next: { revalidate: 3600 },
+  });
+
+  if (response.status !== 401) {
+    return response;
+  }
+
+  cachedToken = null;
+  const retryAuth = await getZendeskAuth();
+  if (typeof retryAuth !== 'string') {
+    return retryAuth;
+  }
+
+  return fetch(url, {
+    headers: { Authorization: retryAuth },
+    next: { revalidate: 3600 },
+  });
+}
+
+export async function fetchFirstReply(): Promise<KpiResult> {
   const days = 30;
   const startTime = Math.round(Date.now() / 1000) - 3600 * 24 * days;
 
   // Step 1: Fetch ticket metrics
-  const metricsResponse = await fetch(
+  const metricsResponse = await zendeskFetch(
     `https://mui.zendesk.com/api/v2/ticket_metrics?start_time=${startTime}`,
-    {
-      headers: { Authorization: auth },
-      next: { revalidate: 3600 },
-    },
   );
+  if (!(metricsResponse instanceof Response)) {
+    return metricsResponse;
+  }
 
   const metricsError = checkHttpError(metricsResponse, 'Metrics');
   if (metricsError) {
@@ -92,13 +123,12 @@ export async function fetchFirstReply(): Promise<KpiResult> {
 
   // Step 2: Fetch ticket details for tags
   const ticketIds = metricsData.ticket_metrics.map((m) => m.ticket_id).join(',');
-  const ticketsResponse = await fetch(
+  const ticketsResponse = await zendeskFetch(
     `https://mui.zendesk.com/api/v2/tickets/show_many?ids=${ticketIds}`,
-    {
-      headers: { Authorization: auth },
-      next: { revalidate: 3600 },
-    },
   );
+  if (!(ticketsResponse instanceof Response)) {
+    return ticketsResponse;
+  }
 
   const ticketsError = checkHttpError(ticketsResponse, 'Tickets');
   if (ticketsError) {
@@ -136,21 +166,15 @@ export async function fetchFirstReply(): Promise<KpiResult> {
 }
 
 export async function fetchSatisfactionScore(): Promise<KpiResult> {
-  const auth = await getZendeskAuth();
-  if (typeof auth !== 'string') {
-    return auth;
-  }
-
   const days = 7 * 4; // 4 weeks
   const startTime = Math.round(Date.now() / 1000) - 3600 * 24 * days;
 
-  const response = await fetch(
+  const response = await zendeskFetch(
     `https://mui.zendesk.com/api/v2/satisfaction_ratings?start_time=${startTime}&score=received`,
-    {
-      headers: { Authorization: auth },
-      next: { revalidate: 3600 },
-    },
   );
+  if (!(response instanceof Response)) {
+    return response;
+  }
 
   const httpError = checkHttpError(response);
   if (httpError) {

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -2,8 +2,9 @@ import type { KpiResult } from '../types';
 import { checkHttpError, errorResult, successResult } from './utils';
 
 const TOKEN_ENDPOINT = 'https://mui.zendesk.com/oauth/tokens';
-// Request a 1 hour token (Zendesk allows 300s–172800s) and refresh slightly early.
-const TOKEN_TTL_SECONDS = 3600;
+// Request a long-lived token (Zendesk allows up to just under 2 days) so it
+// comfortably outlives the hourly KPI data cache and is rarely re-minted.
+const TOKEN_TTL_SECONDS = 86400;
 const EXPIRY_MARGIN_MS = 60_000;
 
 let cachedToken: { header: string; expiresAt: number } | null = null;

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -1,8 +1,59 @@
 import type { KpiResult } from '../types';
-import { checkHttpError, getEnvOrError, successResult } from './utils';
+import { checkHttpError, errorResult, successResult } from './utils';
+
+const TOKEN_ENDPOINT = 'https://mui.zendesk.com/oauth/tokens';
+// Request a 1 hour token (Zendesk allows 300s–172800s) and refresh slightly early.
+const TOKEN_TTL_SECONDS = 3600;
+const EXPIRY_MARGIN_MS = 60_000;
+
+let cachedToken: { header: string; expiresAt: number } | null = null;
+
+/**
+ * Obtains (and caches) a Zendesk OAuth access token via the `client_credentials`
+ * grant. Zendesk is removing API tokens as an auth method, so we exchange an
+ * OAuth client id/secret for a short-lived bearer token on demand.
+ *
+ * Returns the full `Authorization` header value, or a `KpiResult` error if
+ * authentication is not configured or the token request fails.
+ */
+async function getZendeskAuth(): Promise<string | KpiResult> {
+  if (cachedToken && cachedToken.expiresAt - EXPIRY_MARGIN_MS > Date.now()) {
+    return cachedToken.header;
+  }
+
+  const clientId = process.env.ZENDESK_CLIENT_ID;
+  const clientSecret = process.env.ZENDESK_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    return errorResult('ZENDESK_CLIENT_ID / ZENDESK_CLIENT_SECRET not configured');
+  }
+
+  const response = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret,
+      scope: 'read',
+      expires_in: TOKEN_TTL_SECONDS,
+    }),
+    cache: 'no-store',
+  });
+
+  const tokenError = checkHttpError(response, 'OAuth');
+  if (tokenError) {
+    return tokenError;
+  }
+
+  const data: { access_token: string; expires_in: number } = await response.json();
+
+  const header = `Bearer ${data.access_token}`;
+  cachedToken = { header, expiresAt: Date.now() + data.expires_in * 1000 };
+  return header;
+}
 
 export async function fetchFirstReply(): Promise<KpiResult> {
-  const auth = getEnvOrError('ZENDESK');
+  const auth = await getZendeskAuth();
   if (typeof auth !== 'string') {
     return auth;
   }
@@ -81,7 +132,7 @@ export async function fetchFirstReply(): Promise<KpiResult> {
 }
 
 export async function fetchSatisfactionScore(): Promise<KpiResult> {
-  const auth = getEnvOrError('ZENDESK');
+  const auth = await getZendeskAuth();
   if (typeof auth !== 'string') {
     return auth;
   }

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -1,5 +1,5 @@
 import type { KpiResult } from '../types';
-import { checkHttpError, errorResult, successResult } from './utils';
+import { checkHttpError, errorResult, getEnvOrError, successResult } from './utils';
 
 const TOKEN_ENDPOINT = 'https://mui.zendesk.com/oauth/tokens';
 // Request a long-lived token (Zendesk allows up to just under 2 days) so it
@@ -24,10 +24,14 @@ async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult>
     return cachedToken.header;
   }
 
-  const clientId = process.env.ZENDESK_CLIENT_ID;
-  const clientSecret = process.env.ZENDESK_CLIENT_SECRET;
-  if (!clientId || !clientSecret) {
-    return errorResult('ZENDESK_CLIENT_ID / ZENDESK_CLIENT_SECRET not configured');
+  const clientId = getEnvOrError('ZENDESK_CLIENT_ID');
+  if (typeof clientId !== 'string') {
+    return clientId;
+  }
+
+  const clientSecret = getEnvOrError('ZENDESK_CLIENT_SECRET');
+  if (typeof clientSecret !== 'string') {
+    return clientSecret;
   }
 
   const response = await fetch(TOKEN_ENDPOINT, {
@@ -69,29 +73,20 @@ async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult>
  * configured or the token request fails.
  */
 async function zendeskFetch(url: string): Promise<Response | KpiResult> {
-  const auth = await getZendeskAuth();
-  if (typeof auth !== 'string') {
-    return auth;
+  async function attempt(forceRefresh: boolean): Promise<Response | KpiResult> {
+    const auth = await getZendeskAuth(forceRefresh);
+    if (typeof auth !== 'string') {
+      return auth;
+    }
+    return fetch(url, { headers: { Authorization: auth }, next: { revalidate: 3600 } });
   }
 
-  const response = await fetch(url, {
-    headers: { Authorization: auth },
-    next: { revalidate: 3600 },
-  });
-
-  if (response.status !== 401) {
+  const response = await attempt(false);
+  if (!(response instanceof Response) || response.status !== 401) {
     return response;
   }
 
-  const retryAuth = await getZendeskAuth(true);
-  if (typeof retryAuth !== 'string') {
-    return retryAuth;
-  }
-
-  return fetch(url, {
-    headers: { Authorization: retryAuth },
-    next: { revalidate: 3600 },
-  });
+  return attempt(true);
 }
 
 export async function fetchFirstReply(): Promise<KpiResult> {

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -72,21 +72,23 @@ async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult>
  * Returns the `Response`, or a `KpiResult` error if authentication is not
  * configured or the token request fails.
  */
-async function zendeskFetch(url: string): Promise<Response | KpiResult> {
-  async function attempt(forceRefresh: boolean): Promise<Response | KpiResult> {
-    const auth = await getZendeskAuth(forceRefresh);
-    if (typeof auth !== 'string') {
-      return auth;
-    }
-    return fetch(url, { headers: { Authorization: auth }, next: { revalidate: 3600 } });
+async function zendeskFetch(url: string, forceRefresh = false): Promise<Response | KpiResult> {
+  const auth = await getZendeskAuth(forceRefresh);
+  if (typeof auth !== 'string') {
+    return auth;
   }
 
-  const response = await attempt(false);
-  if (!(response instanceof Response) || response.status !== 401) {
-    return response;
+  const response = await fetch(url, {
+    headers: { Authorization: auth },
+    next: { revalidate: 3600 },
+  });
+
+  // Retry once with a freshly minted token if the cached one was rejected.
+  if (response.status === 401 && !forceRefresh) {
+    return zendeskFetch(url, true);
   }
 
-  return attempt(true);
+  return response;
 }
 
 export async function fetchFirstReply(): Promise<KpiResult> {

--- a/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
+++ b/apps/code-infra-dashboard/src/lib/kpis/fetchers/zendesk.ts
@@ -15,10 +15,12 @@ let cachedToken: { header: string; expiresAt: number } | null = null;
  * OAuth client id/secret for a short-lived bearer token on demand.
  *
  * Returns the full `Authorization` header value, or a `KpiResult` error if
- * authentication is not configured or the token request fails.
+ * authentication is not configured or the token request fails. Pass
+ * `forceRefresh` to bypass the cache and mint a fresh token, e.g. after a
+ * request rejected the cached one.
  */
-async function getZendeskAuth(): Promise<string | KpiResult> {
-  if (cachedToken && cachedToken.expiresAt - EXPIRY_MARGIN_MS > Date.now()) {
+async function getZendeskAuth(forceRefresh = false): Promise<string | KpiResult> {
+  if (!forceRefresh && cachedToken && cachedToken.expiresAt - EXPIRY_MARGIN_MS > Date.now()) {
     return cachedToken.header;
   }
 
@@ -59,9 +61,9 @@ async function getZendeskAuth(): Promise<string | KpiResult> {
 /**
  * Performs an authenticated Zendesk API request. Because the OAuth token is
  * cached for up to 24h, it can be revoked or invalidated server-side well
- * before our cached copy lapses. If the request comes back `401`, we drop the
- * cached token, mint a fresh one and retry once so a stale token self-heals
- * instead of leaving the KPI broken until the cache expires.
+ * before our cached copy lapses. If the request comes back `401`, we force a
+ * fresh token and retry once so a stale token self-heals instead of leaving
+ * the KPI broken until the cache expires.
  *
  * Returns the `Response`, or a `KpiResult` error if authentication is not
  * configured or the token request fails.
@@ -81,8 +83,7 @@ async function zendeskFetch(url: string): Promise<Response | KpiResult> {
     return response;
   }
 
-  cachedToken = null;
-  const retryAuth = await getZendeskAuth();
+  const retryAuth = await getZendeskAuth(true);
   if (typeof retryAuth !== 'string') {
     return retryAuth;
   }

--- a/render.yaml
+++ b/render.yaml
@@ -34,4 +34,4 @@ services:
       - fromGroup: Code Infra GH App
       - fromGroup: MUI Store database
       - fromGroup: HiBob
-      - fromGroup: Zendesk
+      - fromGroup: code-infra-dashboard-zendesk


### PR DESCRIPTION
Zendesk is [removing API tokens](https://support.zendesk.com/hc/en-us/articles/10840968198042-Announcing-the-removal-of-API-tokens-as-an-authentication-method-for-API-requests) for the Support API (final cutoff 2027-04-30), which would break the dashboard's two Zendesk KPIs (first-reply time, satisfaction score).

This swaps the static API-token header for the OAuth `client_credentials` grant:

- `getZendeskAuth()` exchanges `ZENDESK_CLIENT_ID` / `ZENDESK_CLIENT_SECRET` for a short-lived bearer token, cached in-module with early refresh (mirrors `getOctokit()` in `src/lib/github.ts`).
- `render.yaml` points at the `code-infra-dashboard-zendesk` env group, which already holds the credentials.

Verified locally and on the preview: both KPIs return live data — [zendesk-first-reply](https://code-infra-dashboard-pr-1589.onrender.com/kpis/zendesk-first-reply).
