### PR TITLE
[code-infra] Use Welch's t-test and adaptive sampling in benchmark comparison

### DIFF
--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -6,9 +6,8 @@ import type { BenchmarkReport, BenchmarkReportEntry, MetricDefinition } from './
 import { makeReport, makeReportFromConfig, makeStatReport, statReport } from './test-fixtures';
 
 // Tight variance + adequate count so duration deltas resolve crisply: a large delta is unambiguously
-// significant, a sub-5%-effect-size delta is unambiguously neutral — no p-values near the boundary.
-const STD_DEV = 2;
-const COUNT = 20;
+// significant, a sub-5%-effect-size delta unambiguously neutral — no p-values near the boundary.
+const statAt = (entries: Record<string, number>) => makeStatReport(entries, 2, 20);
 
 // A single benchmark whose duration/renders are neutral, so the only signal is one metric.
 function metricReport(
@@ -79,8 +78,8 @@ function paintReport(paintMean: number): BenchmarkComparisonInput {
 describe('buildBenchmarkMarkdownReport', () => {
   it('drops within-noise rows but keeps significant regressions', () => {
     const report = compareBenchmarkReports(
-      makeStatReport({ Button: 150, Card: 103 }, STD_DEV, COUNT), // Card +3%: below effect floor
-      makeStatReport({ Button: 100, Card: 100 }, STD_DEV, COUNT),
+      statAt({ Button: 150, Card: 103 }), // Card +3%: below effect floor
+      statAt({ Button: 100, Card: 100 }),
     );
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).toContain('Button');
@@ -97,8 +96,8 @@ describe('buildBenchmarkMarkdownReport', () => {
 
   it('renders "No significant changes" when every entry is within noise', () => {
     const report = compareBenchmarkReports(
-      makeStatReport({ Button: 103, Card: 98 }, STD_DEV, COUNT), // both within ±3%
-      makeStatReport({ Button: 100, Card: 100 }, STD_DEV, COUNT),
+      statAt({ Button: 103, Card: 98 }), // both within ±3%
+      statAt({ Button: 100, Card: 100 }),
     );
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).toContain('No significant changes');
@@ -107,8 +106,8 @@ describe('buildBenchmarkMarkdownReport', () => {
 
   it('includes the details link in the "No significant changes" branch', () => {
     const report = compareBenchmarkReports(
-      makeStatReport({ Button: 103, Card: 98 }, STD_DEV, COUNT),
-      makeStatReport({ Button: 100, Card: 100 }, STD_DEV, COUNT),
+      statAt({ Button: 103, Card: 98 }),
+      statAt({ Button: 100, Card: 100 }),
     );
     const markdown = buildBenchmarkMarkdownReport(report, {
       reportUrl: 'https://example.com/details',
@@ -124,10 +123,7 @@ describe('buildBenchmarkMarkdownReport', () => {
       current[`Test${i}`] = 200;
       base[`Test${i}`] = 100;
     }
-    const report = compareBenchmarkReports(
-      makeStatReport(current, STD_DEV, COUNT),
-      makeStatReport(base, STD_DEV, COUNT),
-    );
+    const report = compareBenchmarkReports(statAt(current), statAt(base));
     const markdown = buildBenchmarkMarkdownReport(report, { maxRows: 5 });
     expect(markdown).toContain('…and 2 more');
     expect(markdown).not.toContain('within noise');
@@ -140,10 +136,7 @@ describe('buildBenchmarkMarkdownReport', () => {
       current[`Stable${i}`] = 103; // +3%: below effect floor
       base[`Stable${i}`] = 100;
     }
-    const report = compareBenchmarkReports(
-      makeStatReport(current, STD_DEV, COUNT),
-      makeStatReport(base, STD_DEV, COUNT),
-    );
+    const report = compareBenchmarkReports(statAt(current), statAt(base));
     const markdown = buildBenchmarkMarkdownReport(report, {
       maxRows: 5,
       reportUrl: 'https://example.com/details',
@@ -163,16 +156,13 @@ describe('buildBenchmarkMarkdownReport', () => {
       current[`Stable${i}`] = 103; // +3%: below effect floor
       base[`Stable${i}`] = 100;
     }
-    const report = compareBenchmarkReports(
-      makeStatReport(current, STD_DEV, COUNT),
-      makeStatReport(base, STD_DEV, COUNT),
-    );
+    const report = compareBenchmarkReports(statAt(current), statAt(base));
     const markdown = buildBenchmarkMarkdownReport(report, { maxRows: 5 });
     expect(markdown).toContain('…and 2 more (+4 within noise)');
   });
 
   it('renders a plain table without totals or diff columns when hasBase is false', () => {
-    const report = compareBenchmarkReports(makeStatReport({ Button: 100 }, STD_DEV, COUNT), null);
+    const report = compareBenchmarkReports(statAt({ Button: 100 }), null);
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).not.toContain('Total duration');
     expect(markdown).not.toContain('🔺');

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -25,6 +25,9 @@ function statReport(mean: number, stdDev: number, count: number): BenchmarkCompa
   const entry: BenchmarkReportEntry = {
     iterations: count,
     totalDuration: mean,
+    // Single render, so the total-duration distribution equals the render's.
+    totalStdDev: stdDev,
+    totalCount: count,
     renders: [
       {
         id: 'render-0',

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -3,7 +3,12 @@ import { buildBenchmarkMarkdownReport } from './buildMarkdownReport';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
 import type { BenchmarkComparisonInput } from './compareBenchmarkReports';
 import type { BenchmarkReport, BenchmarkReportEntry, MetricDefinition } from './types';
-import { makeReport, makeReportFromConfig } from './test-fixtures';
+import { makeReport, makeReportFromConfig, makeStatReport, statReport } from './test-fixtures';
+
+// Tight variance + adequate count so duration deltas resolve crisply: a large delta is unambiguously
+// significant, a sub-5%-effect-size delta is unambiguously neutral — no p-values near the boundary.
+const STD_DEV = 2;
+const COUNT = 20;
 
 // A single benchmark whose duration/renders are neutral, so the only signal is one metric.
 function metricReport(
@@ -18,32 +23,6 @@ function metricReport(
     metrics: { [name]: { mean, stdDev: 0, outliers: 0 } },
   };
   return { report: { Bench: entry }, metricDefinitions: definitions };
-}
-
-/** A single-render benchmark carrying stdDev + sample count, so the comparison runs a Welch test. */
-function statReport(mean: number, stdDev: number, count: number): BenchmarkComparisonInput {
-  const entry: BenchmarkReportEntry = {
-    iterations: count,
-    totalDuration: mean,
-    // Single render, so the total-duration distribution equals the render's.
-    totalStdDev: stdDev,
-    totalCount: count,
-    renders: [
-      {
-        id: 'render-0',
-        phase: 'mount',
-        startTime: 0,
-        actualDuration: mean,
-        stdDev,
-        rawMean: mean,
-        rawStdDev: stdDev,
-        outliers: 0,
-        count,
-      },
-    ],
-    metrics: {},
-  };
-  return { report: { Bench: entry } };
 }
 
 const alarmDefinitions: Record<string, MetricDefinition> = {
@@ -100,8 +79,8 @@ function paintReport(paintMean: number): BenchmarkComparisonInput {
 describe('buildBenchmarkMarkdownReport', () => {
   it('drops within-noise rows but keeps significant regressions', () => {
     const report = compareBenchmarkReports(
-      makeReport({ Button: 150, Card: 105 }),
-      makeReport({ Button: 100, Card: 100 }),
+      makeStatReport({ Button: 150, Card: 103 }, STD_DEV, COUNT), // Card +3%: below effect floor
+      makeStatReport({ Button: 100, Card: 100 }, STD_DEV, COUNT),
     );
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).toContain('Button');
@@ -118,8 +97,8 @@ describe('buildBenchmarkMarkdownReport', () => {
 
   it('renders "No significant changes" when every entry is within noise', () => {
     const report = compareBenchmarkReports(
-      makeReport({ Button: 110, Card: 95 }),
-      makeReport({ Button: 100, Card: 100 }),
+      makeStatReport({ Button: 103, Card: 98 }, STD_DEV, COUNT), // both within ±3%
+      makeStatReport({ Button: 100, Card: 100 }, STD_DEV, COUNT),
     );
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).toContain('No significant changes');
@@ -128,8 +107,8 @@ describe('buildBenchmarkMarkdownReport', () => {
 
   it('includes the details link in the "No significant changes" branch', () => {
     const report = compareBenchmarkReports(
-      makeReport({ Button: 110, Card: 95 }),
-      makeReport({ Button: 100, Card: 100 }),
+      makeStatReport({ Button: 103, Card: 98 }, STD_DEV, COUNT),
+      makeStatReport({ Button: 100, Card: 100 }, STD_DEV, COUNT),
     );
     const markdown = buildBenchmarkMarkdownReport(report, {
       reportUrl: 'https://example.com/details',
@@ -145,7 +124,10 @@ describe('buildBenchmarkMarkdownReport', () => {
       current[`Test${i}`] = 200;
       base[`Test${i}`] = 100;
     }
-    const report = compareBenchmarkReports(makeReport(current), makeReport(base));
+    const report = compareBenchmarkReports(
+      makeStatReport(current, STD_DEV, COUNT),
+      makeStatReport(base, STD_DEV, COUNT),
+    );
     const markdown = buildBenchmarkMarkdownReport(report, { maxRows: 5 });
     expect(markdown).toContain('…and 2 more');
     expect(markdown).not.toContain('within noise');
@@ -155,10 +137,13 @@ describe('buildBenchmarkMarkdownReport', () => {
     const current: Record<string, number> = { Regression: 150 };
     const base: Record<string, number> = { Regression: 100 };
     for (let i = 0; i < 3; i += 1) {
-      current[`Stable${i}`] = 105;
+      current[`Stable${i}`] = 103; // +3%: below effect floor
       base[`Stable${i}`] = 100;
     }
-    const report = compareBenchmarkReports(makeReport(current), makeReport(base));
+    const report = compareBenchmarkReports(
+      makeStatReport(current, STD_DEV, COUNT),
+      makeStatReport(base, STD_DEV, COUNT),
+    );
     const markdown = buildBenchmarkMarkdownReport(report, {
       maxRows: 5,
       reportUrl: 'https://example.com/details',
@@ -175,16 +160,19 @@ describe('buildBenchmarkMarkdownReport', () => {
       base[`Reg${i}`] = 100;
     }
     for (let i = 0; i < 4; i += 1) {
-      current[`Stable${i}`] = 105;
+      current[`Stable${i}`] = 103; // +3%: below effect floor
       base[`Stable${i}`] = 100;
     }
-    const report = compareBenchmarkReports(makeReport(current), makeReport(base));
+    const report = compareBenchmarkReports(
+      makeStatReport(current, STD_DEV, COUNT),
+      makeStatReport(base, STD_DEV, COUNT),
+    );
     const markdown = buildBenchmarkMarkdownReport(report, { maxRows: 5 });
     expect(markdown).toContain('…and 2 more (+4 within noise)');
   });
 
   it('renders a plain table without totals or diff columns when hasBase is false', () => {
-    const report = compareBenchmarkReports(makeReport({ Button: 100 }), null);
+    const report = compareBenchmarkReports(makeStatReport({ Button: 100 }, STD_DEV, COUNT), null);
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).not.toContain('Total duration');
     expect(markdown).not.toContain('🔺');
@@ -226,6 +214,31 @@ describe('buildBenchmarkMarkdownReport', () => {
     const markdown = buildBenchmarkMarkdownReport(report);
     expect(markdown).not.toContain('No significant changes');
     expect(markdown).toContain('| Test |');
+  });
+
+  // Uploads made before per-series sample counts existed carry no stdDev/count, so the comparison
+  // can't run a Welch test and falls back to the fixed ±20% relative band. These lock that
+  // rendering; they can be deleted once the legacy fallback is retired.
+  describe('legacy uploads (no sample counts)', () => {
+    it('flags a past-±20% regression via the noise band, with no p-value annotation', () => {
+      const report = compareBenchmarkReports(
+        makeReport({ Button: 130 }),
+        makeReport({ Button: 100 }),
+      );
+      const markdown = buildBenchmarkMarkdownReport(report);
+      expect(markdown).toContain('Button');
+      expect(markdown).toContain('🔺');
+      expect(markdown).not.toMatch(/p[=<]/); // no Welch test ran, so no p-value is shown
+    });
+
+    it('drops a within-±20% change as noise', () => {
+      const report = compareBenchmarkReports(
+        makeReport({ Button: 110 }),
+        makeReport({ Button: 100 }),
+      );
+      const markdown = buildBenchmarkMarkdownReport(report);
+      expect(markdown).toContain('No significant changes');
+    });
   });
 
   describe('metric alarms', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.test.ts
@@ -20,6 +20,29 @@ function metricReport(
   return { report: { Bench: entry }, metricDefinitions: definitions };
 }
 
+/** A single-render benchmark carrying stdDev + sample count, so the comparison runs a Welch test. */
+function statReport(mean: number, stdDev: number, count: number): BenchmarkComparisonInput {
+  const entry: BenchmarkReportEntry = {
+    iterations: count,
+    totalDuration: mean,
+    renders: [
+      {
+        id: 'render-0',
+        phase: 'mount',
+        startTime: 0,
+        actualDuration: mean,
+        stdDev,
+        rawMean: mean,
+        rawStdDev: stdDev,
+        outliers: 0,
+        count,
+      },
+    ],
+    metrics: {},
+  };
+  return { report: { Bench: entry } };
+}
+
 const alarmDefinitions: Record<string, MetricDefinition> = {
   clicks: {
     kind: 'discrete',
@@ -81,6 +104,13 @@ describe('buildBenchmarkMarkdownReport', () => {
     expect(markdown).toContain('Button');
     expect(markdown).not.toContain('Card');
     expect(markdown).toContain('🔺');
+  });
+
+  it('annotates a flagged duration with its p-value when a Welch test ran', () => {
+    const report = compareBenchmarkReports(statReport(106, 1, 20), statReport(100, 1, 20));
+    const markdown = buildBenchmarkMarkdownReport(report);
+    expect(markdown).toContain('Bench');
+    expect(markdown).toMatch(/p[=<]/);
   });
 
   it('renders "No significant changes" when every entry is within noise', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
@@ -1,4 +1,10 @@
-import { formatMs, formatDiffMs, formatMetricDiff, percentFormatter } from '@/utils/formatters';
+import {
+  formatMs,
+  formatDiffMs,
+  formatMetricDiff,
+  formatPValue,
+  percentFormatter,
+} from '@/utils/formatters';
 import type {
   BenchmarkComparisonReport,
   ComparisonEntry,
@@ -19,12 +25,9 @@ const SEVERITY_PREFIX: Record<string, string> = {
   success: '▼',
 };
 
-/** Compact p-value annotation for the report, shown when a significance test actually ran. */
-function formatPValue(pValue: number | null): string {
-  if (pValue === null) {
-    return '';
-  }
-  return pValue < 0.001 ? ', p<0.001' : `, p=${pValue.toFixed(3)}`;
+/** p-value annotation for a diff cell (with a leading separator), shown only when a test ran. */
+function pValueAnnotation(pValue: number | null): string {
+  return pValue === null ? '' : `, ${formatPValue(pValue)}`;
 }
 
 function formatDiff(diff: DiffValue, unit: 'ms' | 'count'): string {
@@ -36,7 +39,7 @@ function formatDiff(diff: DiffValue, unit: 'ms' | 'count'): string {
     }
     const value = formatDiffMs(diff.absoluteDiff);
     const pct = percentFormatter.format(diff.relativeDiff);
-    return ` ${prefix}${value}<sup>(${pct}${formatPValue(diff.pValue)})</sup>`;
+    return ` ${prefix}${value}<sup>(${pct}${pValueAnnotation(diff.pValue)})</sup>`;
   }
 
   const sign = diff.absoluteDiff >= 0 ? '+' : '';

--- a/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/buildMarkdownReport.ts
@@ -19,6 +19,14 @@ const SEVERITY_PREFIX: Record<string, string> = {
   success: '▼',
 };
 
+/** Compact p-value annotation for the report, shown when a significance test actually ran. */
+function formatPValue(pValue: number | null): string {
+  if (pValue === null) {
+    return '';
+  }
+  return pValue < 0.001 ? ', p<0.001' : `, p=${pValue.toFixed(3)}`;
+}
+
 function formatDiff(diff: DiffValue, unit: 'ms' | 'count'): string {
   const prefix = SEVERITY_PREFIX[diff.severity] ?? '';
 
@@ -28,7 +36,7 @@ function formatDiff(diff: DiffValue, unit: 'ms' | 'count'): string {
     }
     const value = formatDiffMs(diff.absoluteDiff);
     const pct = percentFormatter.format(diff.relativeDiff);
-    return ` ${prefix}${value}<sup>(${pct})</sup>`;
+    return ` ${prefix}${value}<sup>(${pct}${formatPValue(diff.pValue)})</sup>`;
   }
 
   const sign = diff.absoluteDiff >= 0 ? '+' : '';

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -1,7 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
+import type { BenchmarkComparisonInput } from './compareBenchmarkReports';
 import type { BenchmarkReport, BenchmarkReportEntry, MetricDefinition } from './types';
 import { makeReport, makeReportFromConfig } from './test-fixtures';
+
+/** A single-render benchmark carrying the stdDev + sample count needed for a Welch's t-test. */
+function statReport(mean: number, stdDev: number, count: number): BenchmarkComparisonInput {
+  const entry: BenchmarkReportEntry = {
+    iterations: count,
+    totalDuration: mean,
+    renders: [
+      {
+        id: 'render-0',
+        phase: 'mount',
+        startTime: 0,
+        actualDuration: mean,
+        stdDev,
+        rawMean: mean,
+        rawStdDev: stdDev,
+        outliers: 0,
+        count,
+      },
+    ],
+    metrics: {},
+  };
+  return { report: { Bench: entry } };
+}
 
 function reportWithMetrics(metrics: Record<string, number>): BenchmarkReport {
   const entry: BenchmarkReportEntry = {
@@ -232,6 +256,55 @@ describe('compareBenchmarkReports', () => {
       const result = compareBenchmarkReports(currentReport, baseReport);
       const order = result.entries.map((item) => item.name);
       expect(order).toEqual(['DurationRegression', 'FewerRenders']);
+    });
+  });
+
+  describe('statistical gating (Welch)', () => {
+    it('flags a small but confident regression the legacy ±20% band would have missed', () => {
+      // +6% with tight variance across 20 samples — well within the old noise band, but clearly real.
+      const result = compareBenchmarkReports(statReport(106, 1, 20), statReport(100, 1, 20));
+      const entry = result.entries[0];
+      expect(entry.duration.severity).toBe('error');
+      expect(entry.duration.significant).toBe(true);
+      expect(entry.duration.pValue).not.toBeNull();
+      expect(entry.duration.hint).toContain('Regression');
+    });
+
+    it('leaves a large but noisy diff neutral when it is not statistically significant', () => {
+      // +30% (past the old 20% band) but swamped by variance — not significant, so not flagged.
+      const result = compareBenchmarkReports(statReport(130, 60, 20), statReport(100, 60, 20));
+      const entry = result.entries[0];
+      expect(entry.duration.severity).toBe('neutral');
+      expect(entry.duration.significant).toBe(false);
+      expect(entry.duration.hint).toContain('Not significant');
+    });
+
+    it('leaves a significant but sub-threshold change neutral (effect-size floor)', () => {
+      // +3% with tiny variance: statistically significant, but below the 5% minimum effect size.
+      const result = compareBenchmarkReports(statReport(103, 0.5, 20), statReport(100, 0.5, 20));
+      const entry = result.entries[0];
+      expect(entry.duration.severity).toBe('neutral');
+      expect(entry.duration.significant).toBe(true);
+      expect(entry.duration.hint).toContain('Below threshold');
+    });
+
+    it('flags a confident improvement as success', () => {
+      const result = compareBenchmarkReports(statReport(90, 1, 20), statReport(100, 1, 20));
+      const entry = result.entries[0];
+      expect(entry.duration.severity).toBe('success');
+      expect(entry.duration.hint).toContain('Improvement');
+    });
+
+    it('falls back to the legacy noise band when the baseline has no sample count', () => {
+      // Current side has counts, base side (an old upload) does not → no test possible.
+      const legacyBase = makeReport({ Bench: 100 }); // fixtures omit `count`
+      const result = compareBenchmarkReports(statReport(130, 1, 20), legacyBase);
+      const entry = result.entries[0];
+      // Legacy path: +30% is past ±20%, flagged, and no p-value is attached.
+      expect(entry.duration.severity).toBe('error');
+      expect(entry.duration.pValue).toBeNull();
+      expect(entry.duration.significant).toBe(false);
+      expect(entry.duration.hint).toContain('Regression');
     });
   });
 

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
 import type { BenchmarkComparisonInput } from './compareBenchmarkReports';
 import type { BenchmarkReport, BenchmarkReportEntry, MetricDefinition } from './types';
-import { makeReport, makeReportFromConfig, makeStatEntry, statReport } from './test-fixtures';
-
-// Grand-total pooling tests build multi-entry reports directly from statistical entries.
-const totalEntry = makeStatEntry;
+import {
+  makeReport,
+  makeReportFromConfig,
+  makeStatEntry as totalEntry,
+  statReport,
+} from './test-fixtures';
 
 /** A single-metric report whose metric carries the stdDev + count a Welch's t-test needs. */
 function reportWithMetricStats(

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -2,57 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { compareBenchmarkReports } from './compareBenchmarkReports';
 import type { BenchmarkComparisonInput } from './compareBenchmarkReports';
 import type { BenchmarkReport, BenchmarkReportEntry, MetricDefinition } from './types';
-import { makeReport, makeReportFromConfig } from './test-fixtures';
+import { makeReport, makeReportFromConfig, makeStatEntry, statReport } from './test-fixtures';
 
-/** A single-render benchmark carrying the stdDev + sample count needed for a Welch's t-test. */
-function statReport(mean: number, stdDev: number, count: number): BenchmarkComparisonInput {
-  const entry: BenchmarkReportEntry = {
-    iterations: count,
-    totalDuration: mean,
-    // Single render, so the total-duration distribution equals the render's.
-    totalStdDev: stdDev,
-    totalCount: count,
-    renders: [
-      {
-        id: 'render-0',
-        phase: 'mount',
-        startTime: 0,
-        actualDuration: mean,
-        stdDev,
-        rawMean: mean,
-        rawStdDev: stdDev,
-        outliers: 0,
-        count,
-      },
-    ],
-    metrics: {},
-  };
-  return { report: { Bench: entry } };
-}
-
-/** A single-render benchmark entry carrying total-duration stats, for grand-total pooling tests. */
-function totalEntry(mean: number, stdDev: number, count: number): BenchmarkReportEntry {
-  return {
-    iterations: count,
-    totalDuration: mean,
-    totalStdDev: stdDev,
-    totalCount: count,
-    renders: [
-      {
-        id: 'render-0',
-        phase: 'mount',
-        startTime: 0,
-        actualDuration: mean,
-        stdDev,
-        rawMean: mean,
-        rawStdDev: stdDev,
-        outliers: 0,
-        count,
-      },
-    ],
-    metrics: {},
-  };
-}
+// Grand-total pooling tests build multi-entry reports directly from statistical entries.
+const totalEntry = makeStatEntry;
 
 /** A single-metric report whose metric carries the stdDev + count a Welch's t-test needs. */
 function reportWithMetricStats(
@@ -122,45 +75,53 @@ function metricEntry(current: BenchmarkReport, base: BenchmarkReport, metricName
 }
 
 describe('compareBenchmarkReports', () => {
-  it('marks diffs within ±20% as neutral noise', () => {
-    const result = compareBenchmarkReports(
-      makeReport({ Button: 110 }),
-      makeReport({ Button: 100 }),
-    );
-    const entry = result.entries.find((item) => item.name === 'Button')!;
-    expect(entry.duration.severity).toBe('neutral');
-    expect(entry.duration.hint).toContain('Within noise');
-  });
+  // Uploads made before per-series sample counts existed carry no stdDev/count, so the comparison
+  // can't run a Welch test and falls back to the fixed ±20% relative band. These lock that fallback;
+  // they can be deleted once it is retired.
+  describe('legacy uploads (no sample counts)', () => {
+    it('marks diffs within ±20% as neutral noise', () => {
+      const result = compareBenchmarkReports(
+        makeReport({ Button: 110 }),
+        makeReport({ Button: 100 }),
+      );
+      const entry = result.entries.find((item) => item.name === 'Button')!;
+      expect(entry.duration.severity).toBe('neutral');
+      expect(entry.duration.hint).toContain('Within noise');
+    });
 
-  it('flags diffs above +20% as regression', () => {
-    const result = compareBenchmarkReports(
-      makeReport({ Button: 130 }),
-      makeReport({ Button: 100 }),
-    );
-    const entry = result.entries.find((item) => item.name === 'Button')!;
-    expect(entry.duration.severity).toBe('error');
-    expect(entry.duration.hint).toContain('Regression');
-  });
+    it('flags diffs above +20% as regression', () => {
+      const result = compareBenchmarkReports(
+        makeReport({ Button: 130 }),
+        makeReport({ Button: 100 }),
+      );
+      const entry = result.entries.find((item) => item.name === 'Button')!;
+      expect(entry.duration.severity).toBe('error');
+      expect(entry.duration.hint).toContain('Regression');
+    });
 
-  it('flags diffs below -20% as improvement', () => {
-    const result = compareBenchmarkReports(makeReport({ Button: 70 }), makeReport({ Button: 100 }));
-    const entry = result.entries.find((item) => item.name === 'Button')!;
-    expect(entry.duration.severity).toBe('success');
-    expect(entry.duration.hint).toContain('Improvement');
-  });
+    it('flags diffs below -20% as improvement', () => {
+      const result = compareBenchmarkReports(
+        makeReport({ Button: 70 }),
+        makeReport({ Button: 100 }),
+      );
+      const entry = result.entries.find((item) => item.name === 'Button')!;
+      expect(entry.duration.severity).toBe('success');
+      expect(entry.duration.hint).toContain('Improvement');
+    });
 
-  it('treats an exactly-±20% diff as still within noise', () => {
-    const positive = compareBenchmarkReports(
-      makeReport({ Button: 120 }),
-      makeReport({ Button: 100 }),
-    );
-    expect(positive.entries[0].duration.severity).toBe('neutral');
+    it('treats an exactly-±20% diff as still within noise', () => {
+      const positive = compareBenchmarkReports(
+        makeReport({ Button: 120 }),
+        makeReport({ Button: 100 }),
+      );
+      expect(positive.entries[0].duration.severity).toBe('neutral');
 
-    const negative = compareBenchmarkReports(
-      makeReport({ Button: 80 }),
-      makeReport({ Button: 100 }),
-    );
-    expect(negative.entries[0].duration.severity).toBe('neutral');
+      const negative = compareBenchmarkReports(
+        makeReport({ Button: 80 }),
+        makeReport({ Button: 100 }),
+      );
+      expect(negative.entries[0].duration.severity).toBe('neutral');
+    });
   });
 
   it('returns a "New" neutral diff for entries absent in base', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -9,6 +9,9 @@ function statReport(mean: number, stdDev: number, count: number): BenchmarkCompa
   const entry: BenchmarkReportEntry = {
     iterations: count,
     totalDuration: mean,
+    // Single render, so the total-duration distribution equals the render's.
+    totalStdDev: stdDev,
+    totalCount: count,
     renders: [
       {
         id: 'render-0',
@@ -293,6 +296,38 @@ describe('compareBenchmarkReports', () => {
       const entry = result.entries[0];
       expect(entry.duration.severity).toBe('success');
       expect(entry.duration.hint).toContain('Improvement');
+    });
+
+    it('tests Duration from the stored total stats, independent of per-render sample counts', () => {
+      // Renders deliberately carry no `count`; the Duration must still run a Welch test from the
+      // entry-level totalStdDev/totalCount rather than collapsing on a per-render count.
+      const withTotalStats = (totalDuration: number): BenchmarkComparisonInput => ({
+        report: {
+          Bench: {
+            iterations: 20,
+            totalDuration,
+            totalStdDev: 1,
+            totalCount: 20,
+            renders: [
+              {
+                id: 'r',
+                phase: 'mount',
+                startTime: 0,
+                actualDuration: totalDuration,
+                stdDev: 5,
+                rawMean: totalDuration,
+                rawStdDev: 5,
+                outliers: 0,
+              },
+            ],
+            metrics: {},
+          },
+        },
+      });
+      const result = compareBenchmarkReports(withTotalStats(106), withTotalStats(100));
+      const entry = result.entries[0];
+      expect(entry.duration.pValue).not.toBeNull(); // Welch ran despite renders lacking a count
+      expect(entry.duration.severity).toBe('error');
     });
 
     it('falls back to the legacy noise band when the baseline has no sample count', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -30,6 +30,47 @@ function statReport(mean: number, stdDev: number, count: number): BenchmarkCompa
   return { report: { Bench: entry } };
 }
 
+/** A single-render benchmark entry carrying total-duration stats, for grand-total pooling tests. */
+function totalEntry(mean: number, stdDev: number, count: number): BenchmarkReportEntry {
+  return {
+    iterations: count,
+    totalDuration: mean,
+    totalStdDev: stdDev,
+    totalCount: count,
+    renders: [
+      {
+        id: 'render-0',
+        phase: 'mount',
+        startTime: 0,
+        actualDuration: mean,
+        stdDev,
+        rawMean: mean,
+        rawStdDev: stdDev,
+        outliers: 0,
+        count,
+      },
+    ],
+    metrics: {},
+  };
+}
+
+/** A single-metric report whose metric carries the stdDev + count a Welch's t-test needs. */
+function reportWithMetricStats(
+  name: string,
+  mean: number,
+  stdDev: number,
+  count: number,
+): BenchmarkReport {
+  return {
+    Bench: {
+      iterations: count,
+      totalDuration: 0,
+      renders: [],
+      metrics: { [name]: { mean, stdDev, outliers: 0, count } },
+    },
+  };
+}
+
 function reportWithMetrics(metrics: Record<string, number>): BenchmarkReport {
   const entry: BenchmarkReportEntry = {
     iterations: 10,
@@ -341,6 +382,39 @@ describe('compareBenchmarkReports', () => {
       expect(entry.duration.significant).toBe(false);
       expect(entry.duration.hint).toContain('Regression');
     });
+
+    it('routes Duration to the legacy band when a count is present but the stdDev is missing', () => {
+      // A partial upload (count without stdDev) must not be read as zero-variance — that would
+      // fabricate a near-zero standard error and flag the small diff as a significant regression.
+      const base: BenchmarkComparisonInput = {
+        report: {
+          Bench: {
+            iterations: 20,
+            totalDuration: 100,
+            totalCount: 20, // present…
+            // totalStdDev intentionally absent
+            renders: [
+              {
+                id: 'render-0',
+                phase: 'mount',
+                startTime: 0,
+                actualDuration: 100,
+                stdDev: 1,
+                rawMean: 100,
+                rawStdDev: 1,
+                outliers: 0,
+                count: 20,
+              },
+            ],
+            metrics: {},
+          },
+        },
+      };
+      const result = compareBenchmarkReports(statReport(106, 1, 20), base);
+      const entry = result.entries[0];
+      expect(entry.duration.pValue).toBeNull(); // no test ran
+      expect(entry.duration.severity).toBe('neutral'); // +6% is within the legacy ±20% band
+    });
   });
 
   describe('custom metrics', () => {
@@ -393,6 +467,20 @@ describe('compareBenchmarkReports', () => {
         'scalar_tiered',
       );
       expect(metric.diff.severity).toBe('neutral');
+    });
+
+    it('labels a significant sub-band scalar change "Below threshold", not "Within noise"', () => {
+      // +3% with tight variance across 20 samples: statistically significant, but below the metric's
+      // 10% error band — a real change that just isn't big enough to flag. It must read differently
+      // from the untested "Within noise" fallback.
+      const metric = metricEntry(
+        reportWithMetricStats('scalar_alarm', 103, 0.5, 20),
+        reportWithMetricStats('scalar_alarm', 100, 0.5, 20),
+        'scalar_alarm',
+      );
+      expect(metric.diff.severity).toBe('neutral');
+      expect(metric.diff.significant).toBe(true);
+      expect(metric.diff.hint).toContain('Below threshold');
     });
 
     it('tiers discrete metrics by absolute count delta, inclusive of the band', () => {
@@ -470,6 +558,49 @@ describe('compareBenchmarkReports', () => {
       const metric = result.entries[0].metrics.find((entry) => entry.name === 'bytes')!;
       expect(metric.removed).toBe(true);
       expect(metric.format).toEqual({ style: 'unit', unit: 'byte' });
+    });
+  });
+
+  describe('grand-total duration', () => {
+    it('pools unequal-count benchmarks rather than collapsing on the smallest count', () => {
+      // A high-n, noisy benchmark (n=200) and a low-n, tight one (n=10). Pooling each benchmark's
+      // own standard error credits the high-n side's precision; the old min-count approach divided
+      // its variance by the smallest count, over-stating the total standard error.
+      const current = { report: { A: totalEntry(51, 3, 200), B: totalEntry(50, 1, 10) } };
+      const base = { report: { A: totalEntry(45, 3, 200), B: totalEntry(50, 1, 10) } };
+      const result = compareBenchmarkReports(current, base);
+      // Total 101 vs 95 = +6.3%, comfortably significant against the pooled standard error.
+      expect(result.totals.duration.pValue).not.toBeNull();
+      expect(result.totals.duration.significant).toBe(true);
+      expect(result.totals.duration.severity).toBe('error');
+    });
+
+    it('keeps testing the total when one benchmark is pinned to a single run', () => {
+      // The pinned benchmark has count 1 (no estimable variance). It contributes only its mean and
+      // must not collapse the entire Totals row onto the legacy ±20% band.
+      const current = { report: { A: totalEntry(106, 1, 20), Pinned: totalEntry(5, 0, 1) } };
+      const base = { report: { A: totalEntry(100, 1, 20), Pinned: totalEntry(5, 0, 1) } };
+      const result = compareBenchmarkReports(current, base);
+      // Total 111 vs 105 = +5.7%: tested (p-value present) and flagged, not silently neutral.
+      expect(result.totals.duration.pValue).not.toBeNull();
+      expect(result.totals.duration.severity).toBe('error');
+    });
+
+    it('falls back to the legacy band when a benchmark predates total sample counts', () => {
+      const legacyEntry: BenchmarkReportEntry = {
+        iterations: 20,
+        totalDuration: 50,
+        // no totalStdDev / totalCount
+        renders: [],
+        metrics: {},
+      };
+      const current = {
+        report: { A: totalEntry(106, 1, 20), Legacy: { ...legacyEntry, totalDuration: 53 } },
+      };
+      const base = { report: { A: totalEntry(100, 1, 20), Legacy: legacyEntry } };
+      const result = compareBenchmarkReports(current, base);
+      // One un-testable benchmark makes the grand total un-testable → legacy comparison, no p-value.
+      expect(result.totals.duration.pValue).toBeNull();
     });
   });
 

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.test.ts
@@ -575,15 +575,14 @@ describe('compareBenchmarkReports', () => {
       expect(result.totals.duration.severity).toBe('error');
     });
 
-    it('keeps testing the total when one benchmark is pinned to a single run', () => {
-      // The pinned benchmark has count 1 (no estimable variance). It contributes only its mean and
-      // must not collapse the entire Totals row onto the legacy ±20% band.
+    it('falls back to the legacy band when a benchmark is pinned to a single run', () => {
+      // The pinned benchmark has count 1 — no estimable variance. Its mean shift is still summed into
+      // the grand total, so testing it against only the other benchmarks' variance would flag
+      // single-sample noise as significant. The whole total drops to the legacy band instead.
       const current = { report: { A: totalEntry(106, 1, 20), Pinned: totalEntry(5, 0, 1) } };
       const base = { report: { A: totalEntry(100, 1, 20), Pinned: totalEntry(5, 0, 1) } };
       const result = compareBenchmarkReports(current, base);
-      // Total 111 vs 105 = +5.7%: tested (p-value present) and flagged, not silently neutral.
-      expect(result.totals.duration.pValue).not.toBeNull();
-      expect(result.totals.duration.severity).toBe('error');
+      expect(result.totals.duration.pValue).toBeNull();
     });
 
     it('falls back to the legacy band when a benchmark predates total sample counts', () => {

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -6,8 +6,8 @@ import type {
   MetricStats,
   RenderStats,
 } from './types';
-import { welchTTest, welchTTestFromComponents } from './welchTTest';
-import type { WelchResult } from './welchTTest';
+import { sampleComponent, welchTTest, welchTTestFromComponents } from './welchTTest';
+import type { WelchComponent, WelchResult } from './welchTTest';
 
 /** A report paired with its own metric definitions — the unit the comparison operates on. */
 export type BenchmarkComparisonInput = Pick<BenchmarkBaseUpload, 'report' | 'metricDefinitions'>;
@@ -483,15 +483,23 @@ function compareMetrics(
  * the reporter measured directly. `n` is absent on uploads made before `totalCount` existed, which
  * routes the Duration onto the legacy comparison path.
  */
+/**
+ * Whether an entry carries the total-duration stats (stdDev *and* count) a Welch test needs. A
+ * partial upload (one without the other) is not testable and routes onto the legacy path rather than
+ * being read as zero-variance — which would fabricate a near-zero standard error and flag noise as a
+ * significant regression.
+ */
+function hasTotalStats(
+  entry: BenchmarkReportEntry,
+): entry is BenchmarkReportEntry & { totalStdDev: number; totalCount: number } {
+  return entry.totalStdDev !== undefined && entry.totalCount !== undefined;
+}
+
 function entryTotalStats(entry: BenchmarkReportEntry): SeriesStats {
-  // Both fields are needed to run the test; a partial upload (a count without a stdDev, or vice
-  // versa) routes the Duration onto the legacy path rather than being read as zero-variance — which
-  // would fabricate a near-zero standard error and flag noise as a significant regression.
-  const hasStats = entry.totalStdDev !== undefined && entry.totalCount !== undefined;
   return {
     mean: entry.totalDuration,
     stdDev: entry.totalStdDev ?? 0,
-    n: hasStats ? entry.totalCount : undefined,
+    n: hasTotalStats(entry) ? entry.totalCount : undefined,
   };
 }
 
@@ -518,23 +526,27 @@ function createTotalFold(): TotalFold {
  *
  * - Missing `totalStdDev`/`totalCount` (legacy or partial upload) can't be tested → marks the whole
  *   total for the legacy fallback.
- * - Fewer than two samples (e.g. a benchmark pinned to `runs: 1`) has no estimable variance, so it
- *   contributes only its mean (accumulated separately) and is skipped here — one under-sampled
- *   benchmark must not silently disable the significance test for the entire suite.
- * - Otherwise its standard-error² (`σ²/(n-1)`, from the stored population stdDev) and Satterthwaite
- *   term add into the fold.
+ * - Fewer than two samples (e.g. a benchmark pinned to `runs: 1`) has no estimable variance, so
+ *   {@link sampleComponent} returns `null`; it contributes only its mean (accumulated separately) and
+ *   is skipped here — one under-sampled benchmark must not silently disable the significance test for
+ *   the entire suite.
+ * - Otherwise its Welch component (standard error² and Satterthwaite term) adds into the fold.
  */
 function foldEntryTotal(entry: BenchmarkReportEntry, fold: TotalFold): void {
-  if (entry.totalStdDev === undefined || entry.totalCount === undefined) {
+  if (!hasTotalStats(entry)) {
     fold.missing = true;
     return;
   }
-  if (entry.totalCount < 2) {
+  const component = sampleComponent({
+    mean: entry.totalDuration,
+    stdDev: entry.totalStdDev,
+    n: entry.totalCount,
+  });
+  if (!component) {
     return;
   }
-  const standardErrorSquared = (entry.totalStdDev * entry.totalStdDev) / (entry.totalCount - 1);
-  fold.standardErrorSquared += standardErrorSquared;
-  fold.satterthwaiteTerm += (standardErrorSquared * standardErrorSquared) / (entry.totalCount - 1);
+  fold.standardErrorSquared += component.standardErrorSquared;
+  fold.satterthwaiteTerm += component.satterthwaiteTerm;
 }
 
 function worstSeverityRank(item: ComparisonItem): number {
@@ -571,6 +583,15 @@ function compareItems(a: ComparisonItem, b: ComparisonItem): number {
   return Math.abs(b.duration.absoluteDiff) - Math.abs(a.duration.absoluteDiff);
 }
 
+/** Projects a completed fold plus the summed grand-total mean into the Welch component to test. */
+function foldToComponent(mean: number, fold: TotalFold): WelchComponent {
+  return {
+    mean,
+    standardErrorSquared: fold.standardErrorSquared,
+    satterthwaiteTerm: fold.satterthwaiteTerm,
+  };
+}
+
 /**
  * Builds the grand-total-duration diff across all benchmarks. Each benchmark's total-duration
  * standard error and Satterthwaite term are pooled (benchmarks are independent), giving a Welch test
@@ -591,16 +612,8 @@ function makeTotalsDurationDiff(
     current.missing || base.missing
       ? null
       : welchTTestFromComponents(
-          {
-            mean: currentDuration,
-            standardErrorSquared: current.standardErrorSquared,
-            satterthwaiteTerm: current.satterthwaiteTerm,
-          },
-          {
-            mean: baseDuration,
-            standardErrorSquared: base.standardErrorSquared,
-            satterthwaiteTerm: base.satterthwaiteTerm,
-          },
+          foldToComponent(currentDuration, current),
+          foldToComponent(baseDuration, base),
         );
   if (!welch) {
     return legacyDiff(currentDuration, baseDuration);

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -3,12 +3,27 @@ import type {
   BenchmarkBaseUpload,
   BenchmarkReportEntry,
   MetricDefinition,
+  MetricStats,
   RenderStats,
 } from './types';
+import { welchTTest } from './welchTTest';
 
 /** A report paired with its own metric definitions — the unit the comparison operates on. */
 export type BenchmarkComparisonInput = Pick<BenchmarkBaseUpload, 'report' | 'metricDefinitions'>;
 
+/** Significance level: a difference must be less likely than this under the null to count as real. */
+const SIGNIFICANCE_ALPHA = 0.05;
+/**
+ * Minimum relative change worth flagging once a difference is significant. The p-value now rejects
+ * noise, so this is a pure "is it big enough to act on" floor rather than a noise band, and can be
+ * tighter than the legacy ±20%.
+ */
+const MIN_EFFECT_SIZE = 0.05;
+/**
+ * Legacy relative noise band. Kept only as the fallback for series that can't be tested — a
+ * baseline uploaded before per-series sample counts existed, or a series with zero variance — so
+ * those still produce a sensible diff.
+ */
 const NOISE_THRESHOLD = 0.2;
 
 /** Default paint series key (the unnamed sentinel). Named markers are `bench:paint#<id>` sub-series. */
@@ -23,6 +38,10 @@ export interface DiffValue {
   relativeDiff: number;
   severity: BenchmarkDiffSeverity;
   hint: string;
+  /** Two-sided Welch p-value when a significance test ran; `null` when it couldn't (see fallback). */
+  pValue: number | null;
+  /** Whether the difference cleared the significance threshold. `false` when no test ran. */
+  significant: boolean;
 }
 
 export interface ComparisonEntry {
@@ -63,67 +82,161 @@ export interface BenchmarkComparisonReport {
   };
 }
 
-function computeSeverity(absoluteDiff: number, withinNoise: boolean): BenchmarkDiffSeverity {
-  if (withinNoise || absoluteDiff === 0) {
+/** Summary of one measured series, as fed to Welch's t-test. `n` is absent on legacy uploads. */
+interface SeriesStats {
+  mean: number;
+  stdDev: number;
+  n: number | undefined;
+}
+
+function computeRelative(
+  current: number,
+  base: number,
+): { absoluteDiff: number; relativeDiff: number } {
+  const absoluteDiff = current - base;
+  const relativeDiff = base !== 0 ? absoluteDiff / base : 0;
+  return { absoluteDiff, relativeDiff };
+}
+
+function formatPValue(pValue: number): string {
+  return pValue < 0.001 ? 'p<0.001' : `p=${pValue.toFixed(3)}`;
+}
+
+function computeSeverity(absoluteDiff: number, flagged: boolean): BenchmarkDiffSeverity {
+  if (!flagged || absoluteDiff === 0) {
     return 'neutral';
   }
   return absoluteDiff > 0 ? 'error' : 'success';
 }
 
-function buildHint(absoluteDiff: number, relativeDiff: number, withinNoise: boolean): string {
-  if (absoluteDiff === 0) {
-    return 'No change';
-  }
-  const diffStr = `${formatDiffMs(absoluteDiff)} (${percentFormatter.format(relativeDiff)})`;
-  if (withinNoise) {
-    return `Within noise (±${percentFormatter.format(NOISE_THRESHOLD)}): ${diffStr}`;
-  }
-  if (absoluteDiff > 0) {
-    return `Regression: ${diffStr}`;
-  }
-  return `Improvement: ${diffStr}`;
-}
-
-function makeDiffValue(current: number | null, base: number | null): DiffValue {
-  if (base === null) {
-    return {
-      current,
-      base,
-      absoluteDiff: 0,
-      relativeDiff: 0,
-      severity: 'neutral',
-      hint: 'New',
-    };
-  }
-
+/**
+ * Diff for a series that can't be tested statistically (no sample count, or zero variance). Falls
+ * back to the legacy fixed relative noise band so older baselines still render sensibly.
+ */
+function legacyDiff(current: number | null, base: number): DiffValue {
   const currentVal = current ?? 0;
-  const absoluteDiff = currentVal - base;
-  const relativeDiff = base !== 0 ? absoluteDiff / base : 0;
+  const { absoluteDiff, relativeDiff } = computeRelative(currentVal, base);
   const withinNoise = Math.abs(relativeDiff) <= NOISE_THRESHOLD;
+
+  let hint: string;
+  if (absoluteDiff === 0) {
+    hint = 'No change';
+  } else {
+    const diffStr = `${formatDiffMs(absoluteDiff)} (${percentFormatter.format(relativeDiff)})`;
+    if (withinNoise) {
+      hint = `Within noise (±${percentFormatter.format(NOISE_THRESHOLD)}): ${diffStr}`;
+    } else if (absoluteDiff > 0) {
+      hint = `Regression: ${diffStr}`;
+    } else {
+      hint = `Improvement: ${diffStr}`;
+    }
+  }
+
   return {
     current,
     base,
     absoluteDiff,
     relativeDiff,
-    severity: computeSeverity(absoluteDiff, withinNoise),
-    hint: buildHint(absoluteDiff, relativeDiff, withinNoise),
+    severity: computeSeverity(absoluteDiff, !withinNoise),
+    pValue: null,
+    significant: false,
+    hint,
+  };
+}
+
+/**
+ * Diff for a millisecond-valued series (renders, totals, paint without a definition), gated on
+ * Welch's t-test: a change is flagged only when it is statistically significant *and* clears the
+ * minimum effect size. Falls back to {@link legacyDiff} when the test can't run.
+ */
+function statisticalDiff(current: SeriesStats | null, base: SeriesStats | null): DiffValue {
+  // New series (absent in base): neutral, like a brand-new entry.
+  if (base === null) {
+    return {
+      current: current?.mean ?? null,
+      base: null,
+      absoluteDiff: 0,
+      relativeDiff: 0,
+      severity: 'neutral',
+      pValue: null,
+      significant: false,
+      hint: 'New',
+    };
+  }
+  // Removed series (absent in current): fall back so it renders as a drop to zero.
+  if (current === null) {
+    return legacyDiff(null, base.mean);
+  }
+
+  const welch =
+    current.n !== undefined && base.n !== undefined
+      ? welchTTest(
+          { mean: current.mean, stdDev: current.stdDev, n: current.n },
+          { mean: base.mean, stdDev: base.stdDev, n: base.n },
+        )
+      : null;
+
+  if (!welch) {
+    return legacyDiff(current.mean, base.mean);
+  }
+
+  const { absoluteDiff, relativeDiff } = computeRelative(current.mean, base.mean);
+  const significant = welch.pValue < SIGNIFICANCE_ALPHA;
+  const meetsEffect = Math.abs(relativeDiff) >= MIN_EFFECT_SIZE;
+  const flagged = absoluteDiff !== 0 && significant && meetsEffect;
+
+  let hint: string;
+  if (absoluteDiff === 0) {
+    hint = 'No change';
+  } else {
+    const diffStr = `${formatDiffMs(absoluteDiff)} (${percentFormatter.format(relativeDiff)})`;
+    if (!significant) {
+      hint = `Not significant (${formatPValue(welch.pValue)}): ${diffStr}`;
+    } else if (!meetsEffect) {
+      hint = `Below threshold (±${percentFormatter.format(MIN_EFFECT_SIZE)}): ${diffStr}`;
+    } else {
+      const verb = absoluteDiff > 0 ? 'Regression' : 'Improvement';
+      hint = `${verb} (${formatPValue(welch.pValue)}): ${diffStr}`;
+    }
+  }
+
+  return {
+    current: current.mean,
+    base: base.mean,
+    absoluteDiff,
+    relativeDiff,
+    severity: computeSeverity(absoluteDiff, flagged),
+    pValue: welch.pValue,
+    significant,
+    hint,
   };
 }
 
 function makeCountDiffValue(current: number, base: number): DiffValue {
-  const absoluteDiff = current - base;
-  const relativeDiff = base !== 0 ? absoluteDiff / base : 0;
+  const { absoluteDiff, relativeDiff } = computeRelative(current, base);
   return {
     current,
     base,
     absoluteDiff,
     relativeDiff,
-    severity: computeSeverity(absoluteDiff, false),
+    severity: computeSeverity(absoluteDiff, absoluteDiff !== 0),
+    pValue: null,
+    significant: false,
     hint:
       absoluteDiff === 0
         ? 'No change'
         : `${absoluteDiff > 0 ? '+' : ''}${absoluteDiff} render${Math.abs(absoluteDiff) !== 1 ? 's' : ''}`,
   };
+}
+
+function renderStats(
+  render: Pick<RenderStats, 'actualDuration' | 'stdDev' | 'count'>,
+): SeriesStats {
+  return { mean: render.actualDuration, stdDev: render.stdDev, n: render.count };
+}
+
+function metricSeriesStats(stats: Pick<MetricStats, 'mean' | 'stdDev' | 'count'>): SeriesStats {
+  return { mean: stats.mean, stdDev: stats.stdDev, n: stats.count };
 }
 
 function compareRenders(
@@ -134,14 +247,14 @@ function compareRenders(
 
   for (const render of currentRenders) {
     const baseRender = baseEntry?.renders.find(
-      (r) => r.id === render.id && r.phase === render.phase,
+      (candidate) => candidate.id === render.id && candidate.phase === render.phase,
     );
     entries.push({
       name: `${render.id}:${render.phase}`,
       value: render.actualDuration,
       stdDev: render.stdDev,
       outliers: render.outliers,
-      diff: makeDiffValue(render.actualDuration, baseRender?.actualDuration ?? null),
+      diff: statisticalDiff(renderStats(render), baseRender ? renderStats(baseRender) : null),
       removed: false,
     });
   }
@@ -150,7 +263,7 @@ function compareRenders(
   if (baseEntry) {
     for (const baseRender of baseEntry.renders) {
       const exists = currentRenders.some(
-        (r) => r.id === baseRender.id && r.phase === baseRender.phase,
+        (candidate) => candidate.id === baseRender.id && candidate.phase === baseRender.phase,
       );
       if (!exists) {
         entries.push({
@@ -158,7 +271,7 @@ function compareRenders(
           value: 0,
           stdDev: 0,
           outliers: 0,
-          diff: makeDiffValue(null, baseRender.actualDuration),
+          diff: statisticalDiff(null, renderStats(baseRender)),
           removed: true,
         });
       }
@@ -175,24 +288,32 @@ function baseMetricName(key: string): string {
 }
 
 /**
- * Diff for a custom metric, honoring its definition. A metric without an `alarm` is
- * informational (always neutral). With an `alarm`, a regression past the `warn` band is flagged
- * `warning` and past the `error` band `error`; improvements are `success`. Bands are relative
- * fractions for `scalar` metrics and absolute count deltas for `discrete` metrics. Metrics
- * without a definition (e.g. paint) keep the default `makeDiffValue` behavior and never reach here.
+ * Diff for a custom metric, honoring its definition. A metric without an `alarm` is informational
+ * (always neutral). A discrete alarm is compared as an exact integer. A scalar alarm is compared
+ * against its `warn`/`error` bands (effect size) *and*, when sample counts are available, gated on
+ * Welch's t-test — a scalar regression is only flagged when it is both past its band and
+ * statistically significant. Scalar metrics without explicit bands use the {@link MIN_EFFECT_SIZE}
+ * floor. Without sample counts the metric falls back to the legacy fixed noise band.
  */
 function makeMetricDiff(
-  current: number | null,
-  base: number | null,
+  current: SeriesStats,
+  base: SeriesStats | null,
   definition: MetricDefinition,
 ): DiffValue {
   if (base === null) {
-    return { current, base, absoluteDiff: 0, relativeDiff: 0, severity: 'neutral', hint: 'New' };
+    return {
+      current: current.mean,
+      base: null,
+      absoluteDiff: 0,
+      relativeDiff: 0,
+      severity: 'neutral',
+      pValue: null,
+      significant: false,
+      hint: 'New',
+    };
   }
 
-  const currentVal = current ?? 0;
-  const absoluteDiff = currentVal - base;
-  const relativeDiff = base !== 0 ? absoluteDiff / base : 0;
+  const { absoluteDiff, relativeDiff } = computeRelative(current.mean, base.mean);
 
   const { alarm, kind } = definition;
   const isDiscrete = kind === 'discrete';
@@ -203,23 +324,40 @@ function makeMetricDiff(
   // Informational metric: show the change, never flag it.
   if (!alarm) {
     return {
-      current,
-      base,
+      current: current.mean,
+      base: base.mean,
       absoluteDiff,
       relativeDiff,
       severity: 'neutral',
+      pValue: null,
+      significant: false,
       hint: absoluteDiff === 0 ? 'No change' : diffStr,
     };
   }
+
+  // Scalar metrics can be tested for significance; discrete counts are exact and never are.
+  const welch =
+    !isDiscrete && current.n !== undefined && base.n !== undefined
+      ? welchTTest(
+          { mean: current.mean, stdDev: current.stdDev, n: current.n },
+          { mean: base.mean, stdDev: base.stdDev, n: base.n },
+        )
+      : null;
+  const significant = welch !== null && welch.pValue < SIGNIFICANCE_ALPHA;
 
   // Scalar bands are relative fractions; discrete bands are absolute count deltas, and meet their
   // threshold inclusively (an `error: 2` discrete alarm fires on a delta of exactly 2).
   const magnitude = isDiscrete ? Math.abs(absoluteDiff) : Math.abs(relativeDiff);
   const meets = (band: number) => (isDiscrete ? magnitude >= band : magnitude > band);
 
-  // When no bands are given, `error` falls back to the global noise band (scalar) or any change
-  // (discrete). When only `warn` is given, there is no error band.
-  const defaultError = isDiscrete ? 0 : NOISE_THRESHOLD;
+  // When no bands are given, `error` falls back to the effect-size floor once we can test (scalar),
+  // the legacy noise band otherwise (scalar), or any change (discrete). With only `warn`, no error.
+  let defaultError: number;
+  if (isDiscrete) {
+    defaultError = 0;
+  } else {
+    defaultError = welch ? MIN_EFFECT_SIZE : NOISE_THRESHOLD;
+  }
   const errorBand = alarm.error ?? (alarm.warn === undefined ? defaultError : undefined);
   const warnBand = alarm.warn;
 
@@ -230,6 +368,12 @@ function makeMetricDiff(
     } else if (warnBand !== undefined && meets(warnBand)) {
       level = 'warn';
     }
+  }
+
+  // A scalar band tells us the change is large; the t-test tells us it is real. Require both: a
+  // non-significant scalar change is demoted to neutral even when it clears its band.
+  if (welch && !significant) {
+    level = 'none';
   }
 
   const direction = alarm.direction ?? 'lowerIsBetter';
@@ -244,22 +388,35 @@ function makeMetricDiff(
     }
   }
 
+  const pSuffix = welch ? ` (${formatPValue(welch.pValue)})` : '';
   let hint: string;
   if (absoluteDiff === 0) {
     hint = 'No change';
   } else if (level === 'none') {
-    hint = `Within noise: ${diffStr}`;
+    hint =
+      welch && !significant
+        ? `Not significant (${formatPValue(welch.pValue)}): ${diffStr}`
+        : `Within noise: ${diffStr}`;
   } else if (!isRegression) {
-    hint = `Improvement: ${diffStr}`;
+    hint = `Improvement: ${diffStr}${pSuffix}`;
   } else {
-    hint = `${level === 'error' ? 'Regression' : 'Warning'}: ${diffStr}`;
+    hint = `${level === 'error' ? 'Regression' : 'Warning'}: ${diffStr}${pSuffix}`;
   }
 
-  return { current, base, absoluteDiff, relativeDiff, severity, hint };
+  return {
+    current: current.mean,
+    base: base.mean,
+    absoluteDiff,
+    relativeDiff,
+    severity,
+    pValue: welch?.pValue ?? null,
+    significant,
+    hint,
+  };
 }
 
 function compareMetrics(
-  currentMetrics: Record<string, { mean: number; stdDev: number; outliers: number }>,
+  currentMetrics: Record<string, MetricStats>,
   baseEntry: BenchmarkReportEntry | undefined,
   currentDefinitions: Record<string, MetricDefinition> | undefined,
   baseDefinitions: Record<string, MetricDefinition> | undefined,
@@ -269,14 +426,15 @@ function compareMetrics(
   for (const [name, stats] of Object.entries(currentMetrics)) {
     const definition = currentDefinitions?.[baseMetricName(name)];
     const baseStats = baseEntry?.metrics[name];
+    const baseSeries = baseStats ? metricSeriesStats(baseStats) : null;
     entries.push({
       name,
       value: stats.mean,
       stdDev: stats.stdDev,
       outliers: stats.outliers,
       diff: definition
-        ? makeMetricDiff(stats.mean, baseStats?.mean ?? null, definition)
-        : makeDiffValue(stats.mean, baseStats?.mean ?? null),
+        ? makeMetricDiff(metricSeriesStats(stats), baseSeries, definition)
+        : statisticalDiff(metricSeriesStats(stats), baseSeries),
       removed: false,
       format: definition?.format,
     });
@@ -292,7 +450,7 @@ function compareMetrics(
           value: 0,
           stdDev: 0,
           outliers: 0,
-          diff: makeDiffValue(null, baseStats.mean),
+          diff: statisticalDiff(null, metricSeriesStats(baseStats)),
           removed: true,
           format: definition?.format,
         });
@@ -301,6 +459,38 @@ function compareMetrics(
   }
 
   return entries;
+}
+
+/**
+ * Folds a benchmark's renders into a combined-duration variance and a sample count. The total's
+ * variance is approximated as the sum of per-render variances (treating renders as independent),
+ * and its `n` as the smallest render sample count. `missing` marks that a render lacked a count,
+ * which forces the total onto the legacy comparison path.
+ */
+function foldRenderStats(renders: RenderStats[]): {
+  variance: number;
+  minCount: number | undefined;
+  missing: boolean;
+} {
+  let variance = 0;
+  let minCount: number | undefined;
+  let missing = false;
+  for (const render of renders) {
+    variance += render.stdDev * render.stdDev;
+    if (render.count === undefined) {
+      missing = true;
+    } else {
+      minCount = minCount === undefined ? render.count : Math.min(minCount, render.count);
+    }
+  }
+  return { variance, minCount, missing };
+}
+
+type RenderFold = { variance: number; minCount: number | undefined; missing: boolean };
+
+/** Turns a mean plus a render fold into the series stats Welch's t-test consumes. */
+function foldToStats(mean: number, fold: RenderFold): SeriesStats {
+  return { mean, stdDev: Math.sqrt(fold.variance), n: fold.missing ? undefined : fold.minCount };
 }
 
 function worstSeverityRank(item: ComparisonItem): number {
@@ -337,6 +527,24 @@ function compareItems(a: ComparisonItem, b: ComparisonItem): number {
   return Math.abs(b.duration.absoluteDiff) - Math.abs(a.duration.absoluteDiff);
 }
 
+/**
+ * Builds the total-duration diff across all benchmarks. Combined variance is the sum of every
+ * render's variance; combined `n` is the smallest render count seen. If any render lacked a count,
+ * the total falls back to the legacy comparison.
+ */
+function makeTotalsDurationDiff(
+  currentDuration: number,
+  baseDuration: number,
+  hasBase: boolean,
+  current: RenderFold,
+  base: RenderFold,
+): DiffValue {
+  if (!hasBase) {
+    return statisticalDiff({ mean: currentDuration, stdDev: 0, n: undefined }, null);
+  }
+  return statisticalDiff(foldToStats(currentDuration, current), foldToStats(baseDuration, base));
+}
+
 export function compareBenchmarkReports(
   current: BenchmarkComparisonInput,
   base: BenchmarkComparisonInput | null,
@@ -358,11 +566,50 @@ export function compareBenchmarkReports(
   let totalBasePaint = 0;
   let hasPaint = false;
 
+  // Accumulated variance / min sample count across all renders, for the grand-total significance.
+  let totalCurrentVariance = 0;
+  let totalBaseVariance = 0;
+  let totalCurrentMinCount: number | undefined;
+  let totalBaseMinCount: number | undefined;
+  let totalCurrentMissing = false;
+  let totalBaseMissing = false;
+
+  const foldInto = (
+    fold: { variance: number; minCount: number | undefined; missing: boolean },
+    side: 'current' | 'base',
+  ) => {
+    if (side === 'current') {
+      totalCurrentVariance += fold.variance;
+      totalCurrentMissing = totalCurrentMissing || fold.missing;
+      if (fold.minCount !== undefined) {
+        totalCurrentMinCount =
+          totalCurrentMinCount === undefined
+            ? fold.minCount
+            : Math.min(totalCurrentMinCount, fold.minCount);
+      }
+    } else {
+      totalBaseVariance += fold.variance;
+      totalBaseMissing = totalBaseMissing || fold.missing;
+      if (fold.minCount !== undefined) {
+        totalBaseMinCount =
+          totalBaseMinCount === undefined
+            ? fold.minCount
+            : Math.min(totalBaseMinCount, fold.minCount);
+      }
+    }
+  };
+
   // Process current entries
   for (const [name, entry] of Object.entries(currentReport)) {
     const baseEntry = effectiveBase[name];
 
-    const duration = makeDiffValue(entry.totalDuration, baseEntry?.totalDuration ?? null);
+    const currentFold = foldRenderStats(entry.renders);
+    const baseFold = baseEntry ? foldRenderStats(baseEntry.renders) : undefined;
+    const duration = statisticalDiff(
+      foldToStats(entry.totalDuration, currentFold),
+      baseEntry && baseFold ? foldToStats(baseEntry.totalDuration, baseFold) : null,
+    );
+
     entries.push({
       name,
       duration,
@@ -378,6 +625,10 @@ export function compareBenchmarkReports(
     totalBaseDuration += baseEntry?.totalDuration ?? 0;
     totalCurrentRenders += entry.renders.length;
     totalBaseRenders += baseEntry?.renders.length ?? 0;
+    foldInto(currentFold, 'current');
+    if (baseFold) {
+      foldInto(baseFold, 'base');
+    }
 
     const paintMetric = entry.metrics[PAINT_DEFAULT_KEY];
     const basePaintMetric = baseEntry?.metrics[PAINT_DEFAULT_KEY];
@@ -394,7 +645,8 @@ export function compareBenchmarkReports(
       continue;
     }
 
-    const duration = makeDiffValue(null, baseEntry.totalDuration);
+    const baseFold = foldRenderStats(baseEntry.renders);
+    const duration = statisticalDiff(null, foldToStats(baseEntry.totalDuration, baseFold));
     entries.push({
       name,
       duration,
@@ -405,6 +657,7 @@ export function compareBenchmarkReports(
 
     totalBaseDuration += baseEntry.totalDuration;
     totalBaseRenders += baseEntry.renders.length;
+    foldInto(baseFold, 'base');
 
     const basePaintMetric = baseEntry.metrics[PAINT_DEFAULT_KEY];
     if (basePaintMetric) {
@@ -419,9 +672,21 @@ export function compareBenchmarkReports(
     hasBase: base !== null,
     entries,
     totals: {
-      duration: makeDiffValue(totalCurrentDuration, totalBaseDuration),
+      duration: makeTotalsDurationDiff(
+        totalCurrentDuration,
+        totalBaseDuration,
+        base !== null,
+        {
+          variance: totalCurrentVariance,
+          minCount: totalCurrentMinCount,
+          missing: totalCurrentMissing,
+        },
+        { variance: totalBaseVariance, minCount: totalBaseMinCount, missing: totalBaseMissing },
+      ),
       renderCount: makeCountDiffValue(totalCurrentRenders, totalBaseRenders),
-      paintDefault: hasPaint ? makeDiffValue(totalCurrentPaint, totalBasePaint) : null,
+      // Paint totals are summed means with no per-series variance/count, so they use the legacy
+      // relative comparison rather than a Welch test.
+      paintDefault: hasPaint ? legacyDiff(totalCurrentPaint, totalBasePaint) : null,
     },
   };
 }

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -6,7 +6,8 @@ import type {
   MetricStats,
   RenderStats,
 } from './types';
-import { welchTTest } from './welchTTest';
+import { welchTTest, welchTTestFromComponents } from './welchTTest';
+import type { WelchResult } from './welchTTest';
 
 /** A report paired with its own metric definitions — the unit the comparison operates on. */
 export type BenchmarkComparisonInput = Pick<BenchmarkBaseUpload, 'report' | 'metricDefinitions'>;
@@ -141,6 +142,50 @@ function legacyDiff(current: number | null, base: number): DiffValue {
 }
 
 /**
+ * Builds a millisecond-series diff from an already-computed Welch result and the two means. Shared
+ * by the per-series path ({@link statisticalDiff}) and the grand-total path, which pools its Welch
+ * result across independent benchmarks before building the diff.
+ */
+function buildStatisticalDiff(
+  currentMean: number,
+  baseMean: number,
+  welch: WelchResult,
+): DiffValue {
+  const { absoluteDiff, relativeDiff } = computeRelative(currentMean, baseMean);
+  const significant = welch.pValue < SIGNIFICANCE_ALPHA;
+  // Strict `>`, matching the scalar-metric band convention (`meets`) so an effect exactly on the
+  // floor is treated the same everywhere.
+  const meetsEffect = Math.abs(relativeDiff) > MIN_EFFECT_SIZE;
+  const flagged = absoluteDiff !== 0 && significant && meetsEffect;
+
+  let hint: string;
+  if (absoluteDiff === 0) {
+    hint = 'No change';
+  } else {
+    const diffStr = `${formatDiffMs(absoluteDiff)} (${percentFormatter.format(relativeDiff)})`;
+    if (!significant) {
+      hint = `Not significant (${formatPValue(welch.pValue)}): ${diffStr}`;
+    } else if (!meetsEffect) {
+      hint = `Below threshold (±${percentFormatter.format(MIN_EFFECT_SIZE)}): ${diffStr}`;
+    } else {
+      const verb = absoluteDiff > 0 ? 'Regression' : 'Improvement';
+      hint = `${verb} (${formatPValue(welch.pValue)}): ${diffStr}`;
+    }
+  }
+
+  return {
+    current: currentMean,
+    base: baseMean,
+    absoluteDiff,
+    relativeDiff,
+    severity: computeSeverity(absoluteDiff, flagged),
+    pValue: welch.pValue,
+    significant,
+    hint,
+  };
+}
+
+/**
  * Diff for a millisecond-valued series (renders, totals, paint without a definition), gated on
  * Welch's t-test: a change is flagged only when it is statistically significant *and* clears the
  * minimum effect size. Falls back to {@link legacyDiff} when the test can't run.
@@ -176,38 +221,7 @@ function statisticalDiff(current: SeriesStats | null, base: SeriesStats | null):
     return legacyDiff(current.mean, base.mean);
   }
 
-  const { absoluteDiff, relativeDiff } = computeRelative(current.mean, base.mean);
-  const significant = welch.pValue < SIGNIFICANCE_ALPHA;
-  // Strict `>`, matching the scalar-metric band convention (`meets`) so an effect exactly on the
-  // floor is treated the same everywhere.
-  const meetsEffect = Math.abs(relativeDiff) > MIN_EFFECT_SIZE;
-  const flagged = absoluteDiff !== 0 && significant && meetsEffect;
-
-  let hint: string;
-  if (absoluteDiff === 0) {
-    hint = 'No change';
-  } else {
-    const diffStr = `${formatDiffMs(absoluteDiff)} (${percentFormatter.format(relativeDiff)})`;
-    if (!significant) {
-      hint = `Not significant (${formatPValue(welch.pValue)}): ${diffStr}`;
-    } else if (!meetsEffect) {
-      hint = `Below threshold (±${percentFormatter.format(MIN_EFFECT_SIZE)}): ${diffStr}`;
-    } else {
-      const verb = absoluteDiff > 0 ? 'Regression' : 'Improvement';
-      hint = `${verb} (${formatPValue(welch.pValue)}): ${diffStr}`;
-    }
-  }
-
-  return {
-    current: current.mean,
-    base: base.mean,
-    absoluteDiff,
-    relativeDiff,
-    severity: computeSeverity(absoluteDiff, flagged),
-    pValue: welch.pValue,
-    significant,
-    hint,
-  };
+  return buildStatisticalDiff(current.mean, base.mean, welch);
 }
 
 function makeCountDiffValue(current: number, base: number): DiffValue {
@@ -391,10 +405,15 @@ function makeMetricDiff(
   if (absoluteDiff === 0) {
     hint = 'No change';
   } else if (level === 'none') {
-    hint =
-      welch && !significant
-        ? `Not significant (${formatPValue(welch.pValue)}): ${diffStr}`
-        : `Within noise: ${diffStr}`;
+    if (welch && !significant) {
+      hint = `Not significant (${formatPValue(welch.pValue)}): ${diffStr}`;
+    } else if (welch) {
+      // Significant (small p) but below its effect-size band: a real change, just not big enough to
+      // flag — distinct from the untested "Within noise" fallback below.
+      hint = `Below threshold (${formatPValue(welch.pValue)}): ${diffStr}`;
+    } else {
+      hint = `Within noise: ${diffStr}`;
+    }
   } else if (!isRegression) {
     hint = `Improvement: ${diffStr}${pSuffix}`;
   } else {
@@ -465,28 +484,57 @@ function compareMetrics(
  * routes the Duration onto the legacy comparison path.
  */
 function entryTotalStats(entry: BenchmarkReportEntry): SeriesStats {
-  return { mean: entry.totalDuration, stdDev: entry.totalStdDev ?? 0, n: entry.totalCount };
-}
-
-/** Running accumulation of the grand-total duration's variance and sample count across benchmarks. */
-type TotalFold = { variance: number; minCount: number | undefined; missing: boolean };
-
-/** Turns a mean plus an accumulated fold into the series stats Welch's t-test consumes. */
-function foldToStats(mean: number, fold: TotalFold): SeriesStats {
-  return { mean, stdDev: Math.sqrt(fold.variance), n: fold.missing ? undefined : fold.minCount };
+  // Both fields are needed to run the test; a partial upload (a count without a stdDev, or vice
+  // versa) routes the Duration onto the legacy path rather than being read as zero-variance — which
+  // would fabricate a near-zero standard error and flag noise as a significant regression.
+  const hasStats = entry.totalStdDev !== undefined && entry.totalCount !== undefined;
+  return {
+    mean: entry.totalDuration,
+    stdDev: entry.totalStdDev ?? 0,
+    n: hasStats ? entry.totalCount : undefined,
+  };
 }
 
 /**
- * One benchmark's contribution to the grand-total fold. Distinct benchmarks are independent, so
- * summing their total-duration variances is valid (unlike summing correlated per-render variances).
+ * Running accumulation of the grand-total duration's Welch components across benchmarks. Because
+ * distinct benchmarks are independent, both the variance of the total mean (`standardErrorSquared`)
+ * and the Satterthwaite terms add. Pooling the components this way stays correct when benchmarks
+ * have different sample counts (as adaptive sampling produces); summing raw variances under a single
+ * shared `n` would over-state the standard error and under-report grand-total regressions.
  */
-function entryTotalFold(entry: BenchmarkReportEntry): TotalFold {
-  const stdDev = entry.totalStdDev ?? 0;
-  return {
-    variance: stdDev * stdDev,
-    minCount: entry.totalCount,
-    missing: entry.totalCount === undefined,
-  };
+interface TotalFold {
+  standardErrorSquared: number;
+  satterthwaiteTerm: number;
+  /** A benchmark lacked the stats to be tested at all (legacy upload / partial data). */
+  missing: boolean;
+}
+
+function createTotalFold(): TotalFold {
+  return { standardErrorSquared: 0, satterthwaiteTerm: 0, missing: false };
+}
+
+/**
+ * Folds one benchmark's total-duration distribution into a grand-total accumulator.
+ *
+ * - Missing `totalStdDev`/`totalCount` (legacy or partial upload) can't be tested → marks the whole
+ *   total for the legacy fallback.
+ * - Fewer than two samples (e.g. a benchmark pinned to `runs: 1`) has no estimable variance, so it
+ *   contributes only its mean (accumulated separately) and is skipped here — one under-sampled
+ *   benchmark must not silently disable the significance test for the entire suite.
+ * - Otherwise its standard-error² (`σ²/(n-1)`, from the stored population stdDev) and Satterthwaite
+ *   term add into the fold.
+ */
+function foldEntryTotal(entry: BenchmarkReportEntry, fold: TotalFold): void {
+  if (entry.totalStdDev === undefined || entry.totalCount === undefined) {
+    fold.missing = true;
+    return;
+  }
+  if (entry.totalCount < 2) {
+    return;
+  }
+  const standardErrorSquared = (entry.totalStdDev * entry.totalStdDev) / (entry.totalCount - 1);
+  fold.standardErrorSquared += standardErrorSquared;
+  fold.satterthwaiteTerm += (standardErrorSquared * standardErrorSquared) / (entry.totalCount - 1);
 }
 
 function worstSeverityRank(item: ComparisonItem): number {
@@ -524,10 +572,10 @@ function compareItems(a: ComparisonItem, b: ComparisonItem): number {
 }
 
 /**
- * Builds the grand-total-duration diff across all benchmarks. Combined variance is the sum of each
- * benchmark's total-duration variance (benchmarks are independent, so this is valid); combined `n`
- * is the smallest benchmark total-duration count. If any benchmark lacked a count, the total falls
- * back to the legacy comparison.
+ * Builds the grand-total-duration diff across all benchmarks. Each benchmark's total-duration
+ * standard error and Satterthwaite term are pooled (benchmarks are independent), giving a Welch test
+ * that stays correct under adaptive, unequal sample counts. If any benchmark lacked the stats to be
+ * tested, the total falls back to the legacy relative comparison.
  */
 function makeTotalsDurationDiff(
   currentDuration: number,
@@ -539,7 +587,25 @@ function makeTotalsDurationDiff(
   if (!hasBase) {
     return statisticalDiff({ mean: currentDuration, stdDev: 0, n: undefined }, null);
   }
-  return statisticalDiff(foldToStats(currentDuration, current), foldToStats(baseDuration, base));
+  const welch =
+    current.missing || base.missing
+      ? null
+      : welchTTestFromComponents(
+          {
+            mean: currentDuration,
+            standardErrorSquared: current.standardErrorSquared,
+            satterthwaiteTerm: current.satterthwaiteTerm,
+          },
+          {
+            mean: baseDuration,
+            standardErrorSquared: base.standardErrorSquared,
+            satterthwaiteTerm: base.satterthwaiteTerm,
+          },
+        );
+  if (!welch) {
+    return legacyDiff(currentDuration, baseDuration);
+  }
+  return buildStatisticalDiff(currentDuration, baseDuration, welch);
 }
 
 export function compareBenchmarkReports(
@@ -563,39 +629,9 @@ export function compareBenchmarkReports(
   let totalBasePaint = 0;
   let hasPaint = false;
 
-  // Accumulated variance / min sample count across each benchmark's total duration, for the
-  // grand-total significance test.
-  let totalCurrentVariance = 0;
-  let totalBaseVariance = 0;
-  let totalCurrentMinCount: number | undefined;
-  let totalBaseMinCount: number | undefined;
-  let totalCurrentMissing = false;
-  let totalBaseMissing = false;
-
-  const foldInto = (
-    fold: { variance: number; minCount: number | undefined; missing: boolean },
-    side: 'current' | 'base',
-  ) => {
-    if (side === 'current') {
-      totalCurrentVariance += fold.variance;
-      totalCurrentMissing = totalCurrentMissing || fold.missing;
-      if (fold.minCount !== undefined) {
-        totalCurrentMinCount =
-          totalCurrentMinCount === undefined
-            ? fold.minCount
-            : Math.min(totalCurrentMinCount, fold.minCount);
-      }
-    } else {
-      totalBaseVariance += fold.variance;
-      totalBaseMissing = totalBaseMissing || fold.missing;
-      if (fold.minCount !== undefined) {
-        totalBaseMinCount =
-          totalBaseMinCount === undefined
-            ? fold.minCount
-            : Math.min(totalBaseMinCount, fold.minCount);
-      }
-    }
-  };
+  // Pooled Welch components across each benchmark's total duration, for the grand-total test.
+  const currentTotalFold = createTotalFold();
+  const baseTotalFold = createTotalFold();
 
   // Process current entries
   for (const [name, entry] of Object.entries(currentReport)) {
@@ -621,9 +657,9 @@ export function compareBenchmarkReports(
     totalBaseDuration += baseEntry?.totalDuration ?? 0;
     totalCurrentRenders += entry.renders.length;
     totalBaseRenders += baseEntry?.renders.length ?? 0;
-    foldInto(entryTotalFold(entry), 'current');
+    foldEntryTotal(entry, currentTotalFold);
     if (baseEntry) {
-      foldInto(entryTotalFold(baseEntry), 'base');
+      foldEntryTotal(baseEntry, baseTotalFold);
     }
 
     const paintMetric = entry.metrics[PAINT_DEFAULT_KEY];
@@ -652,7 +688,7 @@ export function compareBenchmarkReports(
 
     totalBaseDuration += baseEntry.totalDuration;
     totalBaseRenders += baseEntry.renders.length;
-    foldInto(entryTotalFold(baseEntry), 'base');
+    foldEntryTotal(baseEntry, baseTotalFold);
 
     const basePaintMetric = baseEntry.metrics[PAINT_DEFAULT_KEY];
     if (basePaintMetric) {
@@ -671,12 +707,8 @@ export function compareBenchmarkReports(
         totalCurrentDuration,
         totalBaseDuration,
         base !== null,
-        {
-          variance: totalCurrentVariance,
-          minCount: totalCurrentMinCount,
-          missing: totalCurrentMissing,
-        },
-        { variance: totalBaseVariance, minCount: totalBaseMinCount, missing: totalBaseMissing },
+        currentTotalFold,
+        baseTotalFold,
       ),
       renderCount: makeCountDiffValue(totalCurrentRenders, totalBaseRenders),
       // Paint totals are summed means with no per-series variance/count, so they use the legacy

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -479,11 +479,6 @@ function compareMetrics(
 }
 
 /**
- * Series stats for a benchmark's total duration, taken from the per-iteration total distribution
- * the reporter measured directly. `n` is absent on uploads made before `totalCount` existed, which
- * routes the Duration onto the legacy comparison path.
- */
-/**
  * Whether an entry carries the total-duration stats (stdDev *and* count) a Welch test needs. A
  * partial upload (one without the other) is not testable and routes onto the legacy path rather than
  * being read as zero-variance — which would fabricate a near-zero standard error and flag noise as a
@@ -495,6 +490,11 @@ function hasTotalStats(
   return entry.totalStdDev !== undefined && entry.totalCount !== undefined;
 }
 
+/**
+ * Series stats for a benchmark's total duration, taken from the per-iteration total distribution the
+ * reporter measured directly. `n` is absent on uploads made before `totalCount` existed (or missing
+ * a stdDev), which routes the Duration onto the legacy comparison path.
+ */
 function entryTotalStats(entry: BenchmarkReportEntry): SeriesStats {
   return {
     mean: entry.totalDuration,
@@ -524,13 +524,16 @@ function createTotalFold(): TotalFold {
 /**
  * Folds one benchmark's total-duration distribution into a grand-total accumulator.
  *
- * - Missing `totalStdDev`/`totalCount` (legacy or partial upload) can't be tested → marks the whole
- *   total for the legacy fallback.
- * - Fewer than two samples (e.g. a benchmark pinned to `runs: 1`) has no estimable variance, so
- *   {@link sampleComponent} returns `null`; it contributes only its mean (accumulated separately) and
- *   is skipped here — one under-sampled benchmark must not silently disable the significance test for
- *   the entire suite.
- * - Otherwise its Welch component (standard error² and Satterthwaite term) adds into the fold.
+ * A benchmark that can't be tested marks the whole total for the legacy fallback (`missing`), rather
+ * than being dropped from the fold:
+ * - Missing `totalStdDev`/`totalCount` (legacy or partial upload) — no stats at all.
+ * - Fewer than two samples (e.g. a benchmark pinned to `runs: 1`) — its mean is still summed into
+ *   the grand total elsewhere, but its variance is unknown. Testing that mean shift against only the
+ *   *other* benchmarks' variance would flag single-sample noise as significant, so the honest move is
+ *   to drop the whole total to the legacy band. Only the single aggregate row degrades; every
+ *   per-benchmark Duration row is still tested independently.
+ *
+ * Otherwise its Welch component (standard error² and Satterthwaite term) adds into the fold.
  */
 function foldEntryTotal(entry: BenchmarkReportEntry, fold: TotalFold): void {
   if (!hasTotalStats(entry)) {
@@ -543,6 +546,7 @@ function foldEntryTotal(entry: BenchmarkReportEntry, fold: TotalFold): void {
     n: entry.totalCount,
   });
   if (!component) {
+    fold.missing = true;
     return;
   }
   fold.standardErrorSquared += component.standardErrorSquared;

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -460,35 +460,33 @@ function compareMetrics(
 }
 
 /**
- * Folds a benchmark's renders into a combined-duration variance and a sample count. The total's
- * variance is approximated as the sum of per-render variances (treating renders as independent),
- * and its `n` as the smallest render sample count. `missing` marks that a render lacked a count,
- * which forces the total onto the legacy comparison path.
+ * Series stats for a benchmark's total duration, taken from the per-iteration total distribution
+ * the reporter measured directly. `n` is absent on uploads made before `totalCount` existed, which
+ * routes the Duration onto the legacy comparison path.
  */
-function foldRenderStats(renders: RenderStats[]): {
-  variance: number;
-  minCount: number | undefined;
-  missing: boolean;
-} {
-  let variance = 0;
-  let minCount: number | undefined;
-  let missing = false;
-  for (const render of renders) {
-    variance += render.stdDev * render.stdDev;
-    if (render.count === undefined) {
-      missing = true;
-    } else {
-      minCount = minCount === undefined ? render.count : Math.min(minCount, render.count);
-    }
-  }
-  return { variance, minCount, missing };
+function entryTotalStats(entry: BenchmarkReportEntry): SeriesStats {
+  return { mean: entry.totalDuration, stdDev: entry.totalStdDev ?? 0, n: entry.totalCount };
 }
 
-type RenderFold = { variance: number; minCount: number | undefined; missing: boolean };
+/** Running accumulation of the grand-total duration's variance and sample count across benchmarks. */
+type TotalFold = { variance: number; minCount: number | undefined; missing: boolean };
 
-/** Turns a mean plus a render fold into the series stats Welch's t-test consumes. */
-function foldToStats(mean: number, fold: RenderFold): SeriesStats {
+/** Turns a mean plus an accumulated fold into the series stats Welch's t-test consumes. */
+function foldToStats(mean: number, fold: TotalFold): SeriesStats {
   return { mean, stdDev: Math.sqrt(fold.variance), n: fold.missing ? undefined : fold.minCount };
+}
+
+/**
+ * One benchmark's contribution to the grand-total fold. Distinct benchmarks are independent, so
+ * summing their total-duration variances is valid (unlike summing correlated per-render variances).
+ */
+function entryTotalFold(entry: BenchmarkReportEntry): TotalFold {
+  const stdDev = entry.totalStdDev ?? 0;
+  return {
+    variance: stdDev * stdDev,
+    minCount: entry.totalCount,
+    missing: entry.totalCount === undefined,
+  };
 }
 
 function worstSeverityRank(item: ComparisonItem): number {
@@ -526,16 +524,17 @@ function compareItems(a: ComparisonItem, b: ComparisonItem): number {
 }
 
 /**
- * Builds the total-duration diff across all benchmarks. Combined variance is the sum of every
- * render's variance; combined `n` is the smallest render count seen. If any render lacked a count,
- * the total falls back to the legacy comparison.
+ * Builds the grand-total-duration diff across all benchmarks. Combined variance is the sum of each
+ * benchmark's total-duration variance (benchmarks are independent, so this is valid); combined `n`
+ * is the smallest benchmark total-duration count. If any benchmark lacked a count, the total falls
+ * back to the legacy comparison.
  */
 function makeTotalsDurationDiff(
   currentDuration: number,
   baseDuration: number,
   hasBase: boolean,
-  current: RenderFold,
-  base: RenderFold,
+  current: TotalFold,
+  base: TotalFold,
 ): DiffValue {
   if (!hasBase) {
     return statisticalDiff({ mean: currentDuration, stdDev: 0, n: undefined }, null);
@@ -564,7 +563,8 @@ export function compareBenchmarkReports(
   let totalBasePaint = 0;
   let hasPaint = false;
 
-  // Accumulated variance / min sample count across all renders, for the grand-total significance.
+  // Accumulated variance / min sample count across each benchmark's total duration, for the
+  // grand-total significance test.
   let totalCurrentVariance = 0;
   let totalBaseVariance = 0;
   let totalCurrentMinCount: number | undefined;
@@ -601,11 +601,9 @@ export function compareBenchmarkReports(
   for (const [name, entry] of Object.entries(currentReport)) {
     const baseEntry = effectiveBase[name];
 
-    const currentFold = foldRenderStats(entry.renders);
-    const baseFold = baseEntry ? foldRenderStats(baseEntry.renders) : undefined;
     const duration = statisticalDiff(
-      foldToStats(entry.totalDuration, currentFold),
-      baseEntry && baseFold ? foldToStats(baseEntry.totalDuration, baseFold) : null,
+      entryTotalStats(entry),
+      baseEntry ? entryTotalStats(baseEntry) : null,
     );
 
     entries.push({
@@ -623,9 +621,9 @@ export function compareBenchmarkReports(
     totalBaseDuration += baseEntry?.totalDuration ?? 0;
     totalCurrentRenders += entry.renders.length;
     totalBaseRenders += baseEntry?.renders.length ?? 0;
-    foldInto(currentFold, 'current');
-    if (baseFold) {
-      foldInto(baseFold, 'base');
+    foldInto(entryTotalFold(entry), 'current');
+    if (baseEntry) {
+      foldInto(entryTotalFold(baseEntry), 'base');
     }
 
     const paintMetric = entry.metrics[PAINT_DEFAULT_KEY];
@@ -643,8 +641,7 @@ export function compareBenchmarkReports(
       continue;
     }
 
-    const baseFold = foldRenderStats(baseEntry.renders);
-    const duration = statisticalDiff(null, foldToStats(baseEntry.totalDuration, baseFold));
+    const duration = statisticalDiff(null, entryTotalStats(baseEntry));
     entries.push({
       name,
       duration,
@@ -655,7 +652,7 @@ export function compareBenchmarkReports(
 
     totalBaseDuration += baseEntry.totalDuration;
     totalBaseRenders += baseEntry.renders.length;
-    foldInto(baseFold, 'base');
+    foldInto(entryTotalFold(baseEntry), 'base');
 
     const basePaintMetric = baseEntry.metrics[PAINT_DEFAULT_KEY];
     if (basePaintMetric) {

--- a/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/compareBenchmarkReports.ts
@@ -1,4 +1,4 @@
-import { formatDiffMs, formatMetricDiff, percentFormatter } from '@/utils/formatters';
+import { formatDiffMs, formatMetricDiff, formatPValue, percentFormatter } from '@/utils/formatters';
 import type {
   BenchmarkBaseUpload,
   BenchmarkReportEntry,
@@ -98,10 +98,6 @@ function computeRelative(
   return { absoluteDiff, relativeDiff };
 }
 
-function formatPValue(pValue: number): string {
-  return pValue < 0.001 ? 'p<0.001' : `p=${pValue.toFixed(3)}`;
-}
-
 function computeSeverity(absoluteDiff: number, flagged: boolean): BenchmarkDiffSeverity {
   if (!flagged || absoluteDiff === 0) {
     return 'neutral';
@@ -182,7 +178,9 @@ function statisticalDiff(current: SeriesStats | null, base: SeriesStats | null):
 
   const { absoluteDiff, relativeDiff } = computeRelative(current.mean, base.mean);
   const significant = welch.pValue < SIGNIFICANCE_ALPHA;
-  const meetsEffect = Math.abs(relativeDiff) >= MIN_EFFECT_SIZE;
+  // Strict `>`, matching the scalar-metric band convention (`meets`) so an effect exactly on the
+  // floor is treated the same everywhere.
+  const meetsEffect = Math.abs(relativeDiff) > MIN_EFFECT_SIZE;
   const flagged = absoluteDiff !== 0 && significant && meetsEffect;
 
   let hint: string;

--- a/apps/code-infra-dashboard/src/lib/benchmark/test-fixtures.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/test-fixtures.ts
@@ -1,6 +1,63 @@
 import type { BenchmarkReport, BenchmarkReportEntry } from './types';
 import type { BenchmarkComparisonInput } from './compareBenchmarkReports';
 
+/**
+ * A benchmark entry carrying the total-duration `stdDev` + sample `count` that real uploads now
+ * produce, so the comparison runs a Welch's t-test. This is the default shape for fixtures; use
+ * {@link makeEntry} only to exercise the legacy fallback for uploads made before sample counts
+ * existed.
+ */
+export function makeStatEntry(
+  totalDuration: number,
+  stdDev: number,
+  count: number,
+  renderCount: number = 1,
+): BenchmarkReportEntry {
+  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
+  return {
+    iterations: count,
+    totalDuration,
+    totalStdDev: stdDev,
+    totalCount: count,
+    renders: Array.from({ length: renderCount }, (_, index) => ({
+      id: `render-${index}`,
+      phase: 'mount',
+      startTime: 0,
+      actualDuration: perRender,
+      stdDev,
+      rawMean: perRender,
+      rawStdDev: stdDev,
+      outliers: 0,
+      count,
+    })),
+    metrics: {},
+  };
+}
+
+/** Multi-benchmark statistical report; every entry shares the same `stdDev`/`count` profile. */
+export function makeStatReport(
+  entries: Record<string, number>,
+  stdDev: number,
+  count: number,
+): BenchmarkComparisonInput {
+  const report: BenchmarkReport = {};
+  for (const [name, totalDuration] of Object.entries(entries)) {
+    report[name] = makeStatEntry(totalDuration, stdDev, count);
+  }
+  return { report };
+}
+
+/** Single-benchmark statistical report (named `Bench`), the common case for gating tests. */
+export function statReport(mean: number, stdDev: number, count: number): BenchmarkComparisonInput {
+  return makeStatReport({ Bench: mean }, stdDev, count);
+}
+
+/**
+ * A legacy benchmark entry with no `totalStdDev`/`totalCount` (and zero-variance renders), as
+ * produced by uploads made before sample counts existed. Routes the comparison onto the legacy
+ * relative-noise-band fallback. Prefer {@link makeStatEntry} unless a test specifically covers that
+ * backwards-compatible path.
+ */
 export function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
   const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
   return {

--- a/apps/code-infra-dashboard/src/lib/benchmark/test-fixtures.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/test-fixtures.ts
@@ -2,6 +2,37 @@ import type { BenchmarkReport, BenchmarkReportEntry } from './types';
 import type { BenchmarkComparisonInput } from './compareBenchmarkReports';
 
 /**
+ * Shared entry builder. With `stats`, the entry carries the total-duration `stdDev`/`count` (and
+ * per-render `count`) that route the comparison through Welch's t-test; without, it omits them for
+ * the legacy relative-band fallback. Both variants share the render-array shape.
+ */
+function makeEntryCore(
+  totalDuration: number,
+  renderCount: number,
+  stats: { stdDev: number; count: number } | null,
+): BenchmarkReportEntry {
+  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
+  const stdDev = stats?.stdDev ?? 0;
+  return {
+    iterations: stats?.count ?? 10,
+    totalDuration,
+    ...(stats && { totalStdDev: stats.stdDev, totalCount: stats.count }),
+    renders: Array.from({ length: renderCount }, (_, index) => ({
+      id: `render-${index}`,
+      phase: 'mount',
+      startTime: 0,
+      actualDuration: perRender,
+      stdDev,
+      rawMean: perRender,
+      rawStdDev: stdDev,
+      outliers: 0,
+      ...(stats && { count: stats.count }),
+    })),
+    metrics: {},
+  };
+}
+
+/**
  * A benchmark entry carrying the total-duration `stdDev` + sample `count` that real uploads now
  * produce, so the comparison runs a Welch's t-test. This is the default shape for fixtures; use
  * {@link makeEntry} only to exercise the legacy fallback for uploads made before sample counts
@@ -13,25 +44,7 @@ export function makeStatEntry(
   count: number,
   renderCount: number = 1,
 ): BenchmarkReportEntry {
-  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
-  return {
-    iterations: count,
-    totalDuration,
-    totalStdDev: stdDev,
-    totalCount: count,
-    renders: Array.from({ length: renderCount }, (_, index) => ({
-      id: `render-${index}`,
-      phase: 'mount',
-      startTime: 0,
-      actualDuration: perRender,
-      stdDev,
-      rawMean: perRender,
-      rawStdDev: stdDev,
-      outliers: 0,
-      count,
-    })),
-    metrics: {},
-  };
+  return makeEntryCore(totalDuration, renderCount, { stdDev, count });
 }
 
 /** Multi-benchmark statistical report; every entry shares the same `stdDev`/`count` profile. */
@@ -59,22 +72,7 @@ export function statReport(mean: number, stdDev: number, count: number): Benchma
  * backwards-compatible path.
  */
 export function makeEntry(totalDuration: number, renderCount: number = 1): BenchmarkReportEntry {
-  const perRender = renderCount > 0 ? totalDuration / renderCount : 0;
-  return {
-    iterations: 10,
-    totalDuration,
-    renders: Array.from({ length: renderCount }, (_, index) => ({
-      id: `render-${index}`,
-      phase: 'mount',
-      startTime: 0,
-      actualDuration: perRender,
-      stdDev: 0,
-      rawMean: perRender,
-      rawStdDev: 0,
-      outliers: 0,
-    })),
-    metrics: {},
-  };
+  return makeEntryCore(totalDuration, renderCount, null);
 }
 
 export function makeReport(entries: Record<string, number>): BenchmarkComparisonInput {

--- a/apps/code-infra-dashboard/src/lib/benchmark/types.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/types.ts
@@ -29,6 +29,10 @@ export interface MetricStats {
 export interface BenchmarkReportEntry {
   iterations: number;
   totalDuration: number;
+  /** Spread + effective sample count of the per-iteration total duration; the stdDev/`n` for the
+   * Duration Welch test. Absent on uploads made before they were added. */
+  totalStdDev?: number;
+  totalCount?: number;
   renders: RenderStats[];
   metrics: Record<string, MetricStats>;
 }

--- a/apps/code-infra-dashboard/src/lib/benchmark/types.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/types.ts
@@ -14,12 +14,16 @@ export interface RenderStats {
   rawMean: number;
   rawStdDev: number;
   outliers: number;
+  /** Effective sample count behind mean/stdDev; the `n` for Welch's t-test. Absent on old uploads. */
+  count?: number;
 }
 
 export interface MetricStats {
   mean: number;
   stdDev: number;
   outliers: number;
+  /** Effective sample count behind mean/stdDev; the `n` for Welch's t-test. Absent on old uploads. */
+  count?: number;
 }
 
 export interface BenchmarkReportEntry {

--- a/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { welchTTest, studentTCdf, regularizedIncompleteBeta } from './welchTTest';
+import type { SampleSummary } from './welchTTest';
+
+/**
+ * Builds a summary from a target *sample* standard deviation, converting to the population stdDev
+ * (÷n) the harness stores and `welchTTest` expects. Keeps the tests readable in sample-variance
+ * terms while exercising the internal conversion.
+ */
+function summary(mean: number, sampleStdDev: number, n: number): SampleSummary {
+  const stdDev = sampleStdDev * Math.sqrt((n - 1) / n);
+  return { mean, stdDev, n };
+}
+
+describe('regularizedIncompleteBeta', () => {
+  it('is 0 at x=0 and 1 at x=1', () => {
+    expect(regularizedIncompleteBeta(0, 2, 3)).toBe(0);
+    expect(regularizedIncompleteBeta(1, 2, 3)).toBe(1);
+  });
+
+  it('is 0.5 at the symmetric midpoint (a === b, x = 0.5)', () => {
+    expect(regularizedIncompleteBeta(0.5, 2, 2)).toBeCloseTo(0.5, 10);
+    expect(regularizedIncompleteBeta(0.5, 5, 5)).toBeCloseTo(0.5, 10);
+  });
+
+  it('matches the closed form for I_x(1, 1) = x', () => {
+    expect(regularizedIncompleteBeta(0.3, 1, 1)).toBeCloseTo(0.3, 10);
+    expect(regularizedIncompleteBeta(0.75, 1, 1)).toBeCloseTo(0.75, 10);
+  });
+});
+
+describe('studentTCdf', () => {
+  it('is 0.5 at t=0', () => {
+    expect(studentTCdf(0, 5)).toBeCloseTo(0.5, 10);
+  });
+
+  it('matches a known reference value (t=2, df=8 → two-tailed p≈0.0805)', () => {
+    // CDF = 1 - p/2.
+    expect(studentTCdf(2, 8)).toBeCloseTo(0.9597, 3);
+  });
+
+  it('is symmetric: F(-t) = 1 - F(t)', () => {
+    const positive = studentTCdf(1.7, 12);
+    const negative = studentTCdf(-1.7, 12);
+    expect(negative).toBeCloseTo(1 - positive, 10);
+  });
+
+  it('approaches 1 far out in the upper tail', () => {
+    expect(studentTCdf(50, 10)).toBeCloseTo(1, 6);
+  });
+});
+
+describe('welchTTest', () => {
+  it('returns t=0 and p=1 for identical summaries', () => {
+    const result = welchTTest(summary(10, 2, 20), summary(10, 2, 20));
+    expect(result).not.toBeNull();
+    expect(result!.t).toBe(0);
+    expect(result!.pValue).toBeCloseTo(1, 10);
+  });
+
+  it('computes the expected t, df, and p for a textbook equal-variance case', () => {
+    // Two groups, sample variance 4 (sd 2), n=10 each, means 10 vs 12.
+    // t = (10-12)/sqrt(0.4+0.4) = -2.2360679; df = 18 (reduces to 2(n-1) for equal var & n).
+    const result = welchTTest(summary(10, 2, 10), summary(12, 2, 10));
+    expect(result).not.toBeNull();
+    expect(result!.t).toBeCloseTo(-2.2360679, 5);
+    expect(result!.df).toBeCloseTo(18, 6);
+    expect(result!.pValue).toBeCloseTo(0.038, 2);
+  });
+
+  it('handles unequal variances and sample sizes (Welch–Satterthwaite df)', () => {
+    // Larger, noisier group vs smaller, tighter group.
+    const result = welchTTest(summary(100, 10, 30), summary(108, 4, 12));
+    expect(result).not.toBeNull();
+    // Point estimate is well separated relative to the pooled standard error → clearly significant.
+    expect(result!.pValue).toBeLessThan(0.05);
+    // Welch df lands between the smaller group's df and the pooled total, never above n1+n2-2.
+    expect(result!.df).toBeGreaterThan(11);
+    expect(result!.df).toBeLessThan(40);
+  });
+
+  it('is sign-symmetric in its arguments', () => {
+    const forward = welchTTest(summary(10, 2, 15), summary(13, 3, 18));
+    const reversed = welchTTest(summary(13, 3, 18), summary(10, 2, 15));
+    expect(forward!.t).toBeCloseTo(-reversed!.t, 10);
+    expect(forward!.df).toBeCloseTo(reversed!.df, 10);
+    expect(forward!.pValue).toBeCloseTo(reversed!.pValue, 10);
+  });
+
+  it('returns a vanishingly small p-value for well-separated means', () => {
+    const result = welchTTest(summary(10, 1, 30), summary(30, 1, 30));
+    expect(result!.pValue).toBeLessThan(1e-6);
+  });
+
+  it('returns null when either side has fewer than two samples', () => {
+    expect(welchTTest(summary(10, 2, 1), summary(12, 2, 20))).toBeNull();
+    expect(welchTTest(summary(10, 2, 20), summary(12, 2, 1))).toBeNull();
+  });
+
+  it('returns null when both sides have zero variance', () => {
+    expect(welchTTest({ mean: 10, stdDev: 0, n: 20 }, { mean: 12, stdDev: 0, n: 20 })).toBeNull();
+  });
+
+  it('still tests when only one side has zero variance', () => {
+    const result = welchTTest({ mean: 10, stdDev: 0, n: 20 }, summary(12, 2, 20));
+    expect(result).not.toBeNull();
+    expect(result!.pValue).toBeLessThan(0.05);
+  });
+});

--- a/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { welchTTest, studentTCdf, regularizedIncompleteBeta } from './welchTTest';
+import { welchTTest, welchTTestFromComponents, regularizedIncompleteBeta } from './welchTTest';
 import type { SampleSummary } from './welchTTest';
 
 /**
@@ -29,24 +29,74 @@ describe('regularizedIncompleteBeta', () => {
   });
 });
 
-describe('studentTCdf', () => {
-  it('is 0.5 at t=0', () => {
-    expect(studentTCdf(0, 5)).toBeCloseTo(0.5, 10);
+describe('welchTTestFromComponents', () => {
+  /** Reduces a single summary to its Welch component the way `welchTTest` does internally. */
+  function component(sample: SampleSummary) {
+    const standardErrorSquared = (sample.stdDev * sample.stdDev) / (sample.n - 1);
+    return {
+      mean: sample.mean,
+      standardErrorSquared,
+      satterthwaiteTerm: (standardErrorSquared * standardErrorSquared) / (sample.n - 1),
+    };
+  }
+
+  it('reproduces welchTTest for single-sample components', () => {
+    const a = summary(100, 10, 30);
+    const b = summary(108, 4, 12);
+    const direct = welchTTest(a, b)!;
+    const viaComponents = welchTTestFromComponents(component(a), component(b))!;
+    expect(viaComponents.t).toBeCloseTo(direct.t, 12);
+    expect(viaComponents.df).toBeCloseTo(direct.df, 12);
+    expect(viaComponents.pValue).toBeCloseTo(direct.pValue, 12);
   });
 
-  it('matches a known reference value (t=2, df=8 → two-tailed p≈0.0805)', () => {
-    // CDF = 1 - p/2.
-    expect(studentTCdf(2, 8)).toBeCloseTo(0.9597, 3);
+  it('pools independent series by summing standard errors and Satterthwaite terms', () => {
+    // A grand total of two equal-count benchmarks equals a single series with the summed means and
+    // the summed standard-error² — the components just add.
+    const first = component(summary(50, 3, 20));
+    const second = component(summary(70, 5, 20));
+    const pooledCurrent = {
+      mean: first.mean + second.mean,
+      standardErrorSquared: first.standardErrorSquared + second.standardErrorSquared,
+      satterthwaiteTerm: first.satterthwaiteTerm + second.satterthwaiteTerm,
+    };
+    const baseFirst = component(summary(50, 3, 20));
+    const baseSecond = component(summary(71, 5, 20));
+    const pooledBase = {
+      mean: baseFirst.mean + baseSecond.mean,
+      standardErrorSquared: baseFirst.standardErrorSquared + baseSecond.standardErrorSquared,
+      satterthwaiteTerm: baseFirst.satterthwaiteTerm + baseSecond.satterthwaiteTerm,
+    };
+    const result = welchTTestFromComponents(pooledCurrent, pooledBase)!;
+    expect(result).not.toBeNull();
+    // Only the second benchmark moved (70 → 71), a 1ms shift on a 120ms total.
+    expect(result.t).toBeCloseTo(-1 / Math.sqrt(pooledCurrent.standardErrorSquared * 2), 6);
   });
 
-  it('is symmetric: F(-t) = 1 - F(t)', () => {
-    const positive = studentTCdf(1.7, 12);
-    const negative = studentTCdf(-1.7, 12);
-    expect(negative).toBeCloseTo(1 - positive, 10);
+  it('is not fooled by an unequal-count mix (high-n low-variance benchmark dominates)', () => {
+    // A benchmark that converged at n=200 with tiny variance should barely widen the standard error,
+    // unlike the old min-count pooling which divided its contribution by the smallest count.
+    const tight = (sampleStdDev: number, n: number, mean: number) =>
+      component(summary(mean, sampleStdDev, n));
+    const current = {
+      mean: 100,
+      standardErrorSquared:
+        tight(1, 200, 90).standardErrorSquared + tight(2, 10, 10).standardErrorSquared,
+      satterthwaiteTerm: tight(1, 200, 90).satterthwaiteTerm + tight(2, 10, 10).satterthwaiteTerm,
+    };
+    const base = {
+      mean: 105,
+      standardErrorSquared: current.standardErrorSquared,
+      satterthwaiteTerm: current.satterthwaiteTerm,
+    };
+    const result = welchTTestFromComponents(current, base)!;
+    // A 5ms grand-total shift against a small pooled standard error is clearly significant.
+    expect(result.pValue).toBeLessThan(0.05);
   });
 
-  it('approaches 1 far out in the upper tail', () => {
-    expect(studentTCdf(50, 10)).toBeCloseTo(1, 6);
+  it('returns null when both sides are varianceless', () => {
+    const zero = { mean: 10, standardErrorSquared: 0, satterthwaiteTerm: 0 };
+    expect(welchTTestFromComponents(zero, { ...zero, mean: 12 })).toBeNull();
   });
 });
 

--- a/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.test.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { welchTTest, welchTTestFromComponents, regularizedIncompleteBeta } from './welchTTest';
-import type { SampleSummary } from './welchTTest';
+import type { SampleSummary, WelchComponent } from './welchTTest';
 
 /**
  * Builds a summary from a target *sample* standard deviation, converting to the population stdDev
@@ -30,14 +30,26 @@ describe('regularizedIncompleteBeta', () => {
 });
 
 describe('welchTTestFromComponents', () => {
-  /** Reduces a single summary to its Welch component the way `welchTTest` does internally. */
-  function component(sample: SampleSummary) {
+  /**
+   * Reduces a summary to its Welch component independently of production, so the equivalence test
+   * below stays a real cross-check of the math rather than a tautology.
+   */
+  function component(sample: SampleSummary): WelchComponent {
     const standardErrorSquared = (sample.stdDev * sample.stdDev) / (sample.n - 1);
     return {
       mean: sample.mean,
       standardErrorSquared,
       satterthwaiteTerm: (standardErrorSquared * standardErrorSquared) / (sample.n - 1),
     };
+  }
+
+  /** Sums components the way the grand-total fold pools independent benchmarks. */
+  function pool(...components: WelchComponent[]): WelchComponent {
+    return components.reduce((acc, comp) => ({
+      mean: acc.mean + comp.mean,
+      standardErrorSquared: acc.standardErrorSquared + comp.standardErrorSquared,
+      satterthwaiteTerm: acc.satterthwaiteTerm + comp.satterthwaiteTerm,
+    }));
   }
 
   it('reproduces welchTTest for single-sample components', () => {
@@ -52,43 +64,20 @@ describe('welchTTestFromComponents', () => {
 
   it('pools independent series by summing standard errors and Satterthwaite terms', () => {
     // A grand total of two equal-count benchmarks equals a single series with the summed means and
-    // the summed standard-error² — the components just add.
-    const first = component(summary(50, 3, 20));
-    const second = component(summary(70, 5, 20));
-    const pooledCurrent = {
-      mean: first.mean + second.mean,
-      standardErrorSquared: first.standardErrorSquared + second.standardErrorSquared,
-      satterthwaiteTerm: first.satterthwaiteTerm + second.satterthwaiteTerm,
-    };
-    const baseFirst = component(summary(50, 3, 20));
-    const baseSecond = component(summary(71, 5, 20));
-    const pooledBase = {
-      mean: baseFirst.mean + baseSecond.mean,
-      standardErrorSquared: baseFirst.standardErrorSquared + baseSecond.standardErrorSquared,
-      satterthwaiteTerm: baseFirst.satterthwaiteTerm + baseSecond.satterthwaiteTerm,
-    };
+    // standard-error² — the components just add. Only the second benchmark moves (70 → 71).
+    const pooledCurrent = pool(component(summary(50, 3, 20)), component(summary(70, 5, 20)));
+    const pooledBase = pool(component(summary(50, 3, 20)), component(summary(71, 5, 20)));
     const result = welchTTestFromComponents(pooledCurrent, pooledBase)!;
     expect(result).not.toBeNull();
-    // Only the second benchmark moved (70 → 71), a 1ms shift on a 120ms total.
+    // A 1ms shift on a 120ms total, against the pooled standard error.
     expect(result.t).toBeCloseTo(-1 / Math.sqrt(pooledCurrent.standardErrorSquared * 2), 6);
   });
 
   it('is not fooled by an unequal-count mix (high-n low-variance benchmark dominates)', () => {
-    // A benchmark that converged at n=200 with tiny variance should barely widen the standard error,
+    // A benchmark that converged at n=200 with tiny variance barely widens the standard error,
     // unlike the old min-count pooling which divided its contribution by the smallest count.
-    const tight = (sampleStdDev: number, n: number, mean: number) =>
-      component(summary(mean, sampleStdDev, n));
-    const current = {
-      mean: 100,
-      standardErrorSquared:
-        tight(1, 200, 90).standardErrorSquared + tight(2, 10, 10).standardErrorSquared,
-      satterthwaiteTerm: tight(1, 200, 90).satterthwaiteTerm + tight(2, 10, 10).satterthwaiteTerm,
-    };
-    const base = {
-      mean: 105,
-      standardErrorSquared: current.standardErrorSquared,
-      satterthwaiteTerm: current.satterthwaiteTerm,
-    };
+    const current = pool(component(summary(90, 1, 200)), component(summary(10, 2, 10)));
+    const base = { ...current, mean: current.mean + 5 };
     const result = welchTTestFromComponents(current, base)!;
     // A 5ms grand-total shift against a small pooled standard error is clearly significant.
     expect(result.pValue).toBeLessThan(0.05);

--- a/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.ts
@@ -1,0 +1,192 @@
+/**
+ * Welch's two-sample t-test and the supporting Student-t distribution, implemented from summary
+ * statistics only (no raw samples). This is the significance gate the benchmark comparison uses to
+ * decide whether a mean difference is real before flagging it.
+ *
+ * Custom (no dependency) per the repo's "avoid dependencies" guidance: the only non-trivial piece
+ * is the regularized incomplete beta function, a standard numerical routine.
+ */
+
+/** Summary of one measured series. `stdDev` is the population standard deviation (÷n). */
+export interface SampleSummary {
+  mean: number;
+  /** Population standard deviation as produced by the harness (`calculateStdDev`, divides by n). */
+  stdDev: number;
+  /** Effective sample count behind `mean`/`stdDev`. */
+  n: number;
+}
+
+export interface WelchResult {
+  /** The t statistic. Positive when `a.mean > b.mean`. */
+  t: number;
+  /** Welch–Satterthwaite degrees of freedom. */
+  df: number;
+  /** Two-sided p-value: the probability of a |t| at least this large under the null hypothesis. */
+  pValue: number;
+}
+
+// Lanczos approximation coefficients (g = 7), accurate to ~15 significant digits.
+const LANCZOS_G = 7;
+const LANCZOS_COEFFICIENTS = [
+  0.99999999999980993, 676.5203681218851, -1259.1392167224028, 771.32342877765313,
+  -176.61502916214059, 12.507343278686905, -0.13857109526572012, 9.9843695780195716e-6,
+  1.5056327351493116e-7,
+];
+
+/** Natural log of the gamma function via the Lanczos approximation. */
+function logGamma(value: number): number {
+  if (value < 0.5) {
+    // Reflection formula for the left half-plane.
+    return Math.log(Math.PI / Math.sin(Math.PI * value)) - logGamma(1 - value);
+  }
+  const shifted = value - 1;
+  let series = LANCZOS_COEFFICIENTS[0];
+  for (let index = 1; index < LANCZOS_G + 2; index += 1) {
+    series += LANCZOS_COEFFICIENTS[index] / (shifted + index);
+  }
+  const tValue = shifted + LANCZOS_G + 0.5;
+  return (
+    0.5 * Math.log(2 * Math.PI) + (shifted + 0.5) * Math.log(tValue) - tValue + Math.log(series)
+  );
+}
+
+/**
+ * Continued-fraction expansion for the incomplete beta function, evaluated with the modified Lentz
+ * algorithm (Numerical Recipes, §6.4). Converges rapidly for `x < (a+1)/(a+b+2)`.
+ */
+function betaContinuedFraction(x: number, a: number, b: number): number {
+  const MAX_ITERATIONS = 200;
+  const EPSILON = 3e-12;
+  const TINY = 1e-300;
+
+  const qab = a + b;
+  const qap = a + 1;
+  const qam = a - 1;
+
+  let cTerm = 1;
+  let dTerm = 1 - (qab * x) / qap;
+  if (Math.abs(dTerm) < TINY) {
+    dTerm = TINY;
+  }
+  dTerm = 1 / dTerm;
+  let result = dTerm;
+
+  for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration += 1) {
+    const even = 2 * iteration;
+
+    // Even step of the recurrence.
+    let numerator = (iteration * (b - iteration) * x) / ((qam + even) * (a + even));
+    dTerm = 1 + numerator * dTerm;
+    if (Math.abs(dTerm) < TINY) {
+      dTerm = TINY;
+    }
+    cTerm = 1 + numerator / cTerm;
+    if (Math.abs(cTerm) < TINY) {
+      cTerm = TINY;
+    }
+    dTerm = 1 / dTerm;
+    result *= dTerm * cTerm;
+
+    // Odd step of the recurrence.
+    numerator = (-(a + iteration) * (qab + iteration) * x) / ((a + even) * (qap + even));
+    dTerm = 1 + numerator * dTerm;
+    if (Math.abs(dTerm) < TINY) {
+      dTerm = TINY;
+    }
+    cTerm = 1 + numerator / cTerm;
+    if (Math.abs(cTerm) < TINY) {
+      cTerm = TINY;
+    }
+    dTerm = 1 / dTerm;
+    const delta = dTerm * cTerm;
+    result *= delta;
+
+    if (Math.abs(delta - 1) < EPSILON) {
+      break;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Regularized incomplete beta function `I_x(a, b)`. Returns a value in `[0, 1]`.
+ *
+ * See https://en.wikipedia.org/wiki/Beta_function#Incomplete_beta_function
+ */
+export function regularizedIncompleteBeta(x: number, a: number, b: number): number {
+  if (x <= 0) {
+    return 0;
+  }
+  if (x >= 1) {
+    return 1;
+  }
+
+  const logFront =
+    logGamma(a + b) - logGamma(a) - logGamma(b) + a * Math.log(x) + b * Math.log(1 - x);
+  const front = Math.exp(logFront);
+
+  // Use the expansion that converges fastest for this x, and the symmetry
+  // I_x(a, b) = 1 - I_{1-x}(b, a) otherwise.
+  if (x < (a + 1) / (a + b + 2)) {
+    return (front * betaContinuedFraction(x, a, b)) / a;
+  }
+  return 1 - (front * betaContinuedFraction(1 - x, b, a)) / b;
+}
+
+/**
+ * Cumulative distribution function of Student's t-distribution: `P(T <= t)` for `df` degrees of
+ * freedom.
+ */
+export function studentTCdf(t: number, df: number): number {
+  if (!Number.isFinite(t)) {
+    return t > 0 ? 1 : 0;
+  }
+  // Two-sided tail mass = I_x(df/2, 1/2), split symmetrically around 0.
+  const x = df / (df + t * t);
+  const tail = 0.5 * regularizedIncompleteBeta(x, df / 2, 0.5);
+  return t >= 0 ? 1 - tail : tail;
+}
+
+/**
+ * Two-sided p-value for a t statistic — `P(|T| >= |t|)`. Computed directly from the incomplete
+ * beta (not `2 * (1 - cdf)`) so it stays accurate deep in the tail where the CDF rounds to 1.
+ */
+function studentTTwoSidedPValue(t: number, df: number): number {
+  if (!Number.isFinite(t)) {
+    return 0;
+  }
+  const x = df / (df + t * t);
+  return regularizedIncompleteBeta(x, df / 2, 0.5);
+}
+
+/**
+ * Welch's t-test for two independent series described by their summary statistics. Handles unequal
+ * variances and unequal sample sizes (which adaptive sampling produces).
+ *
+ * Returns `null` when the test is undefined — either side has `n < 2`, or both sides have zero
+ * variance — so the caller can fall back to a non-statistical comparison.
+ */
+export function welchTTest(a: SampleSummary, b: SampleSummary): WelchResult | null {
+  if (a.n < 2 || b.n < 2) {
+    return null;
+  }
+
+  // Convert the stored population variance (÷n) to the sample variance (÷n-1) the t-test assumes.
+  const sampleVarianceA = (a.stdDev * a.stdDev * a.n) / (a.n - 1);
+  const sampleVarianceB = (b.stdDev * b.stdDev * b.n) / (b.n - 1);
+
+  const standardErrorA = sampleVarianceA / a.n;
+  const standardErrorB = sampleVarianceB / b.n;
+  const combinedStandardError = standardErrorA + standardErrorB;
+  if (combinedStandardError === 0) {
+    return null;
+  }
+
+  const t = (a.mean - b.mean) / Math.sqrt(combinedStandardError);
+  const df =
+    (combinedStandardError * combinedStandardError) /
+    ((standardErrorA * standardErrorA) / (a.n - 1) + (standardErrorB * standardErrorB) / (b.n - 1));
+
+  return { t, df, pValue: studentTTwoSidedPValue(t, df) };
+}

--- a/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.ts
@@ -161,8 +161,12 @@ export interface WelchComponent {
   satterthwaiteTerm: number;
 }
 
-/** Reduces a single series summary to its Welch component. Returns `null` for `n < 2`. */
-function sampleComponent(sample: SampleSummary): WelchComponent | null {
+/**
+ * Reduces a single series summary to its Welch component. Returns `null` for `n < 2`. Shared so the
+ * grand-total comparison can pool components across benchmarks from one definition of the variance
+ * arithmetic rather than re-deriving it.
+ */
+export function sampleComponent(sample: SampleSummary): WelchComponent | null {
   if (sample.n < 2) {
     return null;
   }

--- a/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.ts
+++ b/apps/code-infra-dashboard/src/lib/benchmark/welchTTest.ts
@@ -135,20 +135,6 @@ export function regularizedIncompleteBeta(x: number, a: number, b: number): numb
 }
 
 /**
- * Cumulative distribution function of Student's t-distribution: `P(T <= t)` for `df` degrees of
- * freedom.
- */
-export function studentTCdf(t: number, df: number): number {
-  if (!Number.isFinite(t)) {
-    return t > 0 ? 1 : 0;
-  }
-  // Two-sided tail mass = I_x(df/2, 1/2), split symmetrically around 0.
-  const x = df / (df + t * t);
-  const tail = 0.5 * regularizedIncompleteBeta(x, df / 2, 0.5);
-  return t >= 0 ? 1 - tail : tail;
-}
-
-/**
  * Two-sided p-value for a t statistic — `P(|T| >= |t|)`. Computed directly from the incomplete
  * beta (not `2 * (1 - cdf)`) so it stays accurate deep in the tail where the CDF rounds to 1.
  */
@@ -161,6 +147,57 @@ function studentTTwoSidedPValue(t: number, df: number): number {
 }
 
 /**
+ * One side of a Welch test reduced to the quantities that actually combine: its mean, the variance
+ * of that mean estimate (`standardErrorSquared`), and its Satterthwaite term. For a single sample
+ * the term is `(standardErrorSquared)² / (n - 1)`; for a *sum* of independent series (e.g. a grand
+ * total across benchmarks) the standard errors and the terms simply add, which is what lets the
+ * totals comparison pool unequal-count benchmarks correctly.
+ */
+export interface WelchComponent {
+  mean: number;
+  /** Variance of the mean estimate — the standard error squared. */
+  standardErrorSquared: number;
+  /** Satterthwaite denominator contribution; combines across both sides into the degrees of freedom. */
+  satterthwaiteTerm: number;
+}
+
+/** Reduces a single series summary to its Welch component. Returns `null` for `n < 2`. */
+function sampleComponent(sample: SampleSummary): WelchComponent | null {
+  if (sample.n < 2) {
+    return null;
+  }
+  // Convert the stored population variance (÷n) to the variance of the mean:
+  // s²/n = (stdDev² · n/(n-1)) / n = stdDev²/(n-1).
+  const standardErrorSquared = (sample.stdDev * sample.stdDev) / (sample.n - 1);
+  return {
+    mean: sample.mean,
+    standardErrorSquared,
+    satterthwaiteTerm: (standardErrorSquared * standardErrorSquared) / (sample.n - 1),
+  };
+}
+
+/**
+ * Welch's t-test from two already-reduced {@link WelchComponent}s — the shared core. The summary-
+ * stats {@link welchTTest} and the grand-total comparison (which sums components across independent
+ * benchmarks) both funnel through here.
+ *
+ * Returns `null` when the test is undefined: the combined standard error or the Satterthwaite
+ * denominator is zero (both sides effectively varianceless).
+ */
+export function welchTTestFromComponents(a: WelchComponent, b: WelchComponent): WelchResult | null {
+  const combinedStandardError = a.standardErrorSquared + b.standardErrorSquared;
+  const satterthwaiteDenominator = a.satterthwaiteTerm + b.satterthwaiteTerm;
+  if (combinedStandardError <= 0 || satterthwaiteDenominator <= 0) {
+    return null;
+  }
+
+  const t = (a.mean - b.mean) / Math.sqrt(combinedStandardError);
+  const df = (combinedStandardError * combinedStandardError) / satterthwaiteDenominator;
+
+  return { t, df, pValue: studentTTwoSidedPValue(t, df) };
+}
+
+/**
  * Welch's t-test for two independent series described by their summary statistics. Handles unequal
  * variances and unequal sample sizes (which adaptive sampling produces).
  *
@@ -168,25 +205,10 @@ function studentTTwoSidedPValue(t: number, df: number): number {
  * variance — so the caller can fall back to a non-statistical comparison.
  */
 export function welchTTest(a: SampleSummary, b: SampleSummary): WelchResult | null {
-  if (a.n < 2 || b.n < 2) {
+  const componentA = sampleComponent(a);
+  const componentB = sampleComponent(b);
+  if (!componentA || !componentB) {
     return null;
   }
-
-  // Convert the stored population variance (÷n) to the sample variance (÷n-1) the t-test assumes.
-  const sampleVarianceA = (a.stdDev * a.stdDev * a.n) / (a.n - 1);
-  const sampleVarianceB = (b.stdDev * b.stdDev * b.n) / (b.n - 1);
-
-  const standardErrorA = sampleVarianceA / a.n;
-  const standardErrorB = sampleVarianceB / b.n;
-  const combinedStandardError = standardErrorA + standardErrorB;
-  if (combinedStandardError === 0) {
-    return null;
-  }
-
-  const t = (a.mean - b.mean) / Math.sqrt(combinedStandardError);
-  const df =
-    (combinedStandardError * combinedStandardError) /
-    ((standardErrorA * standardErrorA) / (a.n - 1) + (standardErrorB * standardErrorB) / (b.n - 1));
-
-  return { t, df, pValue: studentTTwoSidedPValue(t, df) };
+  return welchTTestFromComponents(componentA, componentB);
 }

--- a/apps/code-infra-dashboard/src/utils/formatters.ts
+++ b/apps/code-infra-dashboard/src/utils/formatters.ts
@@ -49,6 +49,11 @@ export function formatMetricDiff(value: number, format?: Intl.NumberFormatOption
     : formatDiffMs(value);
 }
 
+/** Compact p-value label, e.g. `p=0.031` or `p<0.001` for values too small to show at 3 decimals. */
+export function formatPValue(pValue: number): string {
+  return pValue < 0.001 ? 'p<0.001' : `p=${pValue.toFixed(3)}`;
+}
+
 interface ColumnDefinition {
   field: string;
   header?: string;

--- a/packages/benchmark/src/Metric.ts
+++ b/packages/benchmark/src/Metric.ts
@@ -36,6 +36,33 @@ function flush(test: RunnerTestCase, accumulator: TestAccumulator): void {
   test.meta.benchmarkMetrics = store;
 }
 
+/**
+ * Snapshot of the raw samples collected so far for a test's alarmed scalar metrics — one array per
+ * (metric, sub-series). The adaptive stopping rule reads this so measurement keeps sampling while
+ * any metric that will be significance-tested downstream is still imprecise, not just the render
+ * duration.
+ *
+ * Discrete metrics (compared as exact counts) and informational scalar metrics (shown but never
+ * flagged) are excluded: their precision never changes a verdict, and gating on a noisy one would
+ * needlessly block convergence.
+ */
+export function collectAdaptiveMetricSamples(test: RunnerTestCase): number[][] {
+  const accumulator = accumulators.get(test);
+  if (!accumulator) {
+    return [];
+  }
+  const sampleSets: number[][] = [];
+  for (const entry of accumulator.values()) {
+    if (entry.kind !== 'scalar' || entry.config.alarm === undefined) {
+      continue;
+    }
+    for (const samples of entry.series.values()) {
+      sampleSets.push(samples);
+    }
+  }
+  return sampleSets;
+}
+
 export interface MetricRecordOptions {
   /** Sub-series label. Recorded under `${name}#${id}` in the report; omit for the base series. */
   id?: string;

--- a/packages/benchmark/src/Metric.ts
+++ b/packages/benchmark/src/Metric.ts
@@ -27,7 +27,9 @@ function flush(test: RunnerTestCase, accumulator: TestAccumulator): void {
   for (const [name, entry] of accumulator) {
     const series: Record<string, MetricSampleStats> = {};
     for (const [seriesId, samples] of entry.series) {
-      series[seriesId] = { ...aggregateSamples(samples), count: samples.length };
+      // `aggregateSamples` reports the effective (post-outlier-removal) count as `count`, which is
+      // the `n` behind mean/stdDev — exactly what a downstream Welch's t-test needs.
+      series[seriesId] = aggregateSamples(samples);
     }
     store[name] = { kind: entry.kind, config: entry.config, series };
   }

--- a/packages/benchmark/src/Metric.ts
+++ b/packages/benchmark/src/Metric.ts
@@ -36,28 +36,39 @@ function flush(test: RunnerTestCase, accumulator: TestAccumulator): void {
   test.meta.benchmarkMetrics = store;
 }
 
+/** One alarmed scalar (sub-)series the adaptive stopping rule tracks, named for reporting. */
+export interface AdaptiveMetricSamples {
+  /** Metric name, with a `#sub-series` suffix for named sub-series. */
+  name: string;
+  samples: number[];
+}
+
 /**
- * Snapshot of the raw samples collected so far for a test's alarmed scalar metrics — one array per
- * (metric, sub-series). The adaptive stopping rule reads this so measurement keeps sampling while
- * any metric that will be significance-tested downstream is still imprecise, not just the render
- * duration.
+ * Snapshot of the raw samples collected so far for a test's alarmed scalar metrics — one entry per
+ * (metric, sub-series), each named. The adaptive stopping rule reads this so measurement keeps
+ * sampling while any metric that will be significance-tested downstream is still imprecise, not just
+ * the render duration, and so a non-convergence warning can name the specific metric that stayed
+ * noisy.
  *
  * Discrete metrics (compared as exact counts) and informational scalar metrics (shown but never
  * flagged) are excluded: their precision never changes a verdict, and gating on a noisy one would
  * needlessly block convergence.
  */
-export function collectAdaptiveMetricSamples(test: RunnerTestCase): number[][] {
+export function collectAdaptiveMetricSamples(test: RunnerTestCase): AdaptiveMetricSamples[] {
   const accumulator = accumulators.get(test);
   if (!accumulator) {
     return [];
   }
-  const sampleSets: number[][] = [];
-  for (const entry of accumulator.values()) {
+  const sampleSets: AdaptiveMetricSamples[] = [];
+  for (const [metricName, entry] of accumulator) {
     if (entry.kind !== 'scalar' || entry.config.alarm === undefined) {
       continue;
     }
-    for (const samples of entry.series.values()) {
-      sampleSets.push(samples);
+    for (const [seriesId, samples] of entry.series) {
+      sampleSets.push({
+        name: seriesId === '' ? metricName : `${metricName}#${seriesId}`,
+        samples,
+      });
     }
   }
   return sampleSets;

--- a/packages/benchmark/src/ciReport.ts
+++ b/packages/benchmark/src/ciReport.ts
@@ -65,6 +65,11 @@ const metricStatsSchema = z.object({
 const benchmarkReportEntrySchema = z.object({
   iterations: z.number(),
   totalDuration: z.number(),
+  // Spread and effective sample count of the per-iteration total duration, used as the stdDev/`n`
+  // for the comparison's Welch test on total duration. Optional for backward compatibility with
+  // uploads made before they were added.
+  totalStdDev: z.number().optional(),
+  totalCount: z.number().optional(),
   renders: z.array(renderStatsSchema),
   metrics: z.record(z.string(), metricStatsSchema),
 });

--- a/packages/benchmark/src/ciReport.ts
+++ b/packages/benchmark/src/ciReport.ts
@@ -49,12 +49,17 @@ const renderStatsSchema = z.object({
   actualDuration: z.number(),
   stdDev: z.number(),
   outliers: z.number(),
+  // Effective sample count behind mean/stdDev, used as `n` for the comparison's Welch's t-test.
+  // Optional so baselines uploaded before it was added still parse.
+  count: z.number().optional(),
 });
 
 const metricStatsSchema = z.object({
   mean: z.number(),
   stdDev: z.number(),
   outliers: z.number(),
+  // See `renderStatsSchema.count`. Optional for backward compatibility with older uploads.
+  count: z.number().optional(),
 });
 
 const benchmarkReportEntrySchema = z.object({

--- a/packages/benchmark/src/format.test.ts
+++ b/packages/benchmark/src/format.test.ts
@@ -10,12 +10,12 @@ describe('printTable', () => {
 
     printTable(
       [
-        { header: 'Name', width: 6 },
-        { header: 'Value', width: 5 },
+        { header: 'Name', minWidth: 6 },
+        { header: 'Value', minWidth: 5 },
       ],
       [
-        ['   foo', '   10'],
-        ['   bar', '   20'],
+        ['foo', '10'],
+        ['bar', '20'],
       ],
     );
 
@@ -42,7 +42,7 @@ describe('printTable', () => {
   it('prints a footer when provided', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    printTable([{ header: 'Col', width: 6 }], [['   foo']], 'summary line');
+    printTable([{ header: 'Col', minWidth: 6 }], [['foo']], 'summary line');
 
     const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
 
@@ -56,7 +56,7 @@ describe('printTable', () => {
   it('prints header with no rows', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    printTable([{ header: 'Col', width: 4 }], []);
+    printTable([{ header: 'Col', minWidth: 4 }], []);
 
     const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
 
@@ -71,10 +71,10 @@ describe('printTable', () => {
 
     printTable(
       [
-        { header: 'Name', width: 6 },
-        { header: 'Value', width: 5 },
+        { header: 'Name', minWidth: 6 },
+        { header: 'Value', minWidth: 5 },
       ],
-      [['   foo', '   10']],
+      [['foo', '10']],
       undefined,
       'My Title',
     );
@@ -105,10 +105,10 @@ describe('printTable', () => {
 
     printTable(
       [
-        { header: 'Name', width: 6 },
-        { header: 'Value', width: 5 },
+        { header: 'Name', minWidth: 6 },
+        { header: 'Value', minWidth: 5 },
       ],
-      [['   foo', '   10']],
+      [['foo', '10']],
       undefined,
       longTitle,
     );
@@ -138,8 +138,8 @@ describe('printTable', () => {
     // unit). Every line must still agree on the table width.
     printTable(
       [
-        { header: 'Name', width: 6 },
-        { header: 'Value', width: 5 },
+        { header: 'Name', minWidth: 6 },
+        { header: 'Value', minWidth: 5 },
       ],
       [
         ['foo', '0 ms±0 ms'],
@@ -162,7 +162,7 @@ describe('printTable', () => {
   it('keeps a declared width that is wider than every cell', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    printTable([{ header: 'Col', width: 10 }], [['foo']]);
+    printTable([{ header: 'Col', minWidth: 10 }], [['foo']]);
 
     const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
 
@@ -174,11 +174,66 @@ describe('printTable', () => {
   it('pads coloured cells by their visible width, ignoring escape codes', () => {
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    printTable([{ header: 'Col', width: 6 }], [[cyan('foo')]]);
+    printTable([{ header: 'Col', minWidth: 6 }], [[cyan('foo')]]);
 
     const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
 
     expect(stripAnsi(calls[3])).toBe('│    foo │');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('truncates a cell that exceeds the column maxWidth', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printTable([{ header: 'Col', minWidth: 6, maxWidth: 6 }], [['a-very-long-label']]);
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+
+    expect(stripAnsi(calls[3])).toBe('│ a-ver… │');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('keeps colour codes when truncating, so styling does not leak', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printTable([{ header: 'Col', minWidth: 4, maxWidth: 4 }], [[cyan('longvalue')]]);
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+
+    // Visible text is cut to the cap, and the cell still closes the colour it opened.
+    expect(stripAnsi(calls[3])).toBe('│ lon… │');
+    expect(calls[3]).toContain(cyan('lon'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('grows a column to fit a header wider than its minWidth', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printTable([{ header: 'LongHeader', minWidth: 2 }], [['x']]);
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+
+    expect(stripAnsi(calls[1])).toBe('│ LongHeader │');
+    expect(stripAnsi(calls[3])).toBe('│          x │');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('widens the table for a footer too long for its columns, keeping the text', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const footer = 'F'.repeat(60);
+    printTable([{ header: 'Col', minWidth: 4 }], [['x']], footer);
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+    const widths = calls.map((line) => stripAnsi(line).length);
+
+    // The footer is reported in full and every line still agrees on the table width.
+    expect(stripAnsi(calls[5])).toBe(`│ ${footer} │`);
+    expect(new Set(widths).size).toBe(1);
 
     consoleSpy.mockRestore();
   });
@@ -188,10 +243,10 @@ describe('printTable', () => {
 
     printTable(
       [
-        { header: 'A', width: 4 },
-        { header: 'B', width: 4 },
+        { header: 'A', minWidth: 4 },
+        { header: 'B', minWidth: 4 },
       ],
-      [['  x1', '  x2']],
+      [['x1', 'x2']],
       'footer text',
     );
 

--- a/packages/benchmark/src/format.test.ts
+++ b/packages/benchmark/src/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { printTable } from './format';
+import { cyan, printTable } from './format';
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, '');
@@ -127,6 +127,58 @@ describe('printTable', () => {
     const strippedTitle = stripAnsi(titleLine);
     expect(strippedTitle).toContain('…');
     expect(strippedTitle).toMatch(/… │$/);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('widens a column to fit a cell wider than its declared width', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // The second column declares width 5 but one cell needs 17 (e.g. a metric formatted with a
+    // unit). Every line must still agree on the table width.
+    printTable(
+      [
+        { header: 'Name', width: 6 },
+        { header: 'Value', width: 5 },
+      ],
+      [
+        ['foo', '0 ms±0 ms'],
+        ['bar', '0.456 ms±0.057 ms'],
+      ],
+      'footer text',
+      'My Title',
+    );
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+    const widths = calls.map((line) => stripAnsi(line).length);
+
+    expect(new Set(widths).size).toBe(1);
+    // 6 + 17 for the columns, 2 padding spaces each, 3 vertical borders.
+    expect(widths[0]).toBe(6 + 17 + 4 + 3);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('keeps a declared width that is wider than every cell', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printTable([{ header: 'Col', width: 10 }], [['foo']]);
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+
+    expect(stripAnsi(calls[3])).toBe('│        foo │');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('pads coloured cells by their visible width, ignoring escape codes', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    printTable([{ header: 'Col', width: 6 }], [[cyan('foo')]]);
+
+    const calls = consoleSpy.mock.calls.map((call) => call[0] as string);
+
+    expect(stripAnsi(calls[3])).toBe('│    foo │');
 
     consoleSpy.mockRestore();
   });

--- a/packages/benchmark/src/format.ts
+++ b/packages/benchmark/src/format.ts
@@ -13,6 +13,10 @@ export function fileUrl(filePath: string): string {
 
 interface Column {
   header: string;
+  /**
+   * Minimum width. A column grows to fit its widest cell, so callers only need to pick the width
+   * they want the column to keep when its content is narrower.
+   */
   width: number;
 }
 
@@ -23,13 +27,28 @@ function truncate(str: string, maxLength: number): string {
   return `${str.slice(0, maxLength - 1)}…`;
 }
 
+/** Right-aligns to a visible width, so colour codes in the cell don't eat into the padding. */
+function padCell(cell: string, width: number): string {
+  return ' '.repeat(Math.max(0, width - stripAnsi(cell).length)) + cell;
+}
+
 export function printTable(
   columns: Column[],
   rows: string[][],
   footer?: string,
   title?: string,
 ): void {
-  const colWidths = columns.map((col) => col.width);
+  // Declared widths are minimums: cells are sized off content, because a caller can't know how wide
+  // a value will render (a metric carrying a unit — `0.456 ms±0.057 ms` — is far wider than a bare
+  // `0.46±0.06`). Padding a cell that already overflows its column is a no-op, which used to let one
+  // long value push that row's dividers out of line with every other row.
+  const colWidths = columns.map((col, index) =>
+    Math.max(
+      col.width,
+      stripAnsi(col.header).length,
+      ...rows.map((row) => stripAnsi(row[index] ?? '').length),
+    ),
+  );
   const totalInner = colWidths.reduce((sum, w) => sum + w + 2, 0) + colWidths.length - 1;
 
   if (title) {
@@ -52,7 +71,7 @@ export function printTable(
   }
 
   const headerSep = dim(`├${colWidths.map((w) => '─'.repeat(w + 2)).join('┼')}┤`);
-  const headerCells = columns.map((col) => ` ${col.header.padStart(col.width)} `);
+  const headerCells = columns.map((col, index) => ` ${padCell(col.header, colWidths[index])} `);
   const headerLine = dim('│') + headerCells.join(dim('│')) + dim('│');
 
   // eslint-disable-next-line no-console
@@ -61,7 +80,7 @@ export function printTable(
   console.log(headerSep);
 
   for (const row of rows) {
-    const cells = row.map((cell, i) => ` ${cell.padStart(colWidths[i])} `);
+    const cells = row.map((cell, index) => ` ${padCell(cell, colWidths[index])} `);
     // eslint-disable-next-line no-console
     console.log(dim('│') + cells.join(dim('│')) + dim('│'));
   }

--- a/packages/benchmark/src/format.ts
+++ b/packages/benchmark/src/format.ts
@@ -11,25 +11,61 @@ export function fileUrl(filePath: string): string {
   return pathToFileURL(filePath).href;
 }
 
-interface Column {
-  header: string;
-  /**
-   * Minimum width. A column grows to fit its widest cell, so callers only need to pick the width
-   * they want the column to keep when its content is narrower.
-   */
-  width: number;
+/** Matches an ANSI colour code. Captured, so `split` keeps the codes alongside the text. */
+// eslint-disable-next-line no-control-regex
+const ANSI_PATTERN = /(\x1b\[[0-9;]*m)/g;
+
+function stripAnsi(str: string): string {
+  return str.replace(ANSI_PATTERN, '');
 }
 
-function truncate(str: string, maxLength: number): string {
-  if (str.length <= maxLength) {
+export interface Column {
+  header: string;
+  /** Width the column keeps when every cell is narrower. It grows to fit a wider cell. */
+  minWidth: number;
+  /**
+   * Width the column may not exceed; wider cells are truncated with an ellipsis. Omit to let the
+   * column grow freely, which is what a value the caller can't pre-measure (a metric formatted with
+   * an arbitrary unit) needs — truncating those would destroy the number the table exists to show.
+   */
+  maxWidth?: number;
+}
+
+/** Printable width, i.e. ignoring the zero-width ANSI escape codes that colour a string. */
+function visibleWidth(str: string): number {
+  return stripAnsi(str).length;
+}
+
+/**
+ * Truncates to a visible width, marking the cut with an ellipsis. Escape codes are carried over
+ * rather than counted, so a styled string keeps the closing code that would otherwise be dropped
+ * along with the text it terminated (leaving the rest of the terminal painted).
+ */
+function truncate(str: string, maxWidth: number): string {
+  if (visibleWidth(str) <= maxWidth) {
     return str;
   }
-  return `${str.slice(0, maxLength - 1)}…`;
+  let result = '';
+  let remaining = maxWidth - 1;
+  for (const segment of str.split(ANSI_PATTERN)) {
+    if (segment.startsWith('\x1b')) {
+      result += segment;
+    } else if (remaining > 0) {
+      result += segment.slice(0, remaining);
+      remaining -= Math.min(segment.length, remaining);
+    }
+  }
+  return `${result}…`;
 }
 
 /** Right-aligns to a visible width, so colour codes in the cell don't eat into the padding. */
 function padCell(cell: string, width: number): string {
-  return ' '.repeat(Math.max(0, width - stripAnsi(cell).length)) + cell;
+  return ' '.repeat(Math.max(0, width - visibleWidth(cell))) + cell;
+}
+
+/** Fits a string to an exact visible width, truncating or padding as needed. */
+function fitCell(cell: string, width: number): string {
+  return padCell(truncate(cell, width), width);
 }
 
 export function printTable(
@@ -38,23 +74,34 @@ export function printTable(
   footer?: string,
   title?: string,
 ): void {
-  // Declared widths are minimums: cells are sized off content, because a caller can't know how wide
-  // a value will render (a metric carrying a unit — `0.456 ms±0.057 ms` — is far wider than a bare
-  // `0.46±0.06`). Padding a cell that already overflows its column is a no-op, which used to let one
-  // long value push that row's dividers out of line with every other row.
-  const colWidths = columns.map((col, index) =>
-    Math.max(
-      col.width,
-      stripAnsi(col.header).length,
-      ...rows.map((row) => stripAnsi(row[index] ?? '').length),
-    ),
-  );
-  const totalInner = colWidths.reduce((sum, w) => sum + w + 2, 0) + colWidths.length - 1;
+  // Cells are sized off content, because a caller can't know how wide a value will render (a metric
+  // carrying a unit — `0.456 ms±0.057 ms` — is far wider than a bare `0.46±0.06`). Padding a cell
+  // that already overflows its column is a no-op, which used to let one long value push that row's
+  // dividers out of line with every other row.
+  const colWidths = columns.map((col, index) => {
+    const content = Math.max(
+      col.minWidth,
+      visibleWidth(col.header),
+      ...rows.map((row) => visibleWidth(row[index] ?? '')),
+    );
+    return col.maxWidth === undefined ? content : Math.min(content, col.maxWidth);
+  });
+
+  const innerWidth = () => colWidths.reduce((sum, w) => sum + w + 2, 0) + colWidths.length - 1;
+  // The footer spans the whole table, so it too can be the widest thing in it. It reports counts
+  // that are worth nothing abbreviated, so the table stretches to fit it — the slack goes on the
+  // last column, keeping the columns left of it where the reader expects. A title, by contrast, is
+  // a name: arbitrarily long, and legible truncated, so it fits itself to the table below.
+  const footerWidth = footer ? visibleWidth(footer) + 2 : 0;
+  if (colWidths.length > 0 && footerWidth > innerWidth()) {
+    colWidths[colWidths.length - 1] += footerWidth - innerWidth();
+  }
+  const totalInner = innerWidth();
 
   if (title) {
     const titleTop = dim(`┌${'─'.repeat(totalInner)}┐`);
     const titleContent = ` ${truncate(title, totalInner - 2)}`;
-    const titlePadding = totalInner - titleContent.length;
+    const titlePadding = totalInner - visibleWidth(titleContent);
     const titleLine = dim('│') + titleContent + ' '.repeat(Math.max(0, titlePadding)) + dim('│');
     const titleSep = dim(`├${colWidths.map((w) => '─'.repeat(w + 2)).join('┬')}┤`);
 
@@ -71,7 +118,7 @@ export function printTable(
   }
 
   const headerSep = dim(`├${colWidths.map((w) => '─'.repeat(w + 2)).join('┼')}┤`);
-  const headerCells = columns.map((col, index) => ` ${padCell(col.header, colWidths[index])} `);
+  const headerCells = columns.map((col, index) => ` ${fitCell(col.header, colWidths[index])} `);
   const headerLine = dim('│') + headerCells.join(dim('│')) + dim('│');
 
   // eslint-disable-next-line no-console
@@ -80,7 +127,8 @@ export function printTable(
   console.log(headerSep);
 
   for (const row of rows) {
-    const cells = row.map((cell, index) => ` ${padCell(cell, colWidths[index])} `);
+    // Driven by the columns, not the row, so a short row still emits every cell and divider.
+    const cells = colWidths.map((width, index) => ` ${fitCell(row[index] ?? '', width)} `);
     // eslint-disable-next-line no-console
     console.log(dim('│') + cells.join(dim('│')) + dim('│'));
   }
@@ -88,7 +136,7 @@ export function printTable(
   if (footer) {
     const footerSep = dim(`├${colWidths.map((w) => '─'.repeat(w + 2)).join('┴')}┤`);
     const footerContent = ` ${footer}`;
-    const padding = totalInner - stripAnsi(footerContent).length;
+    const padding = totalInner - visibleWidth(footerContent);
     const footerLine = dim('│') + footerContent + ' '.repeat(Math.max(0, padding)) + dim('│');
     const bottomBorder = dim(`└${'─'.repeat(totalInner)}┘`);
 
@@ -103,10 +151,4 @@ export function printTable(
     // eslint-disable-next-line no-console
     console.log(bottomBorder);
   }
-}
-
-// Strip ANSI escape codes to measure visible string length
-function stripAnsi(str: string): string {
-  // eslint-disable-next-line no-control-regex
-  return str.replace(/\x1b\[[0-9;]*m/g, '');
 }

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -240,7 +240,7 @@ interface BenchmarkOptions {
   /**
    * Adaptive sampling: the harness keeps measuring until the mean render duration is estimated to
    * within `targetRme`, then stops. `minRuns` is the floor before the stopping rule can trigger,
-   * `maxRuns` the ceiling. Ignored when `runs` is set. Defaults: `minRuns` 10, `maxRuns` 100.
+   * `maxRuns` the ceiling. Ignored when `runs` is set. Defaults: `minRuns` 10, `maxRuns` 50.
    */
   minRuns?: number;
   maxRuns?: number;
@@ -296,7 +296,7 @@ export function benchmark(
     // A fixed `runs` pins both bounds; otherwise sample adaptively between min and max.
     const isAdaptive = options?.runs === undefined;
     const minRuns = options?.runs ?? options?.minRuns ?? 10;
-    const maxRuns = options?.runs ?? options?.maxRuns ?? 100;
+    const maxRuns = options?.runs ?? options?.maxRuns ?? 50;
     const targetRme = options?.targetRme ?? 0.02;
 
     // Fail fast on misconfigured sampling bounds rather than silently running a surprising loop.

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -317,6 +317,9 @@ export function benchmark(
     // Relative margin of error of the render duration at the last stopping check — reused for the
     // non-convergence warning instead of recomputing the same trim/variance pass.
     let durationRme = Infinity;
+    // Per-metric relative margin of error from the last stopping check (only populated once render
+    // duration has converged), named so the non-convergence warning can point at the noisy metric.
+    let metricRmes: { name: string; rme: number }[] = [];
 
     // Paint timings are recorded as one harness-owned `bench:paint` metric: the default sentinel
     // is the base series (`bench:paint`) and named `elementtiming` markers are sub-series
@@ -433,30 +436,43 @@ export function benchmark(
       if (!isWarmup && iterationDurations.length >= minRuns) {
         durationRme = relativeMarginOfError(iterationDurations);
         // Duration is the primary (and usually last-to-tighten) signal, so check it first: the
-        // per-metric margin-of-error pass only runs once duration itself has converged.
-        const converged =
-          durationRme <= targetRme &&
-          collectAdaptiveMetricSamples(task).every(
-            (samples) => relativeMarginOfError(samples) <= targetRme,
-          );
-        if (converged) {
-          break;
+        // per-metric margin-of-error pass only runs once duration itself has converged. A
+        // zero-centered metric (mean <= 0) yields a margin of error of 0 — relative precision is
+        // undefined for it — so it never blocks; such a metric can't fire a relative alarm anyway.
+        if (durationRme <= targetRme) {
+          metricRmes = collectAdaptiveMetricSamples(task).map(({ name: metricName, samples }) => ({
+            name: metricName,
+            rme: relativeMarginOfError(samples),
+          }));
+          if (metricRmes.every(({ rme }) => rme <= targetRme)) {
+            break;
+          }
         }
       }
     }
 
-    // Warn only when adaptive sampling exhausted `maxRuns` without every signal reaching `targetRme`
-    // — the common (converged) case stays quiet so large suites don't flood CI logs. Skipped in
-    // fixed mode (`runs` set), where there is no convergence target to miss. The measured iteration
-    // count itself is already reported per benchmark by the reporter.
+    // Warn only when adaptive sampling exhausted `maxRuns` without every signal reaching `targetRme`,
+    // naming each signal that stayed noisy so the author knows what to fix — the common (converged)
+    // case stays quiet so large suites don't flood CI logs. Skipped in fixed mode (`runs` set), where
+    // there is no convergence target to miss. Reuses the margins of error already computed above.
     if (isAdaptive && iterationDurations.length >= maxRuns) {
-      const metricRmes = collectAdaptiveMetricSamples(task).map(relativeMarginOfError);
-      const achievedRme = Math.max(durationRme, ...metricRmes);
-      if (achievedRme > targetRme) {
+      const unconverged: string[] = [];
+      if (durationRme > targetRme) {
+        unconverged.push(`duration (RME ${(durationRme * 100).toFixed(2)}%)`);
+      }
+      for (const metric of metricRmes) {
+        if (metric.rme > targetRme) {
+          const achieved = Number.isFinite(metric.rme)
+            ? `RME ${(metric.rme * 100).toFixed(2)}%`
+            : 'too few samples';
+          unconverged.push(`metric '${metric.name}' (${achieved})`);
+        }
+      }
+      if (unconverged.length > 0) {
         console.warn(
-          `Benchmark "${name}" did not converge: reached maxRuns (${maxRuns}) at RME ` +
-            `${(achievedRme * 100).toFixed(2)}% (target ${(targetRme * 100).toFixed(2)}%). ` +
-            `Results may be noisier than intended — consider raising maxRuns or reducing variance.`,
+          `Benchmark "${name}" reached maxRuns (${maxRuns}) without converging to the ` +
+            `${(targetRme * 100).toFixed(2)}% target: ${unconverged.join(', ')}. Results may be ` +
+            `noisier than intended — consider raising maxRuns or reducing variance.`,
         );
       }
     }

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -6,6 +6,7 @@ import type { RenderEvent, IterationData, InteractionContext, BenchmarkCaseRunti
 import { ElementTiming } from './ElementTiming';
 import { ScalarMetric } from './ScalarMetric';
 import { relativeMarginOfError } from './stats';
+import { collectAdaptiveMetricSamples } from './Metric';
 import { metricsGate } from './metricsGate';
 import { createReactRecordingControls } from './reactRecording';
 import type { ReactRecordingControls } from './reactRecording';
@@ -310,8 +311,12 @@ export function benchmark(
     // Upper bound on the loop; the adaptive stopping rule usually breaks out earlier.
     const totalRuns = warmupRuns + maxRuns;
     const iterations: IterationData[] = [];
-    // Per measured iteration: total render duration, the signal the stopping rule converges on.
+    // Per measured iteration: total render duration, the primary signal the stopping rule converges
+    // on (alongside each alarmed scalar metric).
     const iterationDurations: number[] = [];
+    // Relative margin of error of the render duration at the last stopping check — reused for the
+    // non-convergence warning instead of recomputing the same trim/variance pass.
+    let durationRme = Infinity;
 
     // Paint timings are recorded as one harness-owned `bench:paint` metric: the default sentinel
     // is the base series (`bench:paint`) and named `elementtiming` markers are sub-series
@@ -420,21 +425,29 @@ export function benchmark(
         await options.afterEach();
       }
 
-      // Adaptive stopping: once past the floor, stop as soon as the mean is estimated tightly
-      // enough. `maxRuns` caps the work for benchmarks too noisy to reach `targetRme`.
+      // Adaptive stopping: once past the floor, stop as soon as every measured signal — the mean
+      // render duration and each alarmed scalar metric — is estimated tightly enough. Custom metrics
+      // can only *delay* the stop (the `minRuns` floor and duration target still apply), so a noisy
+      // metric keeps sampling rather than being left underpowered for the dashboard's significance
+      // test. `maxRuns` caps the work for benchmarks too noisy to reach `targetRme`.
       if (!isWarmup && iterationDurations.length >= minRuns) {
-        if (relativeMarginOfError(iterationDurations) <= targetRme) {
+        durationRme = relativeMarginOfError(iterationDurations);
+        const metricsConverged = collectAdaptiveMetricSamples(task).every(
+          (samples) => relativeMarginOfError(samples) <= targetRme,
+        );
+        if (durationRme <= targetRme && metricsConverged) {
           break;
         }
       }
     }
 
-    // Warn only when adaptive sampling exhausted `maxRuns` without reaching `targetRme` — the
-    // common (converged) case stays quiet so large suites don't flood CI logs. Skipped in fixed
-    // mode (`runs` set), where there is no convergence target to miss. The measured iteration count
-    // itself is already reported per benchmark by the reporter.
+    // Warn only when adaptive sampling exhausted `maxRuns` without every signal reaching `targetRme`
+    // — the common (converged) case stays quiet so large suites don't flood CI logs. Skipped in
+    // fixed mode (`runs` set), where there is no convergence target to miss. The measured iteration
+    // count itself is already reported per benchmark by the reporter.
     if (isAdaptive && iterationDurations.length >= maxRuns) {
-      const achievedRme = relativeMarginOfError(iterationDurations);
+      const metricRmes = collectAdaptiveMetricSamples(task).map(relativeMarginOfError);
+      const achievedRme = Math.max(durationRme, ...metricRmes);
       if (achievedRme > targetRme) {
         console.warn(
           `Benchmark "${name}" did not converge: reached maxRuns (${maxRuns}) at RME ` +

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -298,6 +298,14 @@ export function benchmark(
     const maxRuns = options?.runs ?? options?.maxRuns ?? 100;
     const targetRme = options?.targetRme ?? 0.02;
 
+    // Fail fast on misconfigured sampling bounds rather than silently running a surprising loop.
+    if (minRuns < 1 || maxRuns < minRuns || targetRme <= 0) {
+      throw new Error(
+        `Invalid benchmark sampling options for "${name}": require 1 <= minRuns (${minRuns}) <= ` +
+          `maxRuns (${maxRuns}) and targetRme (${targetRme}) > 0.`,
+      );
+    }
+
     // Upper bound on the loop; the adaptive stopping rule usually breaks out earlier.
     const totalRuns = warmupRuns + maxRuns;
     const iterations: IterationData[] = [];
@@ -420,13 +428,18 @@ export function benchmark(
       }
     }
 
-    if (iterationDurations.length > 0) {
+    // Warn only when adaptive sampling exhausted `maxRuns` without reaching `targetRme` — the
+    // common (converged) case stays quiet so large suites don't flood CI logs. The measured
+    // iteration count itself is already reported per benchmark by the reporter.
+    if (iterationDurations.length >= maxRuns) {
       const achievedRme = relativeMarginOfError(iterationDurations);
-      // eslint-disable-next-line no-console
-      console.log(
-        `[benchmark] "${name}": ${iterationDurations.length} measured iterations ` +
-          `(RME ${(achievedRme * 100).toFixed(2)}%, target ${(targetRme * 100).toFixed(2)}%)`,
-      );
+      if (achievedRme > targetRme) {
+        console.warn(
+          `Benchmark "${name}" did not converge: reached maxRuns (${maxRuns}) at RME ` +
+            `${(achievedRme * 100).toFixed(2)}% (target ${(targetRme * 100).toFixed(2)}%). ` +
+            `Results may be noisier than intended — consider raising maxRuns or reducing variance.`,
+        );
+      }
     }
 
     task.meta.benchmarkIterations = iterations;

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -432,10 +432,14 @@ export function benchmark(
       // test. `maxRuns` caps the work for benchmarks too noisy to reach `targetRme`.
       if (!isWarmup && iterationDurations.length >= minRuns) {
         durationRme = relativeMarginOfError(iterationDurations);
-        const metricsConverged = collectAdaptiveMetricSamples(task).every(
-          (samples) => relativeMarginOfError(samples) <= targetRme,
-        );
-        if (durationRme <= targetRme && metricsConverged) {
+        // Duration is the primary (and usually last-to-tighten) signal, so check it first: the
+        // per-metric margin-of-error pass only runs once duration itself has converged.
+        const converged =
+          durationRme <= targetRme &&
+          collectAdaptiveMetricSamples(task).every(
+            (samples) => relativeMarginOfError(samples) <= targetRme,
+          );
+        if (converged) {
           break;
         }
       }

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -465,7 +465,7 @@ export function benchmark(
       );
       if (unconverged.length > 0) {
         console.warn(
-          `Benchmark "${name}" reached maxRuns (${maxRuns}) without converging to the ` +
+          `Benchmark "${name}" reached maxRuns (${maxRuns} runs) without converging to the ` +
             `${(targetRme * 100).toFixed(2)}% target: ${unconverged.join(', ')}. Results may be ` +
             `noisier than intended — consider raising maxRuns or reducing variance.`,
         );

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -5,6 +5,7 @@ import * as ReactDOM from 'react-dom';
 import type { RenderEvent, IterationData, InteractionContext, BenchmarkCaseRuntime } from './types';
 import { ElementTiming } from './ElementTiming';
 import { ScalarMetric } from './ScalarMetric';
+import { relativeMarginOfError } from './stats';
 import { metricsGate } from './metricsGate';
 import { createReactRecordingControls } from './reactRecording';
 import type { ReactRecordingControls } from './reactRecording';
@@ -228,8 +229,26 @@ function createCaseRuntime({
 }
 
 interface BenchmarkOptions {
+  /**
+   * Fixed number of measured iterations. When set, disables adaptive sampling (equivalent to
+   * `minRuns === maxRuns === runs`). Prefer leaving this unset and letting the harness sample
+   * adaptively; use it only to pin a benchmark to an exact iteration count.
+   */
   runs?: number;
+  /** Warmup iterations run before measurement begins (not recorded). Defaults to `5`. */
   warmupRuns?: number;
+  /**
+   * Adaptive sampling: the harness keeps measuring until the mean render duration is estimated to
+   * within `targetRme`, then stops. `minRuns` is the floor before the stopping rule can trigger,
+   * `maxRuns` the ceiling. Ignored when `runs` is set. Defaults: `minRuns` 10, `maxRuns` 100.
+   */
+  minRuns?: number;
+  maxRuns?: number;
+  /**
+   * Target relative margin of error (half-width of the 95% confidence interval of the mean, as a
+   * fraction of the mean) at which adaptive sampling stops. Defaults to `0.02` (2%).
+   */
+  targetRme?: number;
   afterEach?: () => Promise<void> | void;
   /**
    * Start each iteration with React render/paint recording paused. The interaction callback then
@@ -273,11 +292,17 @@ export function benchmark(
   }
 
   it(name, async ({ task }) => {
-    const runs = options?.runs ?? 20;
-    const warmupRuns = options?.warmupRuns ?? 10;
+    const warmupRuns = options?.warmupRuns ?? 5;
+    // A fixed `runs` pins both bounds; otherwise sample adaptively between min and max.
+    const minRuns = options?.runs ?? options?.minRuns ?? 10;
+    const maxRuns = options?.runs ?? options?.maxRuns ?? 100;
+    const targetRme = options?.targetRme ?? 0.02;
 
-    const totalRuns = warmupRuns + runs;
+    // Upper bound on the loop; the adaptive stopping rule usually breaks out earlier.
+    const totalRuns = warmupRuns + maxRuns;
     const iterations: IterationData[] = [];
+    // Per measured iteration: total render duration, the signal the stopping rule converges on.
+    const iterationDurations: number[] = [];
 
     // Paint timings are recorded as one harness-owned `bench:paint` metric: the default sentinel
     // is the base series (`bench:paint`) and named `elementtiming` markers are sub-series
@@ -377,12 +402,31 @@ export function benchmark(
           paint.record(entry.renderTime - iterationStart, id !== undefined ? { id } : undefined);
         }
         iterations.push({ renders: captures });
+        // Total render duration of this iteration — the adaptive stopping rule's convergence signal.
+        iterationDurations.push(captures.reduce((sum, capture) => sum + capture.actualDuration, 0));
       }
 
       if (options?.afterEach) {
         // eslint-disable-next-line no-await-in-loop
         await options.afterEach();
       }
+
+      // Adaptive stopping: once past the floor, stop as soon as the mean is estimated tightly
+      // enough. `maxRuns` caps the work for benchmarks too noisy to reach `targetRme`.
+      if (!isWarmup && iterationDurations.length >= minRuns) {
+        if (relativeMarginOfError(iterationDurations) <= targetRme) {
+          break;
+        }
+      }
+    }
+
+    if (iterationDurations.length > 0) {
+      const achievedRme = relativeMarginOfError(iterationDurations);
+      // eslint-disable-next-line no-console
+      console.log(
+        `[benchmark] "${name}": ${iterationDurations.length} measured iterations ` +
+          `(RME ${(achievedRme * 100).toFixed(2)}%, target ${(targetRme * 100).toFixed(2)}%)`,
+      );
     }
 
     task.meta.benchmarkIterations = iterations;

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -294,6 +294,7 @@ export function benchmark(
   it(name, async ({ task }) => {
     const warmupRuns = options?.warmupRuns ?? 5;
     // A fixed `runs` pins both bounds; otherwise sample adaptively between min and max.
+    const isAdaptive = options?.runs === undefined;
     const minRuns = options?.runs ?? options?.minRuns ?? 10;
     const maxRuns = options?.runs ?? options?.maxRuns ?? 100;
     const targetRme = options?.targetRme ?? 0.02;
@@ -429,9 +430,10 @@ export function benchmark(
     }
 
     // Warn only when adaptive sampling exhausted `maxRuns` without reaching `targetRme` — the
-    // common (converged) case stays quiet so large suites don't flood CI logs. The measured
-    // iteration count itself is already reported per benchmark by the reporter.
-    if (iterationDurations.length >= maxRuns) {
+    // common (converged) case stays quiet so large suites don't flood CI logs. Skipped in fixed
+    // mode (`runs` set), where there is no convergence target to miss. The measured iteration count
+    // itself is already reported per benchmark by the reporter.
+    if (isAdaptive && iterationDurations.length >= maxRuns) {
       const achievedRme = relativeMarginOfError(iterationDurations);
       if (achievedRme > targetRme) {
         console.warn(

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -5,7 +5,7 @@ import * as ReactDOM from 'react-dom';
 import type { RenderEvent, IterationData, InteractionContext, BenchmarkCaseRuntime } from './types';
 import { ElementTiming } from './ElementTiming';
 import { ScalarMetric } from './ScalarMetric';
-import { relativeMarginOfError } from './stats';
+import { describeUnconvergedSignals, relativeMarginOfError } from './stats';
 import { collectAdaptiveMetricSamples } from './Metric';
 import { metricsGate } from './metricsGate';
 import { createReactRecordingControls } from './reactRecording';
@@ -456,18 +456,13 @@ export function benchmark(
     // case stays quiet so large suites don't flood CI logs. Skipped in fixed mode (`runs` set), where
     // there is no convergence target to miss. Reuses the margins of error already computed above.
     if (isAdaptive && iterationDurations.length >= maxRuns) {
-      const unconverged: string[] = [];
-      if (durationRme > targetRme) {
-        unconverged.push(`duration (RME ${(durationRme * 100).toFixed(2)}%)`);
-      }
-      for (const metric of metricRmes) {
-        if (metric.rme > targetRme) {
-          const achieved = Number.isFinite(metric.rme)
-            ? `RME ${(metric.rme * 100).toFixed(2)}%`
-            : 'too few samples';
-          unconverged.push(`metric '${metric.name}' (${achieved})`);
-        }
-      }
+      const unconverged = describeUnconvergedSignals(
+        [
+          { label: 'duration', rme: durationRme },
+          ...metricRmes.map((metric) => ({ label: `metric '${metric.name}'`, rme: metric.rme })),
+        ],
+        targetRme,
+      );
       if (unconverged.length > 0) {
         console.warn(
           `Benchmark "${name}" reached maxRuns (${maxRuns}) without converging to the ` +

--- a/packages/benchmark/src/reporter.test.ts
+++ b/packages/benchmark/src/reporter.test.ts
@@ -71,6 +71,20 @@ describe('generateReportFromIterations', () => {
     expect(report.renders[0].actualDuration).toBe(20);
   });
 
+  it('aggregates the per-iteration total duration for the Welch comparison', () => {
+    // Two renders per iteration: the total is their sum, aggregated across iterations. Totals are
+    // [11, 13, 9] (sum of the two renders each), mean 11, population stdDev sqrt(8/3), count 3.
+    const iterations = [
+      iteration([event('A', 'mount', 0, 6), event('B', 'update', 10, 5)]),
+      iteration([event('A', 'mount', 0, 7), event('B', 'update', 10, 6)]),
+      iteration([event('A', 'mount', 0, 5), event('B', 'update', 10, 4)]),
+    ];
+    const report = generateReportFromIterations(iterations);
+
+    expect(report.totalCount).toBe(3);
+    expect(report.totalStdDev).toBeCloseTo(Math.sqrt(8 / 3), 10);
+  });
+
   it('computes start times from mean gaps between renders', () => {
     // Two renders per iteration, with a gap between them
     // Iteration 1: render0 at 0 for 10ms, render1 at 15 for 5ms (gap = 5ms)

--- a/packages/benchmark/src/reporter.test.ts
+++ b/packages/benchmark/src/reporter.test.ts
@@ -297,7 +297,8 @@ describe('BenchmarkReporter', () => {
                 config: { name: 'fib_phase' },
                 series: {
                   small: { mean: 0.2, stdDev: 0.01, outliers: 0, count: 50 },
-                  large: { mean: 3.4, stdDev: 0.2, outliers: 1, count: 50 },
+                  // 49 used + 1 outlier = 50 raw samples, matching the other series' 50 iterations.
+                  large: { mean: 3.4, stdDev: 0.2, outliers: 1, count: 49 },
                 },
               },
             },

--- a/packages/benchmark/src/reporter.test.ts
+++ b/packages/benchmark/src/reporter.test.ts
@@ -320,8 +320,9 @@ describe('BenchmarkReporter', () => {
         'fib_phase#large': { mean: 3.4, outliers: 1 },
       });
 
-      // The sample count must not leak into the per-entry metric stats.
-      expect(written.report['custom only'].metrics.fib_duration).not.toHaveProperty('count');
+      // The effective sample count is carried into the per-entry metric stats as the `n` the
+      // dashboard's Welch's t-test compares against a baseline.
+      expect(written.report['custom only'].metrics.fib_duration.count).toBe(50);
 
       // Config is hoisted once, keyed by metric name.
       expect(written.metricDefinitions).toMatchObject({

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -97,7 +97,6 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
   }
 
   const renders: BenchmarkReportEntry['renders'] = [];
-  let totalDuration = 0;
   for (let index = 0; index < expectedLength; index += 1) {
     const { event, iqrMean, iqrStdDev, outliers, count } = renderStats[index];
     const startTime =
@@ -113,12 +112,14 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
       outliers,
       count,
     });
-    totalDuration += iqrMean;
   }
 
-  // Aggregate the *actual* per-iteration total duration (sum of that iteration's render durations),
-  // so the comparison's Welch test on total duration uses the real spread and sample count of the
-  // total — capturing cross-render correlation, which a sum of per-render variances cannot.
+  // Aggregate the *actual* per-iteration total duration (sum of that iteration's render durations).
+  // `totalDuration`, `totalStdDev`, and `totalCount` are all taken from this one distribution so the
+  // comparison's Welch test gets a mutually consistent (mean, stdDev, n) triple — and the spread
+  // reflects real cross-render correlation, which a sum of per-render variances cannot. (Because
+  // outliers are filtered here on the totals, not per render, `totalDuration` may differ marginally
+  // from summing the per-render means shown in the render table.)
   const perIterationTotals = iterations.map((iteration) =>
     iteration.renders.reduce((sum, render) => sum + render.actualDuration, 0),
   );
@@ -129,7 +130,7 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
 
   return {
     iterations: iterationCount,
-    totalDuration,
+    totalDuration: totalStats.mean,
     totalStdDev: totalStats.stdDev,
     totalCount: totalStats.count,
     renders,

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -6,6 +6,7 @@ import type { BenchmarkBaseUpload, BenchmarkReportEntry } from './ciReport';
 import { benchmarkUploadSchema, getCiMetadata } from './ciReport';
 import { calculateMean, aggregateSamples } from './stats';
 import { dim, red, green, yellow, cyan, printTable, fileUrl } from './format';
+import type { Column } from './format';
 import { uploadCiReport } from './upload';
 import { syncPrComment } from './syncPrComment';
 // Import for TaskMeta augmentation side effect
@@ -133,6 +134,7 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
 const LABEL_WIDTH = 28;
 const STAT_WIDTH = 16;
 const CV_WIDTH = 8;
+const OUT_WIDTH = 4;
 
 function colorCV(cv: number): string {
   const str = `${cv.toFixed(1)}%`;
@@ -145,6 +147,31 @@ function colorCV(cv: number): string {
   return dim(str);
 }
 
+/**
+ * Columns shared by the duration and metric tables: a label pinned to a fixed width, then stats
+ * free to grow (a metric can be formatted with any unit, so its width isn't knowable here).
+ */
+function statColumns(labelHeader: string, statHeader: string): Column[] {
+  return [
+    { header: labelHeader, minWidth: LABEL_WIDTH, maxWidth: LABEL_WIDTH },
+    { header: statHeader, minWidth: STAT_WIDTH },
+    { header: 'Var%', minWidth: CV_WIDTH },
+    { header: 'Out', minWidth: OUT_WIDTH },
+  ];
+}
+
+/** A `label | mean±σ | variation | outliers` row, as used by both tables. */
+function statRow(
+  label: string,
+  iqrStr: string,
+  mean: number,
+  stdDev: number,
+  outliers: number,
+): string[] {
+  const cv = mean > 0 ? (stdDev / mean) * 100 : 0;
+  return [label, cyan(iqrStr), colorCV(cv), outliers > 0 ? yellow(String(outliers)) : dim('0')];
+}
+
 function printDurationMatrix(name: string, report: BenchmarkReportEntry, footer: string): void {
   if (report.renders.length === 0) {
     return;
@@ -154,29 +181,20 @@ function printDurationMatrix(name: string, report: BenchmarkReportEntry, footer:
 
   for (let r = 0; r < report.renders.length; r += 1) {
     const render = report.renders[r];
-    const label = `#${r} ${render.id}:${render.phase}`;
     const iqrStr = `${render.actualDuration.toFixed(2)}±${render.stdDev.toFixed(2)}`;
-    const cv = render.actualDuration > 0 ? (render.stdDev / render.actualDuration) * 100 : 0;
 
-    rows.push([
-      label.slice(0, LABEL_WIDTH),
-      cyan(iqrStr),
-      colorCV(cv),
-      render.outliers > 0 ? yellow(String(render.outliers)) : dim('0'),
-    ]);
+    rows.push(
+      statRow(
+        `#${r} ${render.id}:${render.phase}`,
+        iqrStr,
+        render.actualDuration,
+        render.stdDev,
+        render.outliers,
+      ),
+    );
   }
 
-  printTable(
-    [
-      { header: 'Render', width: LABEL_WIDTH },
-      { header: 'Mean±σ (ms)', width: STAT_WIDTH },
-      { header: 'Var%', width: CV_WIDTH },
-      { header: 'Out', width: 4 },
-    ],
-    rows,
-    footer,
-    name,
-  );
+  printTable(statColumns('Render', 'Mean±σ (ms)'), rows, footer, name);
 }
 
 /** Strips a `#sub-series` suffix to recover the metric name used to look up its definition. */
@@ -253,23 +271,12 @@ function printMetricsTable(
   const rows: string[][] = entries.map(([metricName, stats]) => {
     const definition = definitions[baseMetricName(metricName)];
     const iqrStr = `${formatMetricValue(stats.mean, definition)}±${formatMetricValue(stats.stdDev, definition)}`;
-    const cv = stats.mean > 0 ? (stats.stdDev / stats.mean) * 100 : 0;
     const label = definition?.alarm ? `${metricName} ⚠` : metricName;
-    return [
-      label.slice(0, LABEL_WIDTH),
-      cyan(iqrStr),
-      colorCV(cv),
-      stats.outliers > 0 ? yellow(String(stats.outliers)) : dim('0'),
-    ];
+    return statRow(label, iqrStr, stats.mean, stats.stdDev, stats.outliers);
   });
 
   printTable(
-    [
-      { header: 'Metric', width: LABEL_WIDTH },
-      { header: 'Mean±σ', width: STAT_WIDTH },
-      { header: 'Var%', width: CV_WIDTH },
-      { header: 'Out', width: 4 },
-    ],
+    statColumns('Metric', 'Mean±σ'),
     rows,
     dim(`${iterationCount} iterations`),
     `${name} — Metrics`,

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -135,7 +135,7 @@ const STAT_WIDTH = 16;
 const CV_WIDTH = 8;
 
 function colorCV(cv: number): string {
-  const str = `${cv.toFixed(1)}%`.padStart(CV_WIDTH);
+  const str = `${cv.toFixed(1)}%`;
   if (cv > 10) {
     return red(str);
   }
@@ -159,10 +159,10 @@ function printDurationMatrix(name: string, report: BenchmarkReportEntry, footer:
     const cv = render.actualDuration > 0 ? (render.stdDev / render.actualDuration) * 100 : 0;
 
     rows.push([
-      label.slice(0, LABEL_WIDTH).padStart(LABEL_WIDTH),
-      cyan(iqrStr.padStart(STAT_WIDTH)),
+      label.slice(0, LABEL_WIDTH),
+      cyan(iqrStr),
       colorCV(cv),
-      render.outliers > 0 ? yellow(String(render.outliers).padStart(4)) : dim('0'.padStart(4)),
+      render.outliers > 0 ? yellow(String(render.outliers)) : dim('0'),
     ]);
   }
 
@@ -256,10 +256,10 @@ function printMetricsTable(
     const cv = stats.mean > 0 ? (stats.stdDev / stats.mean) * 100 : 0;
     const label = definition?.alarm ? `${metricName} ⚠` : metricName;
     return [
-      label.slice(0, LABEL_WIDTH).padStart(LABEL_WIDTH),
-      cyan(iqrStr.padStart(STAT_WIDTH)),
+      label.slice(0, LABEL_WIDTH),
+      cyan(iqrStr),
       colorCV(cv),
-      stats.outliers > 0 ? yellow(String(stats.outliers).padStart(4)) : dim('0'.padStart(4)),
+      stats.outliers > 0 ? yellow(String(stats.outliers)) : dim('0'),
     ];
   });
 

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -11,10 +11,6 @@ import { syncPrComment } from './syncPrComment';
 // Import for TaskMeta augmentation side effect
 import './taskMetaAugmentation';
 
-function getEventKey(event: RenderEvent): string {
-  return `${event.id}:${event.phase}`;
-}
-
 /** Order-insensitive deep equality, treating a missing key and an `undefined` value as equal. */
 function deepEqual(first: unknown, second: unknown): boolean {
   if (first === second) {
@@ -65,16 +61,12 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
   for (let index = 0; index < expectedLength; index += 1) {
     const durations = iterations.map((iteration) => iteration.renders[index].actualDuration);
 
+    // The per-render coefficient of variation is surfaced as the "Var%" column of the results
+    // table (informational). It no longer warrants a warning: the Welch comparison already accounts
+    // for a render's spread (a noisy render yields a high p-value rather than a false flag), and
+    // adaptive sampling drives the *mean's* precision to `targetRme`, warning separately when it
+    // can't converge. High spread alone no longer implies an unreliable result.
     const { mean: iqrMean, stdDev: iqrStdDev, outliers, count } = aggregateSamples(durations);
-    const coefficientOfVariation = iqrMean > 0 ? iqrStdDev / iqrMean : 0;
-
-    if (iqrMean > 1 && coefficientOfVariation > 0.1) {
-      const event = firstIteration.renders[index];
-      console.warn(
-        `High coefficient of variation (${(coefficientOfVariation * 100).toFixed(1)}%) for render #${index} event "${getEventKey(event)}". ` +
-          `Mean: ${iqrMean.toFixed(2)}ms, StdDev: ${iqrStdDev.toFixed(2)}ms. Results may be unreliable.`,
-      );
-    }
 
     renderStats.push({
       event: firstIteration.renders[index],

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -116,12 +116,22 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
     totalDuration += iqrMean;
   }
 
+  // Aggregate the *actual* per-iteration total duration (sum of that iteration's render durations),
+  // so the comparison's Welch test on total duration uses the real spread and sample count of the
+  // total — capturing cross-render correlation, which a sum of per-render variances cannot.
+  const perIterationTotals = iterations.map((iteration) =>
+    iteration.renders.reduce((sum, render) => sum + render.actualDuration, 0),
+  );
+  const totalStats = aggregateSamples(perIterationTotals);
+
   // Custom + paint metrics are merged separately from `task.meta.benchmarkMetrics`.
   const metrics = {};
 
   return {
     iterations: iterationCount,
     totalDuration,
+    totalStdDev: totalStats.stdDev,
+    totalCount: totalStats.count,
     renders,
     metrics,
   };

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -209,7 +209,10 @@ function mergeCustomMetrics(
         outliers: stats.outliers,
         count: stats.count,
       };
-      maxCount = Math.max(maxCount, stats.count);
+      // `stats.count` is the post-outlier-removal count; add back the dropped outliers to recover
+      // the raw number of recorded samples, which is what a metric-only benchmark reports as its
+      // iteration count below.
+      maxCount = Math.max(maxCount, stats.count + stats.outliers);
     }
     const definition: MetricDefinition = {
       kind: metric.kind,

--- a/packages/benchmark/src/reporter.ts
+++ b/packages/benchmark/src/reporter.ts
@@ -59,12 +59,13 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
     iqrMean: number;
     iqrStdDev: number;
     outliers: number;
+    count: number;
   }> = [];
 
   for (let index = 0; index < expectedLength; index += 1) {
     const durations = iterations.map((iteration) => iteration.renders[index].actualDuration);
 
-    const { mean: iqrMean, stdDev: iqrStdDev, outliers } = aggregateSamples(durations);
+    const { mean: iqrMean, stdDev: iqrStdDev, outliers, count } = aggregateSamples(durations);
     const coefficientOfVariation = iqrMean > 0 ? iqrStdDev / iqrMean : 0;
 
     if (iqrMean > 1 && coefficientOfVariation > 0.1) {
@@ -80,6 +81,7 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
       iqrMean,
       iqrStdDev,
       outliers,
+      count,
     });
   }
 
@@ -97,7 +99,7 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
   const renders: BenchmarkReportEntry['renders'] = [];
   let totalDuration = 0;
   for (let index = 0; index < expectedLength; index += 1) {
-    const { event, iqrMean, iqrStdDev, outliers } = renderStats[index];
+    const { event, iqrMean, iqrStdDev, outliers, count } = renderStats[index];
     const startTime =
       index === 0
         ? 0
@@ -109,6 +111,7 @@ function generateReportFromIterations(iterations: IterationData[]): BenchmarkRep
       actualDuration: iqrMean,
       stdDev: iqrStdDev,
       outliers,
+      count,
     });
     totalDuration += iqrMean;
   }
@@ -200,7 +203,12 @@ function mergeCustomMetrics(
   for (const [metricName, metric] of Object.entries(customMetrics)) {
     for (const [seriesId, stats] of Object.entries(metric.series)) {
       const key = seriesId === '' ? metricName : `${metricName}#${seriesId}`;
-      report.metrics[key] = { mean: stats.mean, stdDev: stats.stdDev, outliers: stats.outliers };
+      report.metrics[key] = {
+        mean: stats.mean,
+        stdDev: stats.stdDev,
+        outliers: stats.outliers,
+        count: stats.count,
+      };
       maxCount = Math.max(maxCount, stats.count);
     }
     const definition: MetricDefinition = {

--- a/packages/benchmark/src/stats.test.ts
+++ b/packages/benchmark/src/stats.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { calculateMean, calculateStdDev, quantile, isOutlier, aggregateSamples } from './stats';
+import {
+  calculateMean,
+  calculateStdDev,
+  quantile,
+  isOutlier,
+  aggregateSamples,
+  relativeMarginOfError,
+} from './stats';
 
 describe('calculateMean', () => {
   it('returns the mean of values', () => {
@@ -89,6 +96,12 @@ describe('aggregateSamples', () => {
     expect(result.stdDev).toBeCloseTo(Math.sqrt(8 / 3));
   });
 
+  it('reports the effective (post-outlier-removal) sample count', () => {
+    expect(aggregateSamples([2, 4, 6]).count).toBe(3);
+    // One value is filtered as an outlier, so it is excluded from the effective count.
+    expect(aggregateSamples([10, 10, 10, 10, 10, 1000]).count).toBe(5);
+  });
+
   it('removes IQR outliers before computing the mean', () => {
     const result = aggregateSamples([10, 10, 10, 10, 10, 1000]);
     expect(result.mean).toBe(10);
@@ -99,5 +112,40 @@ describe('aggregateSamples', () => {
     const result = aggregateSamples([5]);
     expect(result.mean).toBe(5);
     expect(result.outliers).toBe(0);
+    expect(result.count).toBe(1);
+  });
+});
+
+describe('relativeMarginOfError', () => {
+  it('is Infinity with fewer than two samples (spread is unknown)', () => {
+    expect(relativeMarginOfError([])).toBe(Infinity);
+    expect(relativeMarginOfError([10])).toBe(Infinity);
+  });
+
+  it('is 0 for a perfectly stable series', () => {
+    expect(relativeMarginOfError([10, 10, 10, 10])).toBe(0);
+  });
+
+  it('shrinks as more samples of the same distribution are added', () => {
+    const few = relativeMarginOfError([10, 12, 8, 11, 9]);
+    const many = relativeMarginOfError([
+      10, 12, 8, 11, 9, 10, 12, 8, 11, 9, 10, 12, 8, 11, 9, 10, 12, 8, 11, 9,
+    ]);
+    expect(many).toBeLessThan(few);
+  });
+
+  it('matches the closed form z * (s / sqrt(n)) / mean', () => {
+    const samples = [10, 12, 8, 14, 6];
+    const mean = 10;
+    const sampleStdDev = Math.sqrt(
+      ((10 - mean) ** 2 + (12 - mean) ** 2 + (8 - mean) ** 2 + (14 - mean) ** 2 + (6 - mean) ** 2) /
+        4,
+    );
+    const expected = (1.96 * (sampleStdDev / Math.sqrt(5))) / mean;
+    expect(relativeMarginOfError(samples)).toBeCloseTo(expected, 12);
+  });
+
+  it('is 0 when the mean is non-positive (no signal to converge on)', () => {
+    expect(relativeMarginOfError([0, 0, 0])).toBe(0);
   });
 });

--- a/packages/benchmark/src/stats.test.ts
+++ b/packages/benchmark/src/stats.test.ts
@@ -148,4 +148,12 @@ describe('relativeMarginOfError', () => {
   it('is 0 when the mean is non-positive (no signal to converge on)', () => {
     expect(relativeMarginOfError([0, 0, 0])).toBe(0);
   });
+
+  it('ignores a spike so a stable-but-spiky series still converges', () => {
+    // The trailing 200 is an artifact (e.g. a GC pause). Trimmed away, the margin of error reflects
+    // the tight underlying spread; left in, the raw mean (~29) and variance would keep it far above
+    // any sensible target and the benchmark would never converge.
+    const spiky = [10, 11, 9, 10, 12, 8, 11, 9, 10, 200];
+    expect(relativeMarginOfError(spiky)).toBeLessThan(0.1);
+  });
 });

--- a/packages/benchmark/src/stats.test.ts
+++ b/packages/benchmark/src/stats.test.ts
@@ -6,6 +6,7 @@ import {
   isOutlier,
   aggregateSamples,
   relativeMarginOfError,
+  describeUnconvergedSignals,
 } from './stats';
 
 describe('calculateMean', () => {
@@ -155,5 +156,37 @@ describe('relativeMarginOfError', () => {
     // any sensible target and the benchmark would never converge.
     const spiky = [10, 11, 9, 10, 12, 8, 11, 9, 10, 200];
     expect(relativeMarginOfError(spiky)).toBeLessThan(0.1);
+  });
+});
+
+describe('describeUnconvergedSignals', () => {
+  it('is empty when every signal is at or below the target', () => {
+    expect(
+      describeUnconvergedSignals(
+        [
+          { label: 'duration', rme: 0.02 },
+          { label: "metric 'x'", rme: 0.01 },
+        ],
+        0.02,
+      ),
+    ).toEqual([]);
+  });
+
+  it('names each signal above the target with its achieved margin of error', () => {
+    expect(
+      describeUnconvergedSignals(
+        [
+          { label: 'duration', rme: 0.015 },
+          { label: "metric 'latency'", rme: 0.061 },
+        ],
+        0.02,
+      ),
+    ).toEqual(["metric 'latency' (RME 6.10%)"]);
+  });
+
+  it('reports "too few samples" when the margin of error could not be estimated', () => {
+    expect(describeUnconvergedSignals([{ label: "metric 'sparse'", rme: Infinity }], 0.02)).toEqual(
+      ["metric 'sparse' (too few samples)"],
+    );
   });
 });

--- a/packages/benchmark/src/stats.ts
+++ b/packages/benchmark/src/stats.ts
@@ -29,9 +29,23 @@ export function isOutlier(value: number, q1: number, q3: number): boolean {
 }
 
 /**
+ * Drops IQR outliers (values outside the 1.5×IQR fences), returning the surviving samples. Falls
+ * back to the original values when filtering would remove everything. Shared by every consumer that
+ * wants to reason about typical performance rather than measurement artifacts (GC pauses, scheduling
+ * hiccups), so they all trim identically.
+ */
+export function removeOutliers(values: number[]): number[] {
+  const sorted = values.toSorted((first, second) => first - second);
+  const q1 = quantile(sorted, 0.25);
+  const q3 = quantile(sorted, 0.75);
+  const filtered = values.filter((value) => !isOutlier(value, q1, q3));
+  return filtered.length > 0 ? filtered : values;
+}
+
+/**
  * Aggregates a series of samples into a mean, standard deviation, outlier count, and effective
- * sample count using IQR-based outlier removal. Falls back to the raw values when filtering would
- * remove everything. This is the shared aggregation core for custom metrics.
+ * sample count using IQR-based outlier removal. This is the shared aggregation core for custom
+ * metrics.
  *
  * `count` is the number of samples that actually back `mean`/`stdDev` (post-outlier-removal), so a
  * downstream Welch's t-test can use it directly as the `n` behind those stats.
@@ -42,12 +56,7 @@ export function aggregateSamples(values: number[]): {
   outliers: number;
   count: number;
 } {
-  const sorted = values.toSorted((first, second) => first - second);
-  const q1 = quantile(sorted, 0.25);
-  const q3 = quantile(sorted, 0.75);
-  const filtered = values.filter((value) => !isOutlier(value, q1, q3));
-  const used = filtered.length > 0 ? filtered : values;
-
+  const used = removeOutliers(values);
   const mean = calculateMean(used);
   const stdDev = calculateStdDev(used, mean);
   return { mean, stdDev, outliers: values.length - used.length, count: used.length };
@@ -59,21 +68,28 @@ export function aggregateSamples(values: number[]): {
  * measurement continues until this drops to a target. A precise t-quantile is unnecessary just to
  * decide when enough samples have been collected.
  *
- * Returns `Infinity` below two samples (spread can't be estimated) and `0` when the mean is
- * non-positive (e.g. a metric-only benchmark with no render duration to converge on), so such
+ * IQR outliers are removed first, so the margin of error is measured on the same trimmed
+ * distribution the reported stats and the Welch comparison use. Without this, a benchmark that is
+ * stable apart from recurring GC/scheduling spikes would keep a high raw margin of error and sample
+ * all the way to its maximum (and warn that it "did not converge") even though its typical estimate
+ * settled long ago.
+ *
+ * Returns `Infinity` below two (trimmed) samples (spread can't be estimated) and `0` when the mean
+ * is non-positive (e.g. a metric-only benchmark with no render duration to converge on), so such
  * benchmarks stop at their minimum run count rather than sampling to the maximum.
  */
 export function relativeMarginOfError(samples: number[]): number {
-  const n = samples.length;
+  const used = removeOutliers(samples);
+  const n = used.length;
   if (n < 2) {
     return Infinity;
   }
-  const mean = calculateMean(samples);
+  const mean = calculateMean(used);
   if (mean <= 0) {
     return 0;
   }
   // Bessel-corrected (sample) variance: the samples estimate the spread of the population.
-  const variance = samples.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (n - 1);
+  const variance = used.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (n - 1);
   const standardError = Math.sqrt(variance / n);
   return (1.96 * standardError) / mean;
 }

--- a/packages/benchmark/src/stats.ts
+++ b/packages/benchmark/src/stats.ts
@@ -93,3 +93,31 @@ export function relativeMarginOfError(samples: number[]): number {
   const standardError = Math.sqrt(variance / n);
   return (1.96 * standardError) / mean;
 }
+
+/** A named adaptive-sampling signal (render duration or a metric) and its achieved margin of error. */
+export interface SignalConvergence {
+  /** Human label, e.g. `duration` or `metric 'input-latency'`. */
+  label: string;
+  /** Relative margin of error achieved; `Infinity` when there were too few samples to estimate it. */
+  rme: number;
+}
+
+/**
+ * Describes the signals that failed to reach `targetRme`, each as a short phrase naming the signal
+ * and the margin of error it settled at (or "too few samples" when it couldn't be estimated).
+ * Returns an empty array when every signal converged. Pure so the non-convergence warning can be
+ * unit-tested apart from the measured benchmark loop.
+ */
+export function describeUnconvergedSignals(
+  signals: SignalConvergence[],
+  targetRme: number,
+): string[] {
+  const unconverged: string[] = [];
+  for (const { label, rme } of signals) {
+    if (rme > targetRme) {
+      const achieved = Number.isFinite(rme) ? `RME ${(rme * 100).toFixed(2)}%` : 'too few samples';
+      unconverged.push(`${label} (${achieved})`);
+    }
+  }
+  return unconverged;
+}

--- a/packages/benchmark/src/stats.ts
+++ b/packages/benchmark/src/stats.ts
@@ -29,14 +29,18 @@ export function isOutlier(value: number, q1: number, q3: number): boolean {
 }
 
 /**
- * Aggregates a series of samples into a mean, standard deviation, and outlier count using
- * IQR-based outlier removal. Falls back to the raw values when filtering would remove
- * everything. This is the shared aggregation core for custom metrics.
+ * Aggregates a series of samples into a mean, standard deviation, outlier count, and effective
+ * sample count using IQR-based outlier removal. Falls back to the raw values when filtering would
+ * remove everything. This is the shared aggregation core for custom metrics.
+ *
+ * `count` is the number of samples that actually back `mean`/`stdDev` (post-outlier-removal), so a
+ * downstream Welch's t-test can use it directly as the `n` behind those stats.
  */
 export function aggregateSamples(values: number[]): {
   mean: number;
   stdDev: number;
   outliers: number;
+  count: number;
 } {
   const sorted = values.toSorted((first, second) => first - second);
   const q1 = quantile(sorted, 0.25);
@@ -46,5 +50,30 @@ export function aggregateSamples(values: number[]): {
 
   const mean = calculateMean(used);
   const stdDev = calculateStdDev(used, mean);
-  return { mean, stdDev, outliers: values.length - used.length };
+  return { mean, stdDev, outliers: values.length - used.length, count: used.length };
+}
+
+/**
+ * Relative margin of error of the mean — half the 95% confidence interval width divided by the
+ * mean, using the normal approximation (`z = 1.96`). This is the adaptive-sampling stopping signal:
+ * measurement continues until this drops to a target. A precise t-quantile is unnecessary just to
+ * decide when enough samples have been collected.
+ *
+ * Returns `Infinity` below two samples (spread can't be estimated) and `0` when the mean is
+ * non-positive (e.g. a metric-only benchmark with no render duration to converge on), so such
+ * benchmarks stop at their minimum run count rather than sampling to the maximum.
+ */
+export function relativeMarginOfError(samples: number[]): number {
+  const n = samples.length;
+  if (n < 2) {
+    return Infinity;
+  }
+  const mean = calculateMean(samples);
+  if (mean <= 0) {
+    return 0;
+  }
+  // Bessel-corrected (sample) variance: the samples estimate the spread of the population.
+  const variance = samples.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (n - 1);
+  const standardError = Math.sqrt(variance / n);
+  return (1.96 * standardError) / mean;
 }

--- a/packages/benchmark/src/types.ts
+++ b/packages/benchmark/src/types.ts
@@ -93,7 +93,10 @@ export interface MetricSampleStats {
   mean: number;
   stdDev: number;
   outliers: number;
-  /** Number of recorded samples (used to derive iteration counts; stripped from the report). */
+  /**
+   * Effective sample count behind `mean`/`stdDev` (post-outlier-removal). Serialized into the
+   * report as the `n` a Welch's t-test uses to compare this series against a baseline.
+   */
   count: number;
 }
 


### PR DESCRIPTION
## What

Replaces the benchmark comparison's fixed ±20% noise band with a statistical significance test, plus adaptive sampling to make each run's stats trustworthy.

### Adaptive sampling (runner)
`benchmark()` now samples until the mean render duration is estimated to within a target relative margin of error (default 2%), between `minRuns` (10) and `maxRuns` (50), instead of a fixed 20. `warmupRuns` default drops 10 → 5. Passing `runs` still pins an exact count (back-compat). Clean benchmarks stop early; noisy ones sample more.

### Welch's t-test (comparison)
Two benchmarks are compared with [Welch's t-test](https://en.wikipedia.org/wiki/Welch%27s_t-test) on summary stats `(mean, stdDev, n)`. A change is flagged only when it is **both**:
- statistically significant (p < 0.05, the p-value replaces the old noise band), **and**
- past a minimum effect size (5%, a "big enough to act on" floor).

Series that can't be tested (baselines without `n`, or zero variance) fall back to the legacy relative-threshold behavior. Discrete metrics keep exact-integer comparison. The PR comment surfaces the p-value behind each flag.

## Implementation notes

Tunable constants:

- **`SIGNIFICANCE_ALPHA`** (0.05) — the *"is it real?"* bar. The most noise we're willing to mistake for a real change: a difference is only flagged if there's less than a 5% chance it came from run-to-run jitter. Lower it to be stricter (fewer false alarms, more missed regressions); raise it to be twitchier.
- **`MIN_EFFECT_SIZE`** (0.05) — the *"is it worth caring about?"* bar. Even a rock-solid, statistically-real change is ignored unless it moves the number by at least 5%. This is what the old ±20% band tried to do, but it no longer has to double as a noise filter — the p-value handles that — so it can be a tight, honest "would we act on this?" threshold.
- **`targetRme`** (0.02) — the *"how sure are we of this run's number?"* bar. Adaptive sampling keeps taking iterations until the mean is pinned down to within a 2% margin of error, so a benchmark's own measurement is trustworthy before it's ever compared. Tighter = more iterations and steadier numbers; looser = faster but noisier.