### PR TITLE
[dashboard] Simplify deploy preview to always-valid homepage link

### DIFF
--- a/apps/code-infra-dashboard/src/constants.ts
+++ b/apps/code-infra-dashboard/src/constants.ts
@@ -69,15 +69,15 @@ export const repositories = new Map<string, Repository>(
           netlifyDocs: {
             siteId: 'material-ui',
             formatDocPath: (filePath) => {
-              if (!filePath.startsWith('docs/data/') || !filePath.endsWith('.md')) {
+              if (
+                !filePath.startsWith('docs/data/') ||
+                !/\.(md|mdx|jsx?|tsx?|json)$/.test(filePath)
+              ) {
                 return null;
               }
-              let url = filePath.replace('docs/data', '').replace(/\.md$/, '');
-              // Deduplicate trailing segment (e.g. /button/button → /button)
-              const fragments = url.split('/').reverse();
-              if (fragments[0] === fragments[1]) {
-                url = fragments.slice(1).reverse().join('/');
-              }
+              // Map a file to its page directory: demos and data files live alongside
+              // the page's markdown, so the containing folder identifies the page.
+              let url = filePath.replace('docs/data', '').replace(/\/[^/]+$/, '');
               if (url.startsWith('/material')) {
                 url = url
                   .replace('/material', '/material-ui')
@@ -128,12 +128,15 @@ export const repositories = new Map<string, Repository>(
           netlifyDocs: {
             siteId: 'material-ui-x',
             formatDocPath: (filePath) => {
-              if (!filePath.startsWith('docs/data/') || !filePath.endsWith('.md')) {
+              if (
+                !filePath.startsWith('docs/data/') ||
+                !/\.(md|mdx|jsx?|tsx?|json)$/.test(filePath)
+              ) {
                 return null;
               }
               return filePath
                 .replace('docs/data', 'x')
-                .replace(/\/[^/]+\.md$/, '/')
+                .replace(/\/[^/]+$/, '/')
                 .replace('data-grid/', 'react-data-grid/')
                 .replace('date-pickers/', 'react-date-pickers/')
                 .replace('charts/', 'react-charts/')

--- a/apps/code-infra-dashboard/src/lib/ciReports/deployPreviewReport.test.ts
+++ b/apps/code-infra-dashboard/src/lib/ciReports/deployPreviewReport.test.ts
@@ -72,6 +72,87 @@ describe('generateDeployPreviewReport', () => {
     expect(report?.content).not.toContain('Button.tsx');
   });
 
+  it('should map a changed demo file to its page', async () => {
+    mockOctokit.pulls.listFiles.mockResolvedValue({
+      data: [
+        { filename: 'docs/data/material/components/buttons/BasicButtons.tsx', status: 'modified' },
+      ],
+    });
+
+    const report = await generateDeployPreviewReport(reportOptions('mui/material-ui', 42));
+
+    const pageUrl =
+      'https://deploy-preview-42--material-ui.netlify.app/material-ui/components/buttons';
+    expect(report?.content).toContain(`<a href="${pageUrl}">`);
+    expect(report?.content).toContain('docs/data/material/components/buttons/BasicButtons.tsx</a>');
+  });
+
+  it('should map a changed JSON data file to its page', async () => {
+    mockOctokit.pulls.listFiles.mockResolvedValue({
+      data: [{ filename: 'docs/data/about/teamMembers.json', status: 'modified' }],
+    });
+
+    const report = await generateDeployPreviewReport(reportOptions('mui/material-ui', 42));
+
+    const pageUrl = 'https://deploy-preview-42--material-ui.netlify.app/about';
+    expect(report?.content).toContain(`<a href="${pageUrl}">`);
+    expect(report?.content).toContain('docs/data/about/teamMembers.json</a>');
+  });
+
+  it('should dedupe multiple changed files that map to the same page', async () => {
+    mockOctokit.pulls.listFiles.mockResolvedValue({
+      data: [
+        { filename: 'docs/data/material/components/buttons/buttons.md', status: 'modified' },
+        { filename: 'docs/data/material/components/buttons/BasicButtons.tsx', status: 'modified' },
+        {
+          filename: 'docs/data/material/components/buttons/ContainedButtons.tsx',
+          status: 'modified',
+        },
+      ],
+    });
+
+    const report = await generateDeployPreviewReport(reportOptions('mui/material-ui', 42));
+
+    const pageUrl =
+      'https://deploy-preview-42--material-ui.netlify.app/material-ui/components/buttons';
+    expect(report?.content.match(new RegExp(`href="${pageUrl}"`, 'g'))).toHaveLength(1);
+  });
+
+  it('should ignore image and other non-doc assets', async () => {
+    mockOctokit.pulls.listFiles.mockResolvedValue({
+      data: [
+        { filename: 'docs/data/material/components/buttons/screenshot.png', status: 'modified' },
+        { filename: 'docs/public/static/branding/about/avatar.png', status: 'modified' },
+      ],
+    });
+
+    const report = await generateDeployPreviewReport(reportOptions('mui/material-ui', 42));
+
+    // No doc page matched, so it falls back to a single link to the preview root.
+    expect(report?.content).not.toContain('screenshot.png');
+    expect(report?.content).not.toContain('avatar.png');
+    expect(report?.content).toContain(
+      '<a href="https://deploy-preview-42--material-ui.netlify.app/">',
+    );
+  });
+
+  it('should map non-markdown doc changes for mui-x', async () => {
+    mockOctokit.pulls.listFiles.mockResolvedValue({
+      data: [
+        {
+          filename: 'docs/data/data-grid/filtering/BasicFilteringGrid.tsx',
+          status: 'modified',
+        },
+      ],
+    });
+
+    const report = await generateDeployPreviewReport(reportOptions('mui/mui-x', 42));
+
+    const pageUrl =
+      'https://deploy-preview-42--material-ui-x.netlify.app/x/react-data-grid/filtering/';
+    expect(report?.content).toContain(`<a href="${pageUrl}">`);
+  });
+
   it('should embed a verifiable signed QR code URL', async () => {
     const report = await generateDeployPreviewReport(reportOptions('mui/material-ui', 42));
 

--- a/apps/code-infra-dashboard/src/lib/ciReports/deployPreviewReport.ts
+++ b/apps/code-infra-dashboard/src/lib/ciReports/deployPreviewReport.ts
@@ -56,19 +56,26 @@ export async function generateDeployPreviewReport(
     per_page: 100,
   });
 
-  const docLinks: { filePath: string; url: string }[] = [];
+  // Several changed files (e.g. a page's markdown plus its demos) can map to the same
+  // page, so dedupe by URL and count unique pages against MAX_DOC_LINKS.
+  const docLinksByUrl = new Map<string, string>(); // url -> first matching filePath (link label)
   for (const file of files) {
     if (file.status === 'removed') {
       continue;
     }
     const docPath = formatDocPath(file.filename);
-    if (docPath) {
-      docLinks.push({ filePath: file.filename, url: new URL(docPath, previewUrl).toString() });
-      if (docLinks.length >= MAX_DOC_LINKS) {
+    if (!docPath) {
+      continue;
+    }
+    const url = new URL(docPath, previewUrl).toString();
+    if (!docLinksByUrl.has(url)) {
+      docLinksByUrl.set(url, file.filename);
+      if (docLinksByUrl.size >= MAX_DOC_LINKS) {
         break;
       }
     }
   }
+  const docLinks = [...docLinksByUrl].map(([url, filePath]) => ({ filePath, url }));
 
   let markdown = `## ${DEPLOY_PREVIEW_SECTION_TITLE}\n\n`;
 


### PR DESCRIPTION
## Problem

The **Deploy preview** comment tried to deep-link each changed doc page by mapping the source path to a published URL. That mapping is unreliable and produced 404s:

- Component pages: `docs/data/material/components/buttons/buttons.md` → `/material-ui/components/buttons` **(404)**; the real URL is `/material-ui/react-button/` (slug comes from routing config, not the folder).
- Section pages: a stray `.replace(/(customization|guides|…)/, 'material-ui/$1')` doubled the prefix → `/material-ui/material-ui/customization/palette` **(404)**, as seen on mui/material-ui#48753.
- Non-`.md` changes (demos, `teamMembers.json`) were detected as nothing.

## Change

Stop guessing per-page URLs. The deploy-preview **root** is the only link we can build reliably, so:

- Always show the homepage preview link (with QR code), whether or not docs changed.
- List changed doc files as **plain text** (no fragile links), filtered by a simple `docsPath` prefix per repo (`docs/data/` for material-ui & mui-x, `docs/app/docs-infra/` for mui-public).
- Remove the `formatDocPath` URL-mapping config entirely.

Fixes the #48753 broken link and removes the component 404s.