### PR TITLE
[code-infra] Bump min Node version to 22.22.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,9 @@ parameters:
 
 default-job: &default-job
   working_directory: /tmp/mui
-  executor: code-infra/mui-node
+  executor:
+    name: code-infra/mui-node
+    node-version: '22.22.3'
   resource_class: medium
 
 default-context: &default-context

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Bootstrap, Build, and Test the Repository
 
-- **Prerequisites**: Node.js 22.18.0+ required. Install pnpm: `npm install -g pnpm@11.1.2`
+- **Prerequisites**: Node.js 22.22.3+ required. Install pnpm: `npm install -g pnpm@11.1.2`
 - **Install dependencies**: `pnpm install --no-frozen-lockfile` -- takes 15-20 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Build all packages**: `pnpm release:build` -- takes 5-10 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Type checking**: `pnpm typescript` -- takes 10-15 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
   "packageManager": "pnpm@11.9.0",
   "engines": {
     "pnpm": "11.9.0",
-    "node": ">=22.18.0"
+    "node": ">=22.22.3"
   }
 }


### PR DESCRIPTION
npm@12 requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. Publishing on Node 22.18 now fails with `EBADENGINE`, so this bumps the minimum Node version in this repo.

- Bump `engines.node` to `>=22.22.3`.
- Pass `node-version: '22.22.3'` explicitly to the `code-infra/mui-node` CircleCI executor.
- Update the Node prerequisite in `AGENTS.md`.

The `mui-node` orb executor already defaults to `22.22.3`. Companion PRs bump the same across consumer repos (mui/material-ui#48799, mui/base-ui#5191, mui/base-ui-charts#638, mui/base-ui-plus#130, mui/base-ui-mosaic#366).