### PR TITLE
Fix Claude review skipping private org members (gate on write access)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,20 +25,15 @@ permissions: {}
 
 jobs:
   review:
-    # Injection defense: PR diff/title/body/comments are attacker-controlled and reach
-    # Claude as text. Require BOTH the commenter and the PR author to be an org
-    # owner/member (author_association). Gating the commenter stops a drive-by from
-    # driving this credentialed run; gating the PR author means we don't review
-    # external PRs for now, keeping the reviewed code to team-authored branches.
-    # Maintainers who work from forks are still MEMBER (association is to the org, not
-    # the branch), so they're covered. issue_comment runs in base context, so WIF
-    # scoping doesn't gate by commenter here — this check does.
+    # Cheap pre-filter only. The team-membership check that actually gates this
+    # credentialed run is the "Verify write access" step below — it can't live here
+    # because `if:` can't make API calls, and author_association (the obvious choice)
+    # silently reports PRIVATE org members as non-members, so it skips real maintainers.
     #
-    # We trigger on created AND edited so a maintainer can add the phrase to an
-    # existing comment. The changes.body.from guard means an edit only fires when the
-    # phrase was NEWLY added (the prior body didn't already start with it), so editing
-    # an already-triggering comment doesn't re-run. On edited, author_association is
-    # still the ORIGINAL author's, so this can't be used to bless an untrusted comment.
+    # We trigger on created AND edited so a maintainer can add the phrase to an existing
+    # comment. The changes.body.from guard means an edit only fires when the phrase was
+    # NEWLY added (the prior body didn't already start with it), so editing an
+    # already-triggering comment doesn't re-run.
     #
     # startsWith (not contains): the phrase must be at the START of the comment, so a
     # quote-reply ("> @claude review") or prose that merely mentions it doesn't fire a
@@ -49,9 +44,7 @@ jobs:
       (
         github.event.action == 'created' ||
         !startsWith(github.event.changes.body.from, '@claude review')
-      ) &&
-      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association) &&
-      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     # The review skill to invoke, kept local to the repo being reviewed. From the
     # workflow_call input when called as a reusable workflow; falls back to the default
@@ -76,11 +69,41 @@ jobs:
       issues: write # needed to comment (also covers the PR top-level comment)
       pull-requests: write # needed to post inline review comments
     steps:
+      # Team-membership gate (the real injection defense). PR diff/title/body/comments
+      # are attacker-controlled and reach Claude as text, and this job mints a Claude
+      # token, so require BOTH the commenter and the PR author to have write access to
+      # this repo. Gating the commenter stops a drive-by from driving the run; gating
+      # the PR author keeps the reviewed code team-authored (no external PRs for now).
+      # We check effective repo permission via the API rather than author_association,
+      # which reports private org members as non-members and would skip real maintainers.
+      # github.token can read this; fail-closed (any non-200 or non-write answer skips).
+      - name: Verify write access
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set -euo pipefail
+          has_write() {
+            local perm
+            perm="$(gh api "repos/${REPO}/collaborators/$1/permission" --jq '.permission' 2>/dev/null)" || return 1
+            [ "$perm" = "admin" ] || [ "$perm" = "write" ]
+          }
+          if has_write "$COMMENTER" && has_write "$PR_AUTHOR"; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Review skipped — commenter ($COMMENTER) or PR author ($PR_AUTHOR) lacks write access."
+          fi
+
       # The repo default branch (trusted — it hosts the review skill) is checked out at
       # the root; the PR head is fetched as data only in the next step. Never checkout
       # the head at root — a malicious postinstall/husky hook in the PR would then run
       # in this OIDC-bearing runner.
       - name: Checkout default branch
+        if: steps.gate.outputs.allowed == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
@@ -91,6 +114,7 @@ jobs:
       # the exact fetched SHA), and parse the optional effort level from the comment.
       - name: Prepare review inputs
         id: prep
+        if: steps.gate.outputs.allowed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -121,6 +145,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Claude review
+        if: steps.gate.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # WIF: the action exchanges this run's GitHub OIDC token for a short-lived

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,20 +24,19 @@ on:
 permissions: {}
 
 jobs:
-  review:
-    # Cheap pre-filter only. The team-membership check that actually gates this
-    # credentialed run is the "Verify write access" step below — it can't live here
-    # because `if:` can't make API calls, and author_association (the obvious choice)
-    # silently reports PRIVATE org members as non-members, so it skips real maintainers.
-    #
-    # We trigger on created AND edited so a maintainer can add the phrase to an existing
-    # comment. The changes.body.from guard means an edit only fires when the phrase was
-    # NEWLY added (the prior body didn't already start with it), so editing an
-    # already-triggering comment doesn't re-run.
-    #
-    # startsWith (not contains): the phrase must be at the START of the comment, so a
-    # quote-reply ("> @claude review") or prose that merely mentions it doesn't fire a
-    # second credentialed review. The optional effort token still follows it directly.
+  # Cheap pre-filter + team-membership check, isolated in a minimal-permission job with
+  # no concurrency group. The review job runs only when this outputs allowed=true; for
+  # unauthorized comments that job is skipped by its `if:`, so it never enters the
+  # concurrency group (a drive-by can't cancel a queued review) and its elevated
+  # permissions are never granted.
+  #
+  # The `if:` is only a cheap pre-filter — the real membership check is the step below,
+  # which needs an API call `if:` can't make:
+  # - created AND edited, so a maintainer can add the phrase to an existing comment; the
+  #   changes.body.from guard fires only when the phrase was NEWLY added.
+  # - startsWith (not contains), so a quote-reply ("> @claude review") or a passing
+  #   mention doesn't trigger. The optional effort token still follows it directly.
+  gate:
     if: >-
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@claude review') &&
@@ -46,17 +45,57 @@ jobs:
         !startsWith(github.event.changes.body.from, '@claude review')
       )
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # only the always-present metadata read is needed for the API below
+    outputs:
+      allowed: ${{ steps.gate.outputs.allowed }}
+    steps:
+      # Team-membership gate (the real injection defense). PR diff/title/body/comments
+      # are attacker-controlled and reach Claude as text, and the review job mints a
+      # Claude token, so require BOTH the commenter and the PR author to have write
+      # access to this repo. Gating the commenter stops a drive-by from driving the run;
+      # gating the PR author keeps the reviewed code team-authored (no external PRs for
+      # now). We check effective repo permission via the API rather than
+      # author_association, which reports private org members as non-members and would
+      # skip real maintainers. github.token can read this; fail-closed (any non-write
+      # answer OR an API error skips).
+      - name: Verify write access
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          set -euo pipefail
+          # No 2>/dev/null: a real API error (rate limit, misconfig) prints to the log so
+          # a failure isn't mistaken for a genuine permission denial.
+          has_write() {
+            local perm
+            perm="$(gh api "repos/${REPO}/collaborators/$1/permission" --jq '.permission')" || return 1
+            [ "$perm" = "admin" ] || [ "$perm" = "write" ]
+          }
+          if has_write "$COMMENTER" && has_write "$PR_AUTHOR"; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "allowed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Review skipped — commenter ($COMMENTER) or PR author ($PR_AUTHOR) lacks write access, or the permission lookup failed (see above)."
+          fi
+
+  review:
+    needs: gate
+    if: needs.gate.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
     # The review skill to invoke, kept local to the repo being reviewed. From the
     # workflow_call input when called as a reusable workflow; falls back to the default
     # on a direct issue_comment run (where `inputs` is empty).
     env:
       REVIEW_SKILL: ${{ inputs.review-skill || 'pr-review' }}
-    # One review at a time per PR, and deliberately at the JOB level, not the workflow
-    # level: a comment that fails the `if:` above never runs this job, so it never
-    # enters the group and can't disturb an in-flight review. cancel-in-progress is
-    # pinned false ON PURPOSE — a running, credentialed review always finishes; a newer
-    # "@claude review" queues behind it. GitHub keeps only the latest pending run per
-    # group, so at most one is ever queued (no pile-up) and we never cancel a live run.
+    # One review at a time per PR. cancel-in-progress is pinned false ON PURPOSE — a
+    # running, credentialed review always finishes; a newer "@claude review" queues
+    # behind it, and GitHub keeps only the latest pending run per group. Unauthorized
+    # comments are filtered by the gate job, so their skipped review job never enters
+    # this group and can't displace a queued review.
     concurrency:
       group: claude-review-${{ github.event.issue.number }}
       cancel-in-progress: false
@@ -69,41 +108,11 @@ jobs:
       issues: write # needed to comment (also covers the PR top-level comment)
       pull-requests: write # needed to post inline review comments
     steps:
-      # Team-membership gate (the real injection defense). PR diff/title/body/comments
-      # are attacker-controlled and reach Claude as text, and this job mints a Claude
-      # token, so require BOTH the commenter and the PR author to have write access to
-      # this repo. Gating the commenter stops a drive-by from driving the run; gating
-      # the PR author keeps the reviewed code team-authored (no external PRs for now).
-      # We check effective repo permission via the API rather than author_association,
-      # which reports private org members as non-members and would skip real maintainers.
-      # github.token can read this; fail-closed (any non-200 or non-write answer skips).
-      - name: Verify write access
-        id: gate
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          COMMENTER: ${{ github.event.comment.user.login }}
-          PR_AUTHOR: ${{ github.event.issue.user.login }}
-        run: |
-          set -euo pipefail
-          has_write() {
-            local perm
-            perm="$(gh api "repos/${REPO}/collaborators/$1/permission" --jq '.permission' 2>/dev/null)" || return 1
-            [ "$perm" = "admin" ] || [ "$perm" = "write" ]
-          }
-          if has_write "$COMMENTER" && has_write "$PR_AUTHOR"; then
-            echo "allowed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "allowed=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Review skipped — commenter ($COMMENTER) or PR author ($PR_AUTHOR) lacks write access."
-          fi
-
       # The repo default branch (trusted — it hosts the review skill) is checked out at
       # the root; the PR head is fetched as data only in the next step. Never checkout
       # the head at root — a malicious postinstall/husky hook in the PR would then run
       # in this OIDC-bearing runner.
       - name: Checkout default branch
-        if: steps.gate.outputs.allowed == 'true'
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
@@ -114,7 +123,6 @@ jobs:
       # the exact fetched SHA), and parse the optional effort level from the comment.
       - name: Prepare review inputs
         id: prep
-        if: steps.gate.outputs.allowed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -145,7 +153,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Claude review
-        if: steps.gate.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # WIF: the action exchanges this run's GitHub OIDC token for a short-lived


### PR DESCRIPTION
## Problem

The review silently skipped for maintainers whose **org membership is private** (e.g. [run 29913724234](https://github.com/mui/mui-public/actions/runs/29913724234) on #1691). `author_association` in `issue_comment` events reports private org members as `NONE`/`CONTRIBUTOR`, so the commenter/PR-author `if:` checks failed for them. Public members worked, which masked it.

## Fix

Replace the two `author_association` checks with a **Verify write access** step that checks effective repo permission for both the commenter and PR author via `repos/.../collaborators/<user>/permission`, gating on `admin`/`write`:

- `github.token` can read it (no new secret), it's immune to membership visibility, and write access = trusted maintainer. Fail-closed.

Verified live: Janpot admin ✓, brijeshb42 admin ✓, octocat read ✗.