### PR TITLE
[renovate] Group eslint-plugin-import monorepo utils into eslint

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -187,6 +187,11 @@
       "matchSourceUrls": ["https://github.com/eslint/*"]
     },
     {
+      "groupName": "eslint",
+      "description": "Catch utility packages published from the eslint-plugin-import monorepo (eslint-module-utils, eslint-import-resolver-*) whose names don't match the eslint-plugin-* pattern.",
+      "matchSourceUrls": ["https://github.com/import-js/eslint-plugin-import"]
+    },
+    {
       "groupName": "Orama Search Packages",
       "matchSourceUrls": ["https://github.com/oramasearch/*"]
     },


### PR DESCRIPTION
Bumps like #1659 (`eslint-module-utils`) land as standalone Renovate PRs instead of joining the `eslint` group.

`eslint-module-utils` is a utility (not a plugin) published from `import-js/eslint-plugin-import`, so it matches none of the group's existing matchers: it's not in the `eslint`/`typescript-eslint` monorepos, its name isn't `eslint-plugin-*`, and its source repo isn't `github.com/eslint/*`. The same applies to `eslint-import-resolver-*`.

This adds a `matchSourceUrls` rule for `https://github.com/import-js/eslint-plugin-import`, folding the whole monorepo (`eslint-plugin-import`, `eslint-module-utils`, `eslint-import-resolver-*`) into the `eslint` group.