### PR TITLE
Exclude code-infra-renovate[bot] from publish and changelog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
   publish-preview:
     if: >
       github.event_name == 'schedule'
-      || (github.event_name == 'push' && github.event.head_commit.author.name != 'renovate[bot]')
+      || (github.event_name == 'push' && github.event.head_commit.author.name != 'renovate[bot]' && github.event.head_commit.author.name != 'code-infra-renovate[bot]')
       || (github.event_name == 'workflow_dispatch' && inputs.preview == true)
     runs-on: ubuntu-latest
     permissions:

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -93,7 +93,7 @@ async function fetchCommitsForPackage({ packagePath }) {
   return results;
 }
 
-const AUTHOR_EXCLUDE_LIST = ['renovate[bot]', 'dependabot[bot]'];
+const AUTHOR_EXCLUDE_LIST = ['renovate[bot]', 'dependabot[bot]', 'code-infra-renovate[bot]'];
 
 /**
  * @param {string} message

--- a/packages/code-infra/src/cli/cmdPublishCanary.mjs
+++ b/packages/code-infra/src/cli/cmdPublishCanary.mjs
@@ -93,7 +93,11 @@ async function fetchCommitsForPackage({ packagePath }) {
   return results;
 }
 
-const AUTHOR_EXCLUDE_LIST = ['renovate[bot]', 'dependabot[bot]', 'code-infra-renovate[bot]'];
+const AUTHOR_EXCLUDE_LIST = new Set([
+  'renovate[bot]',
+  'dependabot[bot]',
+  'code-infra-renovate[bot]',
+]);
 
 /**
  * @param {string} message
@@ -144,7 +148,7 @@ async function prepareChangelogsFromGitCli(packagesToPublish, allPackages, canar
         // Exclude commits authored by bots
         .filter(
           // We want to allow commits from copilot or other AI tools, so only filter known bots
-          (commit) => !AUTHOR_EXCLUDE_LIST.includes(commit.author),
+          (commit) => !AUTHOR_EXCLUDE_LIST.has(commit.author),
         )
         .map((commit) => `- ${cleanupCommitMessage(commit.message)} by ${commit.author}`);
 


### PR DESCRIPTION
Adds `code-infra-renovate[bot]` alongside the existing `renovate[bot]` exclusions in two places:

- `.github/workflows/publish.yml`: the `publish-preview` job gate no longer triggers a preview publish on pushes authored by `code-infra-renovate[bot]`.
- `packages/code-infra/src/cli/cmdPublishCanary.mjs`: `code-infra-renovate[bot]` commits are excluded from generated changelogs.