### PR TITLE
[docs-infra] Keep a section alive for its manually-placed ungrouped link

### DIFF
--- a/packages/docs-infra/src/pipeline/syncPageIndex/groupAwareIndex.test.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/groupAwareIndex.test.ts
@@ -701,6 +701,26 @@ describe('ungrouped links keep their manual section placement', () => {
     // ...and re-rendering keeps it under Handbook (byte-stable round-trip).
     expect(metadataToMarkdown(parsed!, { path: 'src/app/react/page.mdx' })).toBe(markdown);
   });
+
+  it('keeps a section alive when only its manually-placed ungrouped link remains', async () => {
+    // Existing file: the Handbook section holds a route-grouped page and an external link a
+    // human filed under it (sectionGroup).
+    const existing = metadataToMarkdown(grouped([stylingPage, llmsPage('(handbook)')]), {
+      path: 'src/app/react/page.mdx',
+    });
+
+    // Regeneration drops the only route-grouped page; the generator re-lists the external link
+    // but, as usual, without its human-chosen placement (sectionGroup is merge-preserved).
+    const merged = await mergeMetadataMarkdown(
+      existing,
+      { title: 'React', pages: [llmsPage()] },
+      { path: 'src/app/react/page.mdx' },
+    );
+
+    // The Handbook heading survives and the link stays under it instead of falling to the top.
+    expect(merged).toContain('## Handbook');
+    expect(merged.indexOf('## Handbook')).toBeLessThan(merged.indexOf('/llms.txt'));
+  });
 });
 
 // `syncPageIndex` pre-populates its page-index cache from the merged metadata, then asserts a

--- a/packages/docs-infra/src/pipeline/syncPageIndex/mergeMetadataMarkdown.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/mergeMetadataMarkdown.ts
@@ -15,17 +15,18 @@ import type {
 
 /**
  * Derives the ordered route-group sections for an index, given the sections recovered
- * from the existing file (whose titles/order humans may have edited) and the merged
- * pages. Existing sections are kept in place so renames and reordering survive; a group
- * seen for the first time is appended with a seeded title. Sections that no longer have
- * any pages are dropped. Returns undefined when no page has a route group (flat index).
+ * from the existing file (whose titles/order humans may have edited) and the per-page
+ * section groups (each page's own route group, falling back to the group a human filed an
+ * ungrouped page under). Existing sections are kept in place so renames and reordering
+ * survive; a group seen for the first time is appended with a seeded title. Sections whose
+ * last page has gone — including a section left holding only a manually-placed ungrouped
+ * link — are kept as long as some page still references the group; a section no page
+ * references is dropped. Returns undefined when no page has a group at all (flat index).
  */
 function deriveIndexSections(
   existingSections: PageIndexSection[] | undefined,
-  pages: PageMetadata[],
+  pageGroups: (string | undefined)[],
 ): PageIndexSection[] | undefined {
-  // Each page's route group, in order, computed once.
-  const pageGroups = pages.map((page) => routeGroupOfPath(page.path));
   const usedGroups = new Set(pageGroups.filter((group) => group !== undefined));
 
   const result: PageIndexSection[] = [];
@@ -63,10 +64,14 @@ function deriveGroupedFields(
   pages: PageMetadata[],
   existingDetailsSectionTitle: string | undefined,
 ): Pick<PagesMetadata, 'pages' | 'sections' | 'detailsSectionTitle'> {
-  const sections = deriveIndexSections(baseSections, pages);
+  // Each page's section group — its own route group, else the group a human filed it under —
+  // computed once and reused for both deriving the sections and clustering the pages, so the
+  // sync path parses each path only a single time.
+  const pageGroups = pages.map((page) => routeGroupOfPath(page.path) ?? page.sectionGroup);
+  const sections = deriveIndexSections(baseSections, pageGroups);
   return {
     sections,
-    pages: sections ? orderPagesBySection(pages, sections) : pages,
+    pages: sections ? orderPagesBySection(pages, sections, pageGroups) : pages,
     detailsSectionTitle: sections
       ? (existingDetailsSectionTitle ?? DEFAULT_DETAILS_SECTION_TITLE)
       : undefined,

--- a/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.ts
+++ b/packages/docs-infra/src/pipeline/syncPageIndex/metadataToMarkdown.ts
@@ -1138,18 +1138,24 @@ export function routeGroupOfPath(path: string): string | undefined {
  * A page's section is its own route group, falling back to the group a human filed it under
  * (`sectionGroup`); a page matching no section is ungrouped. Shared by the renderer and the
  * merge step so the serialized file and the pre-populated cache agree on page order.
+ *
+ * Callers that have already resolved each page's group may pass it as `pageGroups` (aligned
+ * with `pages` by index) to avoid re-parsing every path; when omitted it is derived here.
  */
 export function clusterPagesBySection(
   pages: PageMetadata[],
   sections: PageIndexSection[],
+  pageGroups?: (string | undefined)[],
 ): { ungrouped: PageMetadata[]; bySection: Map<string, PageMetadata[]> } {
   const bySection = new Map<string, PageMetadata[]>(sections.map((section) => [section.group, []]));
   const ungrouped: PageMetadata[] = [];
-  for (const page of pages) {
-    const group = routeGroupOfPath(page.path) ?? page.sectionGroup;
+  pages.forEach((page, pageIndex) => {
+    const group = pageGroups
+      ? pageGroups[pageIndex]
+      : (routeGroupOfPath(page.path) ?? page.sectionGroup);
     const bucket = (group && bySection.get(group)) || ungrouped;
     bucket.push(page);
-  }
+  });
   return { ungrouped, bySection };
 }
 
@@ -1157,12 +1163,14 @@ export function clusterPagesBySection(
  * Flattens {@link clusterPagesBySection} into the single canonical page order the renderer
  * emits (ungrouped first, then each section). Used to normalize a merged page list so a warm
  * cache matches a fresh parse of the rendered file. A flat index (no sections) is unchanged.
+ * `pageGroups` is forwarded to {@link clusterPagesBySection} as a per-page group cache.
  */
 export function orderPagesBySection(
   pages: PageMetadata[],
   sections: PageIndexSection[],
+  pageGroups?: (string | undefined)[],
 ): PageMetadata[] {
-  const { ungrouped, bySection } = clusterPagesBySection(pages, sections);
+  const { ungrouped, bySection } = clusterPagesBySection(pages, sections, pageGroups);
   return [...ungrouped, ...sections.flatMap((section) => bySection.get(section.group) ?? [])];
 }
 


### PR DESCRIPTION
Fixes a confirmed correctness finding from the review of #1640. Stacked on that PR's branch.

## Finding #2 (correctness)
`deriveIndexSections` keyed grouped sections strictly by the route group parsed from each page's *path* (`usedGroups`). When a section's last route-grouped page is removed but a human-placed ungrouped link (e.g. an external `/llms.txt` filed under the heading via `sectionGroup`) remains, the section was dropped on the next sync and the link fell back to the top of the index — regressing the "ungrouped links keep their manual section placement" behavior.

Fix: key sections by the same expression `clusterPagesBySection` already uses — `routeGroupOfPath(path) ?? page.sectionGroup`.

## Finding #7 (efficiency, folded in)
That per-page group was computed once in `deriveIndexSections` and again in `orderPagesBySection` → `clusterPagesBySection`. It's now computed once in `deriveGroupedFields` and threaded through both via an optional `pageGroups` cache param, so each path is parsed a single time per sync.

## Not included
- **#4** (flat index converted to grouped) is the PR's stated purpose ("Organize index pages by Next.js route group"), not a bug.
- **#3** (an editable-region section with *only* ungrouped pages is dropped) is a documented design tradeoff — it needs a synthetic section key, which is a design decision left to the author. See the review thread.

Adds a regression test in `groupAwareIndex.test.ts`.