### PR TITLE
[docs-infra] Validate page index against rendered markdown

### DIFF
--- a/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.test.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.test.ts
@@ -1410,6 +1410,51 @@ A button component.
         }),
       ).resolves.toBeUndefined();
     });
+
+    it('should not throw when only non-persisted fields differ and errorIfOutOfDate is true', async () => {
+      const metadata: PageMetadata = {
+        slug: 'button',
+        path: './button/page.mdx',
+        title: 'Button',
+        description: 'A button component.',
+      };
+
+      // First create the index from clean metadata.
+      await syncPageIndex({
+        pagePath: join(TEST_DIR, 'components', 'button', 'page.mdx'),
+        metadata,
+        indexTitle: 'Components',
+        baseDir: TEST_DIR,
+      });
+
+      // Freshly extracted metadata carries mdast AST node positions in its markdown
+      // fields. These never reach the persisted index (metadataToMarkdown strips them),
+      // so the raw JSON differs from the committed page while the rendered markdown is
+      // identical. This must not be reported as out of date.
+      const freshMetadata: PageMetadata = {
+        ...metadata,
+        descriptionMarkdown: [
+          {
+            type: 'text',
+            value: 'A button component.',
+            position: {
+              start: { line: 3, column: 1, offset: 0 },
+              end: { line: 3, column: 20, offset: 19 },
+            },
+          },
+        ],
+      };
+
+      await expect(
+        syncPageIndex({
+          pagePath: join(TEST_DIR, 'components', 'button', 'page.mdx'),
+          metadata: freshMetadata,
+          indexTitle: 'Components',
+          baseDir: TEST_DIR,
+          errorIfOutOfDate: true,
+        }),
+      ).resolves.toBeUndefined();
+    });
   });
 
   describe('autogeneration marker check', () => {

--- a/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
@@ -243,6 +243,64 @@ async function savePageIndexCache({
 }
 
 /**
+ * Merges the incoming metadata into the source pages (keyed by path, matching
+ * mergeMetadataMarkdown's logic) and renders the index markdown exactly as it is
+ * persisted. Shared by the writer and the `errorIfOutOfDate` validation path so the two
+ * always agree on what the index should contain - otherwise validation could render
+ * differently from the writer and flag an up-to-date file (or miss a stale one).
+ */
+async function renderIndexPages(
+  sourceMarkdown: string | undefined,
+  sourcePages: PageMetadata[],
+  metadataArray: PageMetadata[],
+  {
+    indexTitle,
+    indexWrapperComponent,
+    preserveExistingTitleAndSlug,
+    relativeIndexPath,
+  }: {
+    indexTitle: string;
+    indexWrapperComponent?: string;
+    preserveExistingTitleAndSlug?: boolean;
+    relativeIndexPath?: string;
+  },
+): Promise<{
+  allPages: PageMetadata[];
+  merged: Awaited<ReturnType<typeof mergeMetadataPages>>;
+  finalMarkdown: string;
+}> {
+  // Build a map keyed by path (not slug) to match mergeMetadataMarkdown's logic.
+  const updatedPagesMap = new Map<string, PageMetadata>();
+  // First, add all source pages.
+  for (const page of sourcePages) {
+    updatedPagesMap.set(page.path, page);
+  }
+  // Then update/add the new metadata items.
+  for (const metaItem of metadataArray) {
+    updatedPagesMap.set(metaItem.path, metaItem);
+  }
+  // The COMPLETE list of pages that should exist.
+  const allPages = Array.from(updatedPagesMap.values());
+
+  // mergeMetadataPages preserves the order from sourceMarkdown and returns the normalized
+  // metadata that renders to finalMarkdown - reused by the writer to populate the cache
+  // without re-parsing what it just wrote.
+  const merged = await mergeMetadataPages(
+    sourceMarkdown,
+    { title: indexTitle, pages: allPages },
+    { indexWrapperComponent, preserveExistingTitleAndSlug },
+  );
+  const finalMarkdown = await metadataToMarkdown(merged.metadata, {
+    editableMarker: merged.editableMarker,
+    indexWrapperComponent: merged.indexWrapperComponent,
+    // Only include path in the comment when baseDir is set (otherwise it's an absolute path).
+    path: relativeIndexPath,
+  });
+
+  return { allPages, merged, finalMarkdown };
+}
+
+/**
  * Updates the parent directory's index file with metadata from a page.
  *
  * This function:
@@ -371,6 +429,21 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
     }
   }
 
+  // Refresh the page-index cache from the committed markdown for the "nothing to write"
+  // exits, so the next cold loadServerPageIndex read stays warm without re-parsing.
+  const saveExistingIndexCache = async () => {
+    if (cacheDir && existingMetadata) {
+      await savePageIndexCache({
+        cacheDir,
+        indexPath,
+        rootContext,
+        markdown: existingContent,
+        metadata: existingMetadata,
+        defaultPageMetadata: false,
+      });
+    }
+  };
+
   // Step 3: Check if any of our metadata items need updating
   let needsUpdate = false;
   for (const metaItem of metadataArray) {
@@ -392,16 +465,7 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
   }
 
   if (!needsUpdate) {
-    if (cacheDir && existingMetadata) {
-      await savePageIndexCache({
-        cacheDir,
-        indexPath,
-        rootContext,
-        markdown: existingContent,
-        metadata: existingMetadata,
-        defaultPageMetadata: false,
-      });
-    }
+    await saveExistingIndexCache();
 
     // All pages are already up-to-date, no need to acquire lock or write the index.
     return;
@@ -412,32 +476,23 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
   // that never reach the persisted index (volatile AST node positions, or metadata that
   // mergeMetadataPages fills in from the existing markdown). Those produce false positives.
   // Determine whether the index is genuinely out of date by rendering the exact markdown
-  // the writer would produce (see Step 6 below) and comparing it to what is committed on
-  // disk. Only fail when the rendered output actually differs.
+  // the writer would produce and comparing it to what is committed on disk. Only fail when
+  // the rendered output actually differs. This is validation only - it never writes, so it
+  // works from the pre-lock read (existingMarkdown/existingPages) rather than re-reading
+  // under a lock like the writer does.
   if (errorIfOutOfDate) {
-    const updatedPagesMap = new Map<string, PageMetadata>();
-    for (const page of existingPages) {
-      updatedPagesMap.set(page.path, page);
-    }
-    for (const metaItem of metadataArray) {
-      updatedPagesMap.set(metaItem.path, metaItem);
-    }
-    const allPages = Array.from(updatedPagesMap.values());
-
     const relativeIndexPath = baseDir ? relative(resolve(baseDir), indexPath) : undefined;
-    const merged = await mergeMetadataPages(
+    const { finalMarkdown } = await renderIndexPages(
       existingMarkdown,
+      existingPages,
+      metadataArray,
       {
-        title: indexTitle,
-        pages: allPages,
+        indexTitle,
+        indexWrapperComponent,
+        preserveExistingTitleAndSlug,
+        relativeIndexPath,
       },
-      { indexWrapperComponent, preserveExistingTitleAndSlug },
     );
-    const finalMarkdown = await metadataToMarkdown(merged.metadata, {
-      editableMarker: merged.editableMarker,
-      indexWrapperComponent: merged.indexWrapperComponent,
-      path: relativeIndexPath,
-    });
 
     if (existingContent !== finalMarkdown) {
       const relativeThrowPath = baseDir ? relative(resolve(baseDir), indexPath) : indexPath;
@@ -448,16 +503,7 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
     }
 
     // The rendered markdown matches what is committed - nothing is actually out of date.
-    if (cacheDir && existingMetadata) {
-      await savePageIndexCache({
-        cacheDir,
-        indexPath,
-        rootContext,
-        markdown: existingContent,
-        metadata: existingMetadata,
-        defaultPageMetadata: false,
-      });
-    }
+    await saveExistingIndexCache();
     return;
   }
 
@@ -505,45 +551,19 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
       }
     }
 
-    // For batch updates, merge the metadata items with existing pages
-    // Build a map keyed by path (not slug) to match mergeMetadataMarkdown's logic
-    const updatedPagesMap = new Map<string, PageMetadata>();
-
-    // First, add all current pages
-    for (const page of currentPages) {
-      updatedPagesMap.set(page.path, page);
-    }
-
-    // Then update/add the new metadata items
-    for (const metaItem of metadataArray) {
-      updatedPagesMap.set(metaItem.path, metaItem);
-    }
-
-    // Convert back to array - this is the COMPLETE list of pages that should exist
-    const allPages = Array.from(updatedPagesMap.values());
+    // Re-merge with the latest content re-read under the lock, passing the COMPLETE list
+    // of pages. The returned normalized metadata is reused below to populate the cache
+    // without re-parsing what we just wrote.
+    const relativeIndexPath = baseDir ? relative(resolve(baseDir), indexPath) : undefined;
+    const { allPages, merged, finalMarkdown } = await renderIndexPages(
+      currentMarkdown,
+      currentPages,
+      metadataArray,
+      { indexTitle, indexWrapperComponent, preserveExistingTitleAndSlug, relativeIndexPath },
+    );
 
     // Store for parent update
     mergedPages = allPages;
-
-    // Re-merge with the latest content, passing the COMPLETE list of pages.
-    // mergeMetadataPages preserves the order from currentMarkdown and returns the
-    // normalized metadata that renders to finalMarkdown - reused below to populate
-    // the cache without re-parsing what we just wrote.
-    // Only include path in the comment when baseDir is set (otherwise it's an absolute path)
-    const relativeIndexPath = baseDir ? relative(resolve(baseDir), indexPath) : undefined;
-    const merged = await mergeMetadataPages(
-      currentMarkdown,
-      {
-        title: indexTitle,
-        pages: allPages,
-      },
-      { indexWrapperComponent, preserveExistingTitleAndSlug },
-    );
-    const finalMarkdown = await metadataToMarkdown(merged.metadata, {
-      editableMarker: merged.editableMarker,
-      indexWrapperComponent: merged.indexWrapperComponent,
-      path: relativeIndexPath,
-    });
 
     // Defensive check
     if (!finalMarkdown || !finalMarkdown.trim()) {

--- a/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
@@ -407,13 +407,58 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
     return;
   }
 
-  // If errorIfOutOfDate is true, throw an error instead of updating
+  // If errorIfOutOfDate is true, the writer would refuse to touch the file. The coarse
+  // per-page comparison above compares the raw in-memory metadata, which contains fields
+  // that never reach the persisted index (volatile AST node positions, or metadata that
+  // mergeMetadataPages fills in from the existing markdown). Those produce false positives.
+  // Determine whether the index is genuinely out of date by rendering the exact markdown
+  // the writer would produce (see Step 6 below) and comparing it to what is committed on
+  // disk. Only fail when the rendered output actually differs.
   if (errorIfOutOfDate) {
-    const relativeIndexPath = baseDir ? relative(resolve(baseDir), indexPath) : indexPath;
-    throw new Error(
-      `Index file is out of date: ${relativeIndexPath}\n` +
-        `Please run the validation command (or next build) locally and commit the updated index files.`,
+    const updatedPagesMap = new Map<string, PageMetadata>();
+    for (const page of existingPages) {
+      updatedPagesMap.set(page.path, page);
+    }
+    for (const metaItem of metadataArray) {
+      updatedPagesMap.set(metaItem.path, metaItem);
+    }
+    const allPages = Array.from(updatedPagesMap.values());
+
+    const relativeIndexPath = baseDir ? relative(resolve(baseDir), indexPath) : undefined;
+    const merged = await mergeMetadataPages(
+      existingMarkdown,
+      {
+        title: indexTitle,
+        pages: allPages,
+      },
+      { indexWrapperComponent, preserveExistingTitleAndSlug },
     );
+    const finalMarkdown = await metadataToMarkdown(merged.metadata, {
+      editableMarker: merged.editableMarker,
+      indexWrapperComponent: merged.indexWrapperComponent,
+      path: relativeIndexPath,
+    });
+
+    if (existingContent !== finalMarkdown) {
+      const relativeThrowPath = baseDir ? relative(resolve(baseDir), indexPath) : indexPath;
+      throw new Error(
+        `Index file is out of date: ${relativeThrowPath}\n` +
+          `Please run the validation command (or next build) locally and commit the updated index files.`,
+      );
+    }
+
+    // The rendered markdown matches what is committed - nothing is actually out of date.
+    if (cacheDir && existingMetadata) {
+      await savePageIndexCache({
+        cacheDir,
+        indexPath,
+        rootContext,
+        markdown: existingContent,
+        metadata: existingMetadata,
+        defaultPageMetadata: false,
+      });
+    }
+    return;
   }
 
   // Step 4: Ensure the file exists before locking (proper-lockfile requires an existing file)

--- a/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/syncPageIndex.ts
@@ -495,14 +495,12 @@ export async function syncPageIndex(options: SyncPageIndexOptions): Promise<void
     );
 
     if (existingContent !== finalMarkdown) {
-      const relativeThrowPath = baseDir ? relative(resolve(baseDir), indexPath) : indexPath;
       throw new Error(
-        `Index file is out of date: ${relativeThrowPath}\n` +
+        `Index file is out of date: ${relativeIndexPath ?? indexPath}\n` +
           `Please run the validation command (or next build) locally and commit the updated index files.`,
       );
     }
 
-    // The rendered markdown matches what is committed - nothing is actually out of date.
     await saveExistingIndexCache();
     return;
   }


### PR DESCRIPTION
## Problem

The Netlify build for #1600 fails with:

```
Failed to update page index for .../docs-infra/components/code-provider/page.mdx
Error: Index file is out of date: app/docs-infra/components/page.mdx
Please run the validation command (or next build) locally and commit the updated index files.
```

But running `next build` locally regenerates **nothing** — the index files are already up to date. So the recommended remedy does not work, and the failure recurs (72 spurious errors across essentially every index).

## Root cause

`syncPageIndex`'s `errorIfOutOfDate` path (used in CI, gated on `process.env.CI`) threw as soon as the coarse per-page check found *any* difference:

```js
JSON.stringify(existingPage) !== JSON.stringify(metaItem)
```

That comparison includes fields that never reach the persisted index markdown — volatile mdast node `position` data, and metadata that `mergeMetadataPages` fills in from the existing markdown. The **writer** already ignores these: it only writes when the *rendered* markdown differs (`currentContent !== finalMarkdown`). So locally (write mode) nothing changed, while CI (error mode) failed on the same, genuinely-up-to-date files.

## Fix

In the `errorIfOutOfDate` branch, render the exact markdown the writer would produce and only fail when it differs from what is committed on disk — making CI validation consistent with the writer's own definition of "out of date".

## Verification

- `CI=true pnpm docs:build` now completes with 0 out-of-date errors and no index files changed (previously 72 errors).
- A genuinely out-of-date index still throws (existing test preserved).
- Added a regression test covering the false-positive case (JSON differs via volatile `position` data, rendered markdown identical → must not throw). It fails without the fix.
- `pnpm test --run` (5556 tests), `pnpm typescript`, `pnpm eslint`, `pnpm prettier` all pass.

Merging this to master unblocks the Netlify check on #1600 (and any other branch that hits the same latent false-positive).