### PR TITLE
Prepare babel config and internal plugins for Babel 8

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,32 +1,17 @@
 // @ts-check
 /* eslint-disable @typescript-eslint/no-require-imports */
 // copied from https://github.com/mui/material-ui/blob/master/babel.config.js
-// defaultAlias modified
 // @mui/internal-babel-plugin-minify-errors removed
 
-const path = require('node:path');
 const { default: getBaseConfig } = require('@mui/internal-code-infra/babel-config');
 
 /**
  * @typedef {import('@babel/core')} babel
  */
 
-/**
- * @param {string} relativeToBabelConf
- * @returns {string}
- */
-function resolveAliasPath(relativeToBabelConf) {
-  const resolvedPath = path.relative(process.cwd(), path.resolve(__dirname, relativeToBabelConf));
-  return `./${resolvedPath.replace('\\', '/')}`;
-}
-
 /** @type {babel.ConfigFunction} */
 module.exports = function getBabelConfig(api) {
   const baseConfig = getBaseConfig(api);
-
-  const defaultAlias = {
-    '@mui/internal-docs-infra': resolveAliasPath('./packages/docs-infra/src'),
-  };
 
   return {
     ...baseConfig,
@@ -43,45 +28,5 @@ module.exports = function getBabelConfig(api) {
         plugins: [['@mui/internal-babel-plugin-resolve-imports', false]],
       },
     ],
-    env: {
-      coverage: {
-        plugins: [
-          'babel-plugin-istanbul',
-          [
-            'babel-plugin-module-resolver',
-            {
-              root: ['./'],
-              alias: defaultAlias,
-            },
-          ],
-        ],
-      },
-      development: {
-        plugins: [
-          [
-            'babel-plugin-module-resolver',
-            {
-              alias: {
-                ...defaultAlias,
-                modules: './modules',
-              },
-              root: ['./'],
-            },
-          ],
-        ],
-      },
-      test: {
-        sourceMaps: 'both',
-        plugins: [
-          [
-            'babel-plugin-module-resolver',
-            {
-              root: ['./'],
-              alias: defaultAlias,
-            },
-          ],
-        ],
-      },
-    },
   };
 };

--- a/packages/babel-plugin-display-name/package.json
+++ b/packages/babel-plugin-display-name/package.json
@@ -33,8 +33,8 @@
     "@types/babel__helper-plugin-utils": "7.10.3"
   },
   "peerDependencies": {
-    "@babel/core": "7",
-    "@babel/preset-react": "7"
+    "@babel/core": "^7.0.0 || ^8.0.0",
+    "@babel/preset-react": "^7.0.0 || ^8.0.0"
   },
   "keywords": [
     "displayName",

--- a/packages/babel-plugin-display-name/src/index.js
+++ b/packages/babel-plugin-display-name/src/index.js
@@ -34,7 +34,7 @@ function applyAllowedCallees(mapping) {
 
 module.exports = /** @type {any} */ (
   declare((api, /** @type {import('./index.d.ts').PluginOptions} */ options) => {
-    api.assertVersion(7);
+    api.assertVersion('^7.0.0 || ^8.0.0');
 
     calleeModuleMapping.clear();
 

--- a/packages/babel-plugin-minify-errors/package.json
+++ b/packages/babel-plugin-minify-errors/package.json
@@ -32,7 +32,7 @@
     "babel-plugin-tester": "12.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "7"
+    "@babel/core": "^7.0.0 || ^8.0.0"
   },
   "sideEffects": false,
   "type": "commonjs",

--- a/packages/babel-plugin-resolve-imports/package.json
+++ b/packages/babel-plugin-resolve-imports/package.json
@@ -30,7 +30,7 @@
     "babel-plugin-tester": "12.0.0"
   },
   "peerDependencies": {
-    "@babel/core": "7"
+    "@babel/core": "^7.0.0 || ^8.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Groundwork for a future Babel 7 → 8 migration ([v8 guide](https://babeljs.io/docs/v8-migration/)). Config-level prerequisites are already met; this handles the leftovers.

- **Root `babel.config.js`**: drop the dead `env` block (`coverage`, `development`, `test`) and its alias helpers. `coverage` used `babel-plugin-istanbul` (coverage now runs via `@vitest/coverage-v8`); `development`/`test` aliased `@mui/internal-docs-infra` via `babel-plugin-module-resolver` (vitest resolves it through the package `exports`). Neither plugin is a declared dependency. `overrides` unchanged.
- **Internal plugins**: widen `@babel/core` (and `@babel/preset-react`) peerDeps from `"7"` to `"^7.0.0 || ^8.0.0"`, and relax `api.assertVersion(7)` in display-name to match.

All 53 plugin tests pass on the current Babel 7.29.