### PR TITLE
[benchmark] Use paintTime instead of renderTime for bench:paint

### DIFF
--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -14,7 +14,9 @@ import './taskMetaAugmentation';
 
 interface PerformanceElementTiming extends PerformanceEntry {
   readonly entryType: 'element';
-  readonly renderTime: DOMHighResTimeStamp;
+  // End of the main-thread paint phase — deterministic and interoperable, unlike `renderTime`
+  // which resolves to the VSync-approximated presentation time (quantized to the display refresh).
+  readonly paintTime: DOMHighResTimeStamp;
   readonly identifier: string;
 }
 
@@ -368,13 +370,13 @@ export function benchmark(
       if (!isWarmup) {
         for (const entry of timing.elementEntries) {
           // Skip paints that happened while recording was paused. Attribute by the paint's
-          // `renderTime`, not by when the observer callback fired (which can lag the paint).
-          if (!recording.activeAt(entry.renderTime)) {
+          // `paintTime`, not by when the observer callback fired (which can lag the paint).
+          if (!recording.activeAt(entry.paintTime)) {
             continue;
           }
           // The default sentinel is the base series; named markers become sub-series.
           const id = entry.identifier === 'default' ? undefined : entry.identifier;
-          paint.record(entry.renderTime - iterationStart, id !== undefined ? { id } : undefined);
+          paint.record(entry.paintTime - iterationStart, id !== undefined ? { id } : undefined);
         }
         iterations.push({ renders: captures });
       }

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -14,9 +14,10 @@ import './taskMetaAugmentation';
 
 interface PerformanceElementTiming extends PerformanceEntry {
   readonly entryType: 'element';
-  // When the browser started painting the element (i.e. the render phase ended). More stable than
-  // `renderTime`, which reports when the pixels reached the screen and so varies with the display's
-  // refresh timing.
+  // When the browser started painting the element (i.e. the render phase ended). Preferred over
+  // `renderTime`, which reports when the pixels reached the screen: that includes the wait for the
+  // next display refresh, adding variance and time unrelated to the CPU-bound render work these
+  // benchmarks optimize.
   readonly paintTime: DOMHighResTimeStamp;
   readonly identifier: string;
 }

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -14,8 +14,8 @@ import './taskMetaAugmentation';
 
 interface PerformanceElementTiming extends PerformanceEntry {
   readonly entryType: 'element';
-  // End of the main-thread paint phase — deterministic and interoperable, unlike `renderTime`
-  // which resolves to the VSync-approximated presentation time (quantized to the display refresh).
+  // When the browser finished painting the element. More stable than `renderTime`, which reports
+  // when the pixels reached the screen and so varies with the display's refresh timing.
   readonly paintTime: DOMHighResTimeStamp;
   readonly identifier: string;
 }

--- a/packages/benchmark/src/index.tsx
+++ b/packages/benchmark/src/index.tsx
@@ -14,8 +14,9 @@ import './taskMetaAugmentation';
 
 interface PerformanceElementTiming extends PerformanceEntry {
   readonly entryType: 'element';
-  // When the browser finished painting the element. More stable than `renderTime`, which reports
-  // when the pixels reached the screen and so varies with the display's refresh timing.
+  // When the browser started painting the element (i.e. the render phase ended). More stable than
+  // `renderTime`, which reports when the pixels reached the screen and so varies with the display's
+  // refresh timing.
   readonly paintTime: DOMHighResTimeStamp;
   readonly identifier: string;
 }

--- a/packages/benchmark/src/reactRecording.ts
+++ b/packages/benchmark/src/reactRecording.ts
@@ -5,7 +5,7 @@ export interface ReactRecordingControls {
   readonly hadEmptyActiveWindow: boolean;
   /**
    * Whether recording was active at `time` (a `performance.now()` timestamp). Paint entries are
-   * observed asynchronously, so they are attributed by their `renderTime` rather than by the
+   * observed asynchronously, so they are attributed by their `paintTime` rather than by the
    * recording state at the moment the observer callback happens to fire.
    */
   activeAt(time: number): boolean;


### PR DESCRIPTION
`bench:paint` was recorded from the Element Timing entry's `renderTime`, which reports when pixels reach the screen and so varies with the display's refresh timing. This switches to `paintTime` (when the browser finished painting) for a more stable, lower-variance signal.

Metric names (`bench:paint` / `bench:paint#<id>`) are unchanged, so the compare/dashboard code is unaffected. Chromium-only, so no fallback needed.