### PR TITLE
[code-infra] Remove npm-dry-run param and bump min Node to 22.22.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ parameters:
 
 default-job: &default-job
   working_directory: /tmp/mui
-  executor: code-infra/mui-node
+  executor:
+    name: code-infra/mui-node
+    node-version: '22.22.3'
   resource_class: medium
 
 default-context: &default-context

--- a/.github/actions/ci-publish/action.yml
+++ b/.github/actions/ci-publish/action.yml
@@ -1,13 +1,8 @@
 name: 'pkg.pr.new release'
 
-description: 'Publishes a new release to pkg.pr.new and dry-runs npm publishing'
+description: 'Publishes a new release to pkg.pr.new'
 
 inputs:
-  npm-dry-run:
-    description: 'Run the npm publish flow in dry-run mode'
-    type: boolean
-    required: false
-    default: false
   pr-comment:
     description: 'Configure comments from pkg.pr.new bot'
     type: boolean
@@ -42,14 +37,3 @@ runs:
             sleep 30
           fi
         done
-
-    # This step makes sure that publishing doesn't break over time due to changes in the environment or dependencies.
-    - name: Dry run npm publishing
-      if: ${{ inputs.npm-dry-run == 'true' }}
-      # Tolerates the push permission error in dry-run explicitly
-      env:
-        IS_PUBLISH_TEST: 'true'
-      run: |
-        echo "Running npm publish in dry-run mode..."
-        pnpm code-infra publish --ci --dry-run
-      shell: bash

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -14,11 +14,6 @@ on:
         type: boolean
         required: false
         default: false
-      npm-dry-run:
-        description: 'Run the npm publish flow in dry-run mode'
-        type: boolean
-        required: false
-        default: false
 
 permissions: {}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Bootstrap, Build, and Test the Repository
 
-- **Prerequisites**: Node.js 22.18.0+ required. Install pnpm: `npm install -g pnpm@11.1.2`
+- **Prerequisites**: Node.js 22.22.3+ required. Install pnpm: `npm install -g pnpm@11.1.2`
 - **Install dependencies**: `pnpm install --no-frozen-lockfile` -- takes 15-20 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Build all packages**: `pnpm release:build` -- takes 5-10 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Type checking**: `pnpm typescript` -- takes 10-15 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
   "packageManager": "pnpm@11.9.0",
   "engines": {
     "pnpm": "11.9.0",
-    "node": ">=22.18.0"
+    "node": ">=22.22.3"
   }
 }


### PR DESCRIPTION
Combines two related code-infra changes.

**1. Remove `npm-dry-run` support from `ci-publish`**
The npm dry-run now lives in a dedicated `publish-dry-run` job in each consumer repo (mirroring the real `publish.yml` environment), so the action no longer needs to run it.
- Remove the `npm-dry-run` input and the "Dry run npm publishing" step from `.github/actions/ci-publish/action.yml`.
- Remove the unused `npm-dry-run` input from `.github/workflows/ci-base.yml`.

**2. Bump min Node version to 22.22.3**
npm@12 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, so publishing on Node 22.18 fails with `EBADENGINE`.
- Bump `engines.node` to `>=22.22.3`.
- Pass `node-version: '22.22.3'` explicitly to the `code-infra/mui-node` CircleCI executor.
- Update the Node prerequisite in `AGENTS.md`.

Companion consumer PRs: mui/mui-x#23113, mui/material-ui#48799, mui/base-ui#5191, mui/base-ui-charts#638, mui/base-ui-plus#130, mui/base-ui-mosaic#366.