### PR TITLE
Fix cherry-pick checkout for fork pull requests

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -66,6 +66,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          # Check out the base branch explicitly. On `pull_request_target` the default
+          # resolves to the PR's merge commit SHA, which `actions/checkout` v7 refuses for
+          # fork PRs. We only ever need base branch history to replay the merged commit.
+          ref: ${{ github.event.pull_request.base.ref }}
       - name: Cherry pick and create the new PR
         uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
         with:


### PR DESCRIPTION
## Problem

The `Create cherry-pick PR` workflow now fails at the `Checkout` step for any **fork-authored** PR labelled `needs cherry-pick`:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. [...]
To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set
'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

Example failure: https://github.com/mui/mui-x/actions/runs/29920926183/job/88925973895 (mui-x PR https://github.com/mui/mui-x/pull/23166, authored from a fork).

## Cause

`actions/checkout` v7 added a "pwn request" guard ([unsafe-pr-checkout-helper.ts](https://github.com/actions/checkout/blob/v7.0.0/src/unsafe-pr-checkout-helper.ts)). Under `pull_request_target` it throws when the PR is from a fork **and** any of these match: `repository:` resolves to the fork, `ref:` matches `refs/pull/N/(head|merge)`, or the resolved commit is `pull_request.head.sha` / `pull_request.merge_commit_sha`.

The `open_cherry_pick_pr` checkout passes no `ref`, so it resolves to the PR's merge commit SHA -- which matches that last condition, and the step is rejected. This only started failing when the pin moved from `actions/checkout` v6.0.2 to v7.x; GitHub also backported the protection to all supported majors on 2026-07-16, so it is not avoidable by staying on v6.

Note this is effectively a false positive for this workflow: it triggers on `types: [closed]`, so `merge_commit_sha` is a commit that already landed on the base branch. No fork code is fetched, and the checked-out tree is never executed -- the cherry-pick action only shells out to `git`.

## Fix

Check out the base branch explicitly:

```yaml
ref: ${{ github.event.pull_request.base.ref }}
```

`ref` then resolves to e.g. `master`, and no commit is passed, so none of the guard's conditions match. This keeps the protection enabled rather than disabling it wholesale with `allow-unsafe-pr-checkout: true`.

This is also the correct ref on the merits: `carloscastrojumo/github-cherry-pick-action` replays `github.context.payload.pull_request.merge_commit_sha`, which lives on the base branch, and `fetch-depth: 0` is retained so that commit is present in history.

The `workflow_dispatch` path is unaffected -- `github.event.pull_request` is undefined there, so `ref` evaluates to an empty string and `actions/checkout` falls back to its default behaviour (and the guard only applies to `pull_request_target` / `workflow_run` anyway).

The other checkout in `detect_cherry_pick_targets` needs no change: it sets `repository: mui/mui-public`, so it resolves to that repo's default branch and never matches the guard.