### PR TITLE
Add Prettier group to Renovate config

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -227,6 +227,16 @@
       "allowedVersions": ">=10.1.8"
     },
     {
+      "groupName": "Prettier",
+      "description": "Group Prettier-related dependencies and run a full Prettier pass on the branch after updating.",
+      "matchPackageNames": ["prettier", "pretty-quick", "eslint-config-prettier"],
+      "postUpgradeTasks": {
+        "commands": ["pnpm exec prettier --write . --ignore-path .lintignore"],
+        "fileFilters": ["**/*"],
+        "executionMode": "branch"
+      }
+    },
+    {
       "description": "Disable replacements for @tsconfig/node* packages",
       "matchPackagePatterns": ["^@tsconfig/node"],
       "replacementName": null,


### PR DESCRIPTION
Adds a `Prettier` group to `renovate/default.json` that batches Prettier-related dependency updates together and runs a full Prettier pass on the branch afterward.

## Changes

- Groups `prettier`, `pretty-quick`, and `eslint-config-prettier` into a single `Prettier` group.
- Adds a branch-level `postUpgradeTasks` running `pnpm exec prettier --write . --ignore-path .lintignore` — a full-repo format, unlike the vulnerability-report task which only formats `pnpm-workspace.yaml` and `package.json`.

`prettier-plugin-tailwindcss` is intentionally left out, as it's kept in the existing "Tailwind CSS" group.