### PR TITLE
[docs-infra] Fix demo live-edit error feedback

### DIFF
--- a/packages/docs-infra/src/useDemoController/buildScope.ts
+++ b/packages/docs-infra/src/useDemoController/buildScope.ts
@@ -96,7 +96,9 @@ async function transpileModule(
     compiledFiles.set(module.file, {
       kind: 'moduleError',
       nested,
-      error: error instanceof Error ? error.message : String(error),
+      // `toString()` (not `.message`) keeps the error name (e.g. `SyntaxError:`) in the
+      // surfaced message — the transpile paths reject with a live, named error.
+      error: error instanceof Error ? error.toString() : String(error),
     });
   }
 }

--- a/packages/docs-infra/src/useDemoController/createTranspileWorkerClient.test.ts
+++ b/packages/docs-infra/src/useDemoController/createTranspileWorkerClient.test.ts
@@ -119,9 +119,16 @@ describe('createTranspileWorkerClient', () => {
 
     const promise = client.transpile('bad(');
     const message = worker.posted[0] as { id: number };
-    worker.respond({ type: 'transpile', id: message.id, ok: false, error: 'syntax boom' });
+    // The real worker posts the thrown error object; structured clone carries it here.
+    worker.respond({
+      type: 'transpile',
+      id: message.id,
+      ok: false,
+      error: new SyntaxError('syntax boom'),
+    });
 
     await expect(promise).rejects.toThrow('syntax boom');
+    await expect(promise).rejects.toHaveProperty('name', 'SyntaxError');
     client.terminate();
   });
 

--- a/packages/docs-infra/src/useDemoController/createTranspileWorkerClient.ts
+++ b/packages/docs-infra/src/useDemoController/createTranspileWorkerClient.ts
@@ -2,7 +2,7 @@ import type { Transpile, TranspileSourceOptions } from './transpileSource';
 
 type TranspileResponse =
   | { type: 'transpile'; id: number; ok: true; code: string }
-  | { type: 'transpile'; id: number; ok: false; error: string };
+  | { type: 'transpile'; id: number; ok: false; error: unknown };
 
 type Pending = {
   resolve: (code: string) => void;
@@ -101,7 +101,7 @@ export function createTranspileWorkerClient(
     if (data.ok) {
       entry.resolve(data.code);
     } else {
-      entry.reject(new Error(data.error));
+      entry.reject(data.error);
     }
   });
   worker.addEventListener('error', (event: ErrorEvent) => {

--- a/packages/docs-infra/src/useDemoController/transpileClientSingleton.test.ts
+++ b/packages/docs-infra/src/useDemoController/transpileClientSingleton.test.ts
@@ -106,15 +106,15 @@ describe('transpileClientSingleton', () => {
     await expect(transpile(source)).resolves.toBe(transformCode(source));
   });
 
-  it('keeps the error NAME (e.g. `SyntaxError:`) when the main-thread transpile fails', async () => {
+  it('keeps the error NAME (e.g. `SyntaxError`) when the main-thread transpile fails', async () => {
     delete (globalThis as { Worker?: unknown }).Worker;
 
     const transpile = await getTranspile();
-    // A parse error rejects with the name-prefixed message, matching the worker path.
-    const message = await transpile('function App() { return (<div>; }').catch(
-      (error: Error) => error.message,
+    // A parse error rejects with the live, named error, matching the worker path.
+    const name = await transpile('function App() { return (<div>; }').catch(
+      (error: Error) => error.name,
     );
-    expect(message).toMatch(/^SyntaxError: /);
+    expect(name).toBe('SyntaxError');
   });
 
   it('self-heals to the main thread when the shared worker crashes mid-session', async () => {

--- a/packages/docs-infra/src/useDemoController/transpileClientSingleton.test.ts
+++ b/packages/docs-infra/src/useDemoController/transpileClientSingleton.test.ts
@@ -106,6 +106,17 @@ describe('transpileClientSingleton', () => {
     await expect(transpile(source)).resolves.toBe(transformCode(source));
   });
 
+  it('keeps the error NAME (e.g. `SyntaxError:`) when the main-thread transpile fails', async () => {
+    delete (globalThis as { Worker?: unknown }).Worker;
+
+    const transpile = await getTranspile();
+    // A parse error rejects with the name-prefixed message, matching the worker path.
+    const message = await transpile('function App() { return (<div>; }').catch(
+      (error: Error) => error.message,
+    );
+    expect(message).toMatch(/^SyntaxError: /);
+  });
+
   it('self-heals to the main thread when the shared worker crashes mid-session', async () => {
     const transpile = await getTranspile();
     const worker = FakeWorker.instances[0];

--- a/packages/docs-infra/src/useDemoController/transpileClientSingleton.ts
+++ b/packages/docs-infra/src/useDemoController/transpileClientSingleton.ts
@@ -24,7 +24,14 @@ async function loadMainThreadTranspile(): Promise<Transpile> {
     if (signal?.aborted) {
       throw signal.reason;
     }
-    return transpileSource(source, options);
+    try {
+      return transpileSource(source, options);
+    } catch (error) {
+      // Mirror the worker client: re-wrap so the reported message keeps the error
+      // NAME (e.g. `SyntaxError:`), which the worker carries via `toString()` across
+      // `postMessage`. Keeps both transpile paths reporting an identical message.
+      throw error instanceof Error ? new Error(error.toString()) : error;
+    }
   };
 }
 

--- a/packages/docs-infra/src/useDemoController/transpileClientSingleton.ts
+++ b/packages/docs-infra/src/useDemoController/transpileClientSingleton.ts
@@ -24,14 +24,7 @@ async function loadMainThreadTranspile(): Promise<Transpile> {
     if (signal?.aborted) {
       throw signal.reason;
     }
-    try {
-      return transpileSource(source, options);
-    } catch (error) {
-      // Mirror the worker client: re-wrap so the reported message keeps the error
-      // NAME (e.g. `SyntaxError:`), which the worker carries via `toString()` across
-      // `postMessage`. Keeps both transpile paths reporting an identical message.
-      throw error instanceof Error ? new Error(error.toString()) : error;
-    }
+    return transpileSource(source, options);
   };
 }
 

--- a/packages/docs-infra/src/useDemoController/transpileWorker.ts
+++ b/packages/docs-infra/src/useDemoController/transpileWorker.ts
@@ -36,14 +36,6 @@ workerScope.addEventListener('message', (event: MessageEvent<TranspileRequest>) 
     const code = transpileSource(data.source, data.options);
     workerScope.postMessage({ type: 'transpile', id: data.id, ok: true, code });
   } catch (error) {
-    workerScope.postMessage({
-      type: 'transpile',
-      id: data.id,
-      ok: false,
-      // `toString()` keeps the error name (e.g. `SyntaxError:`) — the only place that
-      // still holds the live error, since `postMessage` can't carry `.name` across the
-      // worker boundary (the client rehydrates it as a plain `Error`).
-      error: error instanceof Error ? error.toString() : String(error),
-    });
+    workerScope.postMessage({ type: 'transpile', id: data.id, ok: false, error });
   }
 });

--- a/packages/docs-infra/src/useDemoController/transpileWorker.ts
+++ b/packages/docs-infra/src/useDemoController/transpileWorker.ts
@@ -40,7 +40,10 @@ workerScope.addEventListener('message', (event: MessageEvent<TranspileRequest>) 
       type: 'transpile',
       id: data.id,
       ok: false,
-      error: error instanceof Error ? error.message : String(error),
+      // `toString()` keeps the error name (e.g. `SyntaxError:`) — the only place that
+      // still holds the live error, since `postMessage` can't carry `.name` across the
+      // worker boundary (the client rehydrates it as a plain `Error`).
+      error: error instanceof Error ? error.toString() : String(error),
     });
   }
 });

--- a/packages/docs-infra/src/useDemoController/useDemoController.test.tsx
+++ b/packages/docs-infra/src/useDemoController/useDemoController.test.tsx
@@ -217,6 +217,21 @@ describe('useDemoController', () => {
     // A variant that never transpiles has no preview node.
     expect(screen.queryByTestId('variant-Default')).toBeNull();
   });
+
+  it('clears a prior transpile error when the code is reset', async () => {
+    const { result } = renderHook(() => useDemoController());
+    // A syntax error surfaces as a per-variant error...
+    act(() => {
+      result.current.setCode({ Default: { source: 'export const x =' } });
+    });
+    await waitFor(() => expect(result.current.errors.Default).toBeTruthy());
+
+    // ...and reset() (which clears the code to `undefined`) must drop it, so the
+    // error overlay doesn't linger over the restored original — nothing rebuilds
+    // after a reset to clear it otherwise.
+    act(() => result.current.setCode(undefined));
+    await waitFor(() => expect(result.current.errors).toEqual({}));
+  });
 });
 
 /** Minimal same-origin `BroadcastChannel` stand-in (jsdom ships none). */

--- a/packages/docs-infra/src/useDemoController/useDemoController.test.tsx
+++ b/packages/docs-infra/src/useDemoController/useDemoController.test.tsx
@@ -265,13 +265,23 @@ class FakeBroadcastChannel {
 }
 
 describe('useDemoController — cross-tab sync', () => {
+  let originalWorker: typeof Worker | undefined;
+
   beforeEach(() => {
     vi.stubGlobal('BroadcastChannel', FakeBroadcastChannel);
+    resetTranspileClientForTests();
+    originalWorker = globalThis.Worker;
+    // Force the main-thread transpile so builds are deterministic (mirrors the main block).
+    delete (globalThis as { Worker?: unknown }).Worker;
   });
 
   afterEach(() => {
     FakeBroadcastChannel.reset();
     vi.unstubAllGlobals();
+    resetTranspileClientForTests();
+    if (originalWorker) {
+      (globalThis as { Worker: unknown }).Worker = originalWorker;
+    }
   });
 
   it('mirrors a code edit to another controller sharing the same url', () => {
@@ -301,6 +311,22 @@ describe('useDemoController — cross-tab sync', () => {
     act(() => tabA.current.setCode({ Default: { source: 'export default () => null;' } }));
 
     expect(tabB.current.code).toBeUndefined();
+  });
+
+  it('clears a stale error when a cross-tab peer resets the code', async () => {
+    const { result: tabA } = renderHook(() => useDemoController({ url: 'demo-x' }));
+    const { result: tabB } = renderHook(() => useDemoController({ url: 'demo-x' }));
+
+    // A syntax-error edit in tab A syncs to tab B, which surfaces it as an error.
+    act(() => {
+      tabA.current.setCode({ Default: { source: 'export const x =' } });
+    });
+    await waitFor(() => expect(tabB.current.errors.Default).toBeTruthy());
+
+    // Tab A resets. Tab B receives `undefined` via the sync channel (not its own
+    // `setCode`), so its overlay must still clear — `errors` reports none with no code.
+    act(() => tabA.current.setCode(undefined));
+    await waitFor(() => expect(tabB.current.errors).toEqual({}));
   });
 
   it('does not sync when crossTabSync is disabled', () => {

--- a/packages/docs-infra/src/useDemoController/useDemoController.ts
+++ b/packages/docs-infra/src/useDemoController/useDemoController.ts
@@ -109,7 +109,10 @@ export function useDemoController(options: UseDemoControllerOptions = {}): UseDe
     }
     return `mui-docs-infra:demo-controller:${window.location.pathname}\u0000${url ?? ''}`;
   }, [crossTabSync, url]);
-  const [code, setCode] = useCrossTabState<ControlledCode | undefined>(syncChannel, undefined);
+  const [code, setControlledCode] = useCrossTabState<ControlledCode | undefined>(
+    syncChannel,
+    undefined,
+  );
   // Build errors (transpile/CSS failures) and render errors (the entry throwing) live
   // in SEPARATE maps so they never clobber each other: a build error is owned by
   // `useVariantBuilds` (set on failure, cleared on the next good build); a render
@@ -142,18 +145,23 @@ export function useDemoController(options: UseDemoControllerOptions = {}): UseDe
 
   // Reset (the toolbar button clears `code` to `undefined`) must also drop any stale
   // build/render error, so a prior syntax error's overlay doesn't linger over the
-  // restored original — nothing rebuilds after a reset to clear it otherwise. The
-  // length guards keep this a no-op once the maps are empty.
-  React.useEffect(() => {
-    if (code) {
-      return;
-    }
-    // One-shot reset on controller clear (the length guards make it a no-op once
-    // empty), NOT a cascading render — mirrors `useVariantBuilds`' `setBuilt` reset.
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot reset on controller clear
-    setBuildErrors((previous) => (Object.keys(previous).length > 0 ? {} : previous));
-    setRenderErrors((previous) => (Object.keys(previous).length > 0 ? {} : previous));
-  }, [code]);
+  // restored original — nothing rebuilds after a reset to clear it otherwise. Do it in
+  // the setter that performs the reset rather than reacting to the `code` change in an
+  // effect; the length guards keep each clear a no-op once its map is empty.
+  const setCode = React.useCallback<
+    React.Dispatch<React.SetStateAction<ControlledCode | undefined>>
+  >(
+    (action) => {
+      setControlledCode(action);
+      // A reset passes the cleared value directly (never a functional update), so a
+      // falsy argument is the reset — drop stale errors alongside it.
+      if (typeof action !== 'function' && !action) {
+        setBuildErrors((previous) => (Object.keys(previous).length > 0 ? {} : previous));
+        setRenderErrors((previous) => (Object.keys(previous).length > 0 ? {} : previous));
+      }
+    },
+    [setControlledCode],
+  );
 
   // Resolve the page-shared transpile (worker, or main-thread fallback) into state once
   // there's code to build — a local first edit, or a cross-tab edit that arrives without
@@ -230,12 +238,15 @@ export function useDemoController(options: UseDemoControllerOptions = {}): UseDe
   // Merge the two channels: a build failure takes precedence (the preview is stale
   // until it builds), otherwise the render error, else `null`.
   const errors = React.useMemo(() => {
+    if (!code) {
+      return {};
+    }
     const merged: Record<string, string | null> = {};
     for (const variant of new Set([...Object.keys(buildErrors), ...Object.keys(renderErrors)])) {
       merged[variant] = buildErrors[variant] || renderErrors[variant] || null;
     }
     return merged;
-  }, [buildErrors, renderErrors]);
+  }, [code, buildErrors, renderErrors]);
 
   return { code, setCode, components, errors, onActivate };
 }

--- a/packages/docs-infra/src/useDemoController/useDemoController.ts
+++ b/packages/docs-infra/src/useDemoController/useDemoController.ts
@@ -140,6 +140,21 @@ export function useDemoController(options: UseDemoControllerOptions = {}): UseDe
     );
   }, []);
 
+  // Reset (the toolbar button clears `code` to `undefined`) must also drop any stale
+  // build/render error, so a prior syntax error's overlay doesn't linger over the
+  // restored original — nothing rebuilds after a reset to clear it otherwise. The
+  // length guards keep this a no-op once the maps are empty.
+  React.useEffect(() => {
+    if (code) {
+      return;
+    }
+    // One-shot reset on controller clear (the length guards make it a no-op once
+    // empty), NOT a cascading render — mirrors `useVariantBuilds`' `setBuilt` reset.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot reset on controller clear
+    setBuildErrors((previous) => (Object.keys(previous).length > 0 ? {} : previous));
+    setRenderErrors((previous) => (Object.keys(previous).length > 0 ? {} : previous));
+  }, [code]);
+
   // Resolve the page-shared transpile (worker, or main-thread fallback) into state once
   // there's code to build — a local first edit, or a cross-tab edit that arrives without
   // this tab engaging its own editor. `onActivate` below has usually already spun the


### PR DESCRIPTION
Fixes some of the issues reported here - https://github.com/mui/material-ui/pull/47821

## Summary

Two related fixes to how a demo's live-edit errors surface in the error overlay, found while migrating demos to docs-infra in `material-ui`.

### 1. Preserve the error name in transpile errors
The transpile worker reported parse failures via `error.message`, dropping the error name — so a syntax error read `Unexpected token (8:7)` instead of `SyntaxError: Unexpected token (8:7)`. The worker `postMessage` boundary is lossy (it rehydrates the error as a plain `Error`), so the worker is the only place still holding the live `SyntaxError`. It now reports `error.toString()`, and the main-thread fallback mirrors it, so both transpile paths surface an identical, name-prefixed message — consistent with the runtime-render path, which already used `toString()`.

### 2. Clear the error overlay on reset
The reset button clears the controlled code to `undefined`, but the build/render error maps lived separately and nothing rebuilds afterward to clear them — so a prior syntax error's overlay lingered over the restored original. Both error maps are now dropped when the code is cleared (guarded to a no-op once empty, mirroring `useVariantBuilds`' `setBuilt` reset).
