### PR TITLE
[code-infra] Add SSR defaults to mui:recommended html-validate preset

### DIFF
--- a/packages/code-infra/src/brokenLinksChecker/__fixtures__/static-site/recommended-defaults.html
+++ b/packages/code-infra/src/brokenLinksChecker/__fixtures__/static-site/recommended-defaults.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Recommended defaults</title>
+  </head>
+  <body>
+    <h1>Recommended defaults</h1>
+
+    <!-- no-missing-references is off by default: this aria-labelledby points at
+         an id that only exists after client hydration, so it must not report. -->
+    <button aria-labelledby="not-here">Menu</button>
+
+    <!-- The default mui:recommended form action enum permits React's SSR
+         sentinel value, so this must not report an invalid attribute value. -->
+    <form action="javascript:throw new Error('not hydrated')">
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
+++ b/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
@@ -189,7 +189,30 @@ if (pageData.status < 200 || pageData.status >= 400) {
             rules: {
               // TODO: Enable when subresource integrity is adopted across projects
               'require-sri': 'off',
+              // Components that portal their content (menus, selects, listboxes,
+              // etc.) wire up aria-controls/aria-labelledby targets only after
+              // client hydration, so those targets are absent from the
+              // statically rendered HTML. Disable rather than report false
+              // positives.
+              'no-missing-references': 'off',
             },
+            elements: [
+              'html5',
+              {
+                form: {
+                  attributes: {
+                    // React renders `action="javascript:throw new Error(...)"` on
+                    // a <form> with a function action during SSR (a sentinel that
+                    // throws if the form is submitted before hydration wires up
+                    // the real handler). Permit that value while keeping the
+                    // default check (`^\s*\S+\s*$`) for every other action value.
+                    action: {
+                      enum: ['/^\\s*\\S+\\s*$/', '/^\\s*javascript:throw new Error\\(/'],
+                    },
+                  },
+                },
+              },
+            ],
           },
           ...overridePresets,
         },

--- a/packages/code-infra/src/brokenLinksChecker/index.test.ts
+++ b/packages/code-infra/src/brokenLinksChecker/index.test.ts
@@ -298,4 +298,26 @@ describe('Broken Links Checker', () => {
     );
     expect(invalidHtmlIssues).toEqual([]);
   }, 30000);
+
+  it('applies mui:recommended defaults so SSR patterns validate without overrides', async () => {
+    const port = await getPort();
+    const host = `http://localhost:${port}`;
+
+    // Validate with recommended rules only (no caller-supplied overrides), so
+    // this exercises the mui:recommended baseline in isolation. The fixture page
+    // relies on two defaults: `no-missing-references` is off (portaled targets
+    // are absent from static HTML) and the `<form>` action enum permits React's
+    // SSR sentinel value `javascript:throw new Error(...)`. Neither should report.
+    const result = await crawl({
+      startCommand: `${servePath} ${fixtureDir} -p ${port}`,
+      host,
+      seedUrls: ['/recommended-defaults.html'],
+      htmlValidate: true,
+    });
+
+    const htmlValidateIssues = result.issues.filter(
+      (issue): issue is HtmlValidateIssue => issue.type === 'html-validate',
+    );
+    expect(htmlValidateIssues).toEqual([]);
+  }, 30000);
 });


### PR DESCRIPTION
Folds the generic, "every page" html-validate config that React SSR docs sites (e.g. [mui/base-ui#4734](https://github.com/mui/base-ui/pull/4734)) repeat into the shared `mui:recommended` baseline in `@mui/internal-code-infra/brokenLinksChecker`, so consumers inherit it:

- `no-missing-references: 'off'` — portaled components (menus, selects, listboxes) wire up aria targets only after hydration, so they're absent from static HTML.
- A `<form>` `action` enum permitting React's SSR sentinel `action="javascript:throw new Error(...)"`, keeping the default non-empty check for other values.
