### PR TITLE
[code-infra] Republish workspace:* dependents in canary flow

### DIFF
--- a/packages/code-infra/src/utils/pnpm.mjs
+++ b/packages/code-infra/src/utils/pnpm.mjs
@@ -89,12 +89,15 @@ export async function getWorkspacePackages(options = {}) {
   };
 
   // pnpm ORs --filter args, so intersect "matches filter" with "changed since ref"
-  // in JS. The `[ref]` selector (no `...`) excludes dependents of changed packages.
+  // in JS. The `...[ref]` selector includes dependents of changed packages, so a
+  // package whose `workspace:*` dependency changed is treated as changed too. This
+  // keeps consumers from getting duplicate copies when only a leaf package is
+  // republished but its dependents still pin the previous version.
   const patternFilterArg = filter.flatMap((f) => ['--filter', f]);
   const [candidatePackages, changedPackages] = await Promise.all([
     listPackages(patternFilterArg),
     // null when no sinceRef (skip the constraint); [] when nothing changed.
-    sinceRef ? listPackages(['--filter', `[${sinceRef}]`]) : Promise.resolve(null),
+    sinceRef ? listPackages(['--filter', `...[${sinceRef}]`]) : Promise.resolve(null),
   ]);
   let packageData = candidatePackages;
   if (changedPackages) {


### PR DESCRIPTION
Regression from #1569. `getWorkspacePackages()` used the `...[ref]` pnpm selector, whose leading `...` includes **dependents** of changed packages — so a `workspace:*` dependent got republished and re-pinned. #1569 rewrote the filtering (to fix a separate OR-vs-AND bug) and dropped the `...`, silently excluding dependents.

Result: when `display-name`/`minify-errors` bumped, `code-infra` (which pins both via `workspace:*` in `dependencies`) wasn't republished, so consumers kept both versions → duplication ([mui-x#23140](https://github.com/mui/mui-x/pull/23140)).

Fix: restore `...[${sinceRef}]`, keeping #1569's intersection logic.

Doesn't retroactively fix mui-x#23140 — that needs a fresh `code-infra` canary published after the newer plugin canaries.