### PR TITLE
[docs-infra] Enable webpackBuildWorker in shared Next.js config

### DIFF
--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.test.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import type { NextConfig } from 'next';
+import { withDeploymentConfig } from './withDeploymentConfig';
+
+describe('withDeploymentConfig', () => {
+  it('enables webpackBuildWorker by default', () => {
+    const config: NextConfig = {};
+    const result = withDeploymentConfig(config);
+
+    expect(result.experimental?.webpackBuildWorker).toBe(true);
+  });
+
+  it('lets consumers override webpackBuildWorker', () => {
+    const config: NextConfig = { experimental: { webpackBuildWorker: false } };
+    const result = withDeploymentConfig(config);
+
+    expect(result.experimental?.webpackBuildWorker).toBe(false);
+  });
+});

--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -239,6 +239,12 @@ export function withDeploymentConfig<T extends NextConfig>(nextConfig: T): T {
     experimental: {
       scrollRestoration: true,
       workerThreads: false,
+      // Run each webpack compilation in a separate, disposable worker process so
+      // its memory is released before static generation instead of accumulating
+      // in the long-lived build process. This is off by default whenever a custom
+      // `webpack` config is present (Next resolves the `undefined` default to
+      // `false` when `config.webpack` is set), so it must be enabled explicitly.
+      webpackBuildWorker: true,
       ...(process.env.CI
         ? {
             cpus: process.env.NEXT_PARALLELISM


### PR DESCRIPTION
Closes https://github.com/mui/material-ui/pull/48790

Enables Next.js's `experimental.webpackBuildWorker` in the shared `withDeploymentConfig` factory so every docs consumer runs each webpack compilation in a separate, disposable worker process. Its memory is released before static generation instead of accumulating in the long-lived build process, lowering peak docs-build memory.

The flag is off by default whenever a custom `webpack` config is present — Next resolves the `undefined` default to `false` when `config.webpack` is set, and `withDeploymentConfig` wraps `withDocsInfra(...)` which defines one — so it has to be enabled explicitly. It's placed before the `...nextConfig.experimental` spread so individual projects can still override it.

Moves the change from mui/material-ui#48790 to the shared docs infrastructure, per review feedback on that PR (the config now lives here in mui-public).