### PR TITLE
TEMP: verbose agent transcript for claude-review diagnosis

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -170,8 +170,9 @@ jobs:
       # "for security", so a failed review gives no clue what happened. Dump the whole
       # execution transcript verbatim to see everything the agent did — tool calls,
       # results, AND its own text (why it stopped, whether it produced a review, how it
-      # tried to post). Printed to the LOG, so GitHub still masks registered secrets;
-      # a sed pass additionally redacts well-known token shapes. Remove once diagnosed.
+      # tried to post). Printed to the LOG (not an artifact) so GitHub's secret masking
+      # applies: GITHUB_TOKEN is auto-masked and the action setSecret()s the OIDC token,
+      # which are the credentials in scope here. Remove once the failure is diagnosed.
       - name: Debug — full agent transcript (TEMP)
         if: always() && steps.claude.outputs.execution_file != ''
         env:
@@ -179,5 +180,5 @@ jobs:
         run: |
           set -euo pipefail
           echo "::group::Full execution transcript"
-          sed -E 's/(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-ant-[A-Za-z0-9-]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,})/<redacted>/g' "$EXEC_FILE"
+          cat "$EXEC_FILE"
           echo "::endgroup::"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -167,26 +167,17 @@ jobs:
             --max-turns 60
 
       # TEMPORARY debug: the action hides the model's turn-by-turn output from the log
-      # "for security", so a failed review gives no clue what happened. Print just the
-      # tool calls and their results (truncated) from the execution transcript to see
-      # what the agent actually ran — e.g. whether/how it invoked `gh pr comment` and
-      # what error came back. Remove once posting is diagnosed.
-      - name: Debug — agent tool trace (TEMP)
+      # "for security", so a failed review gives no clue what happened. Dump the whole
+      # execution transcript verbatim to see everything the agent did — tool calls,
+      # results, AND its own text (why it stopped, whether it produced a review, how it
+      # tried to post). Printed to the LOG, so GitHub still masks registered secrets;
+      # a sed pass additionally redacts well-known token shapes. Remove once diagnosed.
+      - name: Debug — full agent transcript (TEMP)
         if: always() && steps.claude.outputs.execution_file != ''
         env:
           EXEC_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
           set -euo pipefail
-          jq -rs '
-            [ .[] | .. | objects
-              | select(.type? == "tool_use" or .type? == "tool_result") ]
-            | .[]
-            | if .type == "tool_use"
-              then "▶ " + (.name // "?") + ": "
-                   + ((.input.command // .input.description // (.input | tojson)) | tostring | .[0:600])
-              else "  ↳ result: "
-                   + (( .content
-                        | if type == "array" then (map(.text? // "") | join(" ")) else (. | tostring) end
-                      ) | .[0:600])
-              end
-          ' "$EXEC_FILE"
+          echo "::group::Full execution transcript"
+          sed -E 's/(gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|sk-ant-[A-Za-z0-9-]{20,}|eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,})/<redacted>/g' "$EXEC_FILE"
+          echo "::endgroup::"


### PR DESCRIPTION
Replaces the truncated tool-only trace with a verbatim dump of the execution transcript, so we can see the agent's own text (why it stopped at 7 turns, whether it produced a review, how it tried to post) — not just tool calls.