### PR TITLE
[docs-infra] Patch MDX webpack layers for Next.js 16.2 RSC

### DIFF
--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.test.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.test.ts
@@ -53,14 +53,14 @@ describe('withDeploymentConfig', () => {
       expect(config.module.rules[0].use[0].options).toEqual({});
     });
 
-    it('preserves an existing bundleLayer', () => {
+    it('throws when a bundleLayer is already assigned, signaling the workaround is obsolete', () => {
       const result = withDeploymentConfig<NextConfig>({});
       const config = createMdxConfig();
-      config.module.rules[0].use[0].options = { bundleLayer: 'custom' } as any;
+      config.module.rules[0].use[0].options = { bundleLayer: 'rsc' } as any;
 
-      result.webpack!(config, { isServer: true } as any);
-
-      expect(config.module.rules[0].use[0].options).toEqual({ bundleLayer: 'custom' });
+      expect(() => result.webpack!(config, { isServer: true } as any)).toThrow(
+        /vercel\/next\.js\/issues\/91735/,
+      );
     });
 
     it('delegates to a consumer-supplied webpack config', () => {

--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.test.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { NextConfig } from 'next';
 import { withDeploymentConfig } from './withDeploymentConfig';
 
@@ -15,5 +15,65 @@ describe('withDeploymentConfig', () => {
     const result = withDeploymentConfig(config);
 
     expect(result.experimental?.webpackBuildWorker).toBe(false);
+  });
+
+  describe('webpack MDX layer patch', () => {
+    function createMdxConfig() {
+      return {
+        module: {
+          rules: [
+            {
+              test: /\.mdx$/,
+              use: [
+                { loader: 'some/next-swc-loader.js', options: {} },
+                { loader: 'other-loader.js', options: {} },
+              ],
+            },
+          ],
+        },
+      };
+    }
+
+    it('assigns the rsc bundle layer to MDX swc loaders on the server', () => {
+      const result = withDeploymentConfig<NextConfig>({});
+      const config = createMdxConfig();
+
+      result.webpack!(config, { isServer: true } as any);
+
+      expect(config.module.rules[0].use[0].options).toEqual({ bundleLayer: 'rsc' });
+      expect(config.module.rules[0].use[1].options).toEqual({});
+    });
+
+    it('does not patch on the client', () => {
+      const result = withDeploymentConfig<NextConfig>({});
+      const config = createMdxConfig();
+
+      result.webpack!(config, { isServer: false } as any);
+
+      expect(config.module.rules[0].use[0].options).toEqual({});
+    });
+
+    it('preserves an existing bundleLayer', () => {
+      const result = withDeploymentConfig<NextConfig>({});
+      const config = createMdxConfig();
+      config.module.rules[0].use[0].options = { bundleLayer: 'custom' } as any;
+
+      result.webpack!(config, { isServer: true } as any);
+
+      expect(config.module.rules[0].use[0].options).toEqual({ bundleLayer: 'custom' });
+    });
+
+    it('delegates to a consumer-supplied webpack config', () => {
+      const consumerWebpack = vi.fn((config) => config);
+      const result = withDeploymentConfig<NextConfig>({ webpack: consumerWebpack });
+      const config = createMdxConfig();
+      const context = { isServer: true } as any;
+
+      const returned = result.webpack!(config, context);
+
+      expect(consumerWebpack).toHaveBeenCalledWith(config, context);
+      expect(returned).toBe(config);
+      expect(config.module.rules[0].use[0].options).toEqual({ bundleLayer: 'rsc' });
+    });
   });
 });

--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -230,6 +230,11 @@ function patchMdxWebpackLayers(rules: unknown[]): void {
           const webpackOptions = options as Record<string, unknown>;
           if (webpackOptions.bundleLayer == null) {
             webpackOptions.bundleLayer = 'rsc';
+          } else {
+            // Next.js now assigns the bundle layer itself, so this workaround is obsolete.
+            throw new Error(
+              'MDX webpack layer workaround is obsolete; remove patchMdxWebpackLayers (see https://github.com/vercel/next.js/issues/91735).',
+            );
           }
         }
       }

--- a/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDeploymentConfig.ts
@@ -197,12 +197,68 @@ function readCommitShaFromGit(): string | undefined {
   }
 }
 
+/**
+ * Work around https://github.com/vercel/next.js/issues/91735.
+ * Next.js 16.2 does not assign MDX files to the React Server Components webpack layer.
+ */
+function patchMdxWebpackLayers(rules: unknown[]): void {
+  for (const rule of rules) {
+    if (!rule || typeof rule !== 'object') {
+      continue;
+    }
+
+    const webpackRule = rule as Record<string, unknown>;
+
+    // page.mdx just verifies the regex matches MDX files
+    if (webpackRule.test instanceof RegExp && webpackRule.test.test('page.mdx')) {
+      const loaders = Array.isArray(webpackRule.use) ? webpackRule.use : [webpackRule.use];
+
+      for (const loader of loaders) {
+        if (!loader || typeof loader !== 'object') {
+          continue;
+        }
+
+        const webpackLoader = loader as Record<string, unknown>;
+        const { options } = webpackLoader;
+
+        if (
+          typeof webpackLoader.loader === 'string' &&
+          webpackLoader.loader.includes('next-swc-loader') &&
+          options &&
+          typeof options === 'object'
+        ) {
+          const webpackOptions = options as Record<string, unknown>;
+          if (webpackOptions.bundleLayer == null) {
+            webpackOptions.bundleLayer = 'rsc';
+          }
+        }
+      }
+    }
+
+    if (Array.isArray(webpackRule.oneOf)) {
+      patchMdxWebpackLayers(webpackRule.oneOf);
+    }
+    if (Array.isArray(webpackRule.rules)) {
+      patchMdxWebpackLayers(webpackRule.rules);
+    }
+  }
+}
+
 export function withDeploymentConfig<T extends NextConfig>(nextConfig: T): T {
+  const consumerWebpack = nextConfig.webpack;
+  const webpack: NonNullable<NextConfig['webpack']> = (config, context) => {
+    if (context.isServer && config?.module && Array.isArray(config.module.rules)) {
+      patchMdxWebpackLayers(config.module.rules);
+    }
+    return consumerWebpack ? consumerWebpack(config, context) : config;
+  };
+
   return {
     trailingSlash: true,
     reactStrictMode: true,
     productionBrowserSourceMaps: true,
     ...nextConfig,
+    webpack,
     env: {
       // production | staging | pull-request | development
       DEPLOY_ENV,


### PR DESCRIPTION
## Summary

Next.js 16.2 does not assign MDX files to the React Server Components webpack layer (see https://github.com/vercel/next.js/issues/91735). This adds `patchMdxWebpackLayers`, which walks the webpack rules and sets `bundleLayer: 'rsc'` on MDX `next-swc-loader` entries.

Applied inside `withDeploymentConfig` so all consumers inherit the fix, while still delegating to any consumer-supplied `webpack` config.

Migrated from https://github.com/mui/base-ui/pull/4394 (excluding the Next.js version bumps).

> [!NOTE]
> This is a **temporary fix applied in a single place** (`withDeploymentConfig`). It should be **removed once the underlying issue is fixed in Next.js** ([vercel/next.js#91735](https://github.com/vercel/next.js/issues/91735)).

## Testing

Added unit tests covering server patching, client no-op, preserving an existing `bundleLayer`, and delegation to a consumer webpack config.