### PR TITLE
[code-infra] Let publish-prepare configure the self-hosted registry

### DIFF
--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -46,11 +46,6 @@ runs:
         MUI_NPM_AUTH: ${{ inputs.mui-npm-auth }}
       run: |
         set -euo pipefail
-        # chmod rather than umask: setup-node has already created the file, and
-        # umask only applies to newly created ones.
-        chmod 600 "${NPM_CONFIG_USERCONFIG}"
-        # printf, not echo: bash's echo is fine here but zsh's would expand
-        # backslashes in the token, and a corrupted credential fails obscurely.
         printf '%s\n%s\n' \
           "@base-ui-private:registry=https://npm.mui.com/" \
           "//npm.mui.com/:_auth=${MUI_NPM_AUTH}" \

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -45,14 +45,10 @@ runs:
       env:
         MUI_NPM_AUTH: ${{ inputs.mui-npm-auth }}
       run: |
+        # No fallback if NPM_CONFIG_USERCONFIG is missing: `set -u` fails the step
+        # instead. Defaulting to ~/.npmrc would leave the credential on disk after
+        # the job on a self-hosted runner. setup-node above always sets it.
         set -euo pipefail
-        # No fallback to ~/.npmrc: that path outlives the job on a self-hosted
-        # runner, so a missing NPM_CONFIG_USERCONFIG would leave the credential
-        # behind on the machine. setup-node above always sets it.
-        if [[ -z "${NPM_CONFIG_USERCONFIG:-}" ]]; then
-          echo "::error::NPM_CONFIG_USERCONFIG is unset; expected actions/setup-node to have set it." >&2
-          exit 1
-        fi
         # chmod rather than umask: setup-node has already created the file, and
         # umask only applies to newly created ones.
         touch "${NPM_CONFIG_USERCONFIG}"

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -46,10 +46,23 @@ runs:
         MUI_NPM_AUTH: ${{ inputs.mui-npm-auth }}
       run: |
         set -euo pipefail
-        {
-          echo "@base-ui-private:registry=https://npm.mui.com/"
-          echo "//npm.mui.com/:_auth=${MUI_NPM_AUTH}"
-        } >> "${NPM_CONFIG_USERCONFIG:-${HOME}/.npmrc}"
+        # No fallback to ~/.npmrc: that path outlives the job on a self-hosted
+        # runner, so a missing NPM_CONFIG_USERCONFIG would leave the credential
+        # behind on the machine. setup-node above always sets it.
+        if [[ -z "${NPM_CONFIG_USERCONFIG:-}" ]]; then
+          echo "::error::NPM_CONFIG_USERCONFIG is unset; expected actions/setup-node to have set it." >&2
+          exit 1
+        fi
+        # chmod rather than umask: setup-node has already created the file, and
+        # umask only applies to newly created ones.
+        touch "${NPM_CONFIG_USERCONFIG}"
+        chmod 600 "${NPM_CONFIG_USERCONFIG}"
+        # printf, not echo: bash's echo is fine here but zsh's would expand
+        # backslashes in the token, and a corrupted credential fails obscurely.
+        printf '%s\n%s\n' \
+          "@base-ui-private:registry=https://npm.mui.com/" \
+          "//npm.mui.com/:_auth=${MUI_NPM_AUTH}" \
+          >> "${NPM_CONFIG_USERCONFIG}"
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -7,6 +7,13 @@ inputs:
     description: 'Node.js version to set up.'
     required: false
     default: '22.22.3'
+  mui-npm-auth:
+    description: >
+      Basic auth token for the self-hosted registry at https://npm.mui.com (the
+      `ci-publisher` credential). When set, the `@base-ui-private` scope is
+      routed there and authenticated for the rest of the job.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -25,6 +32,24 @@ runs:
     - name: Update npm
       shell: bash
       run: npm install -g npm@latest
+    # Must run after setup-node, which is what points NPM_CONFIG_USERCONFIG at the
+    # npmrc being appended to here, and before any install from the private scope.
+    #
+    # The credential cannot live in a committed .npmrc: pnpm refuses to expand env
+    # vars in auth values read from a project-level file, so a `${VAR}` placeholder
+    # there is dropped and the publish goes out unauthenticated. The npm user
+    # config is a trusted source, so the value goes there directly.
+    - name: Configure the self-hosted npm registry
+      if: inputs.mui-npm-auth != ''
+      shell: bash
+      env:
+        MUI_NPM_AUTH: ${{ inputs.mui-npm-auth }}
+      run: |
+        set -euo pipefail
+        {
+          echo "@base-ui-private:registry=https://npm.mui.com/"
+          echo "//npm.mui.com/:_auth=${MUI_NPM_AUTH}"
+        } >> "${NPM_CONFIG_USERCONFIG:-${HOME}/.npmrc}"
     - name: Install dependencies
       shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -32,8 +32,9 @@ runs:
     - name: Update npm
       shell: bash
       run: npm install -g npm@latest
-    # Must run after setup-node, which is what points NPM_CONFIG_USERCONFIG at the
-    # npmrc being appended to here, and before any install from the private scope.
+    # Must run after setup-node, which points NPM_CONFIG_USERCONFIG at the npmrc
+    # appended to here. setup-node can't do this itself: it only emits an
+    # `_authToken` for its single registry-url, not Basic `_auth` for a second host.
     #
     # The credential cannot live in a committed .npmrc: pnpm refuses to expand env
     # vars in auth values read from a project-level file, so a `${VAR}` placeholder
@@ -45,7 +46,10 @@ runs:
       env:
         MUI_NPM_AUTH: ${{ inputs.mui-npm-auth }}
       run: |
-        set -euo pipefail
+        # -u is the guard: an unset NPM_CONFIG_USERCONFIG fails the step rather
+        # than writing the credential somewhere that outlives the job. The runner
+        # already applies -e and -o pipefail to `shell: bash`.
+        set -u
         printf '%s\n%s\n' \
           "@base-ui-private:registry=https://npm.mui.com/" \
           "//npm.mui.com/:_auth=${MUI_NPM_AUTH}" \

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -45,9 +45,6 @@ runs:
       env:
         MUI_NPM_AUTH: ${{ inputs.mui-npm-auth }}
       run: |
-        # No fallback if NPM_CONFIG_USERCONFIG is missing: `set -u` fails the step
-        # instead. Defaulting to ~/.npmrc would leave the credential on disk after
-        # the job on a self-hosted runner. setup-node above always sets it.
         set -euo pipefail
         # chmod rather than umask: setup-node has already created the file, and
         # umask only applies to newly created ones.

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -9,9 +9,9 @@ inputs:
     default: '22.22.3'
   mui-npm-auth:
     description: >
-      Basic auth token for the self-hosted registry at https://npm.mui.com (the
-      `ci-publisher` credential). When set, the `@base-ui-private` scope is
-      routed there and authenticated for the rest of the job.
+      Basic auth token for the self-hosted registry at https://npm.mui.com. When
+      set, the `@base-ui-private` scope is routed there and authenticated for the
+      rest of the job.
     required: false
     default: ''
 

--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -48,7 +48,6 @@ runs:
         set -euo pipefail
         # chmod rather than umask: setup-node has already created the file, and
         # umask only applies to newly created ones.
-        touch "${NPM_CONFIG_USERCONFIG}"
         chmod 600 "${NPM_CONFIG_USERCONFIG}"
         # printf, not echo: bash's echo is fine here but zsh's would expand
         # backslashes in the token, and a corrupted credential fails obscurely.

--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -38,7 +38,7 @@ This is stored in the `docs` top-level directory.
 Whenever new packages are added to the repo (that will get published to npm) or a private package is turned into a public one, follow the below steps before invoking the publish workflow of the previous section.
 
 > [!NOTE]
-> This applies to packages published to npm, which is where Trusted Publishing needs the package to already exist. Packages that set `publishConfig.registry` to another registry are skipped by this check and need none of these steps — see [Publishing to the self-hosted registry](#publishing-to-the-self-hosted-registry).
+> This applies to packages published to npm, which is where Trusted Publishing needs the package to already exist. Packages that set `publishConfig.registry` to another registry are skipped by this check and need none of these steps.
 
 1. Go to your repo's code base on your system, then log in to npm using
 
@@ -70,30 +70,3 @@ pnpm code-infra publish-new-package --otp=123456
 7. Finally, save the changes by clicking on `Update Package Settings` button.
 
 After following these steps, the `Publish` workflow can be invoked again.
-
-### Publishing to the self-hosted registry
-
-Some packages are published to `https://npm.mui.com`, a self-hosted registry that serves the `@base-ui-private` scope to a small set of external consumers. It has no Trusted Publishing and no provenance; publishing is authenticated with a `ci-publisher` credential.
-
-Point each package at it in its `package.json`:
-
-```json
-{
-  "publishConfig": {
-    "registry": "https://npm.mui.com/"
-  }
-}
-```
-
-Leave `access` out — the registry derives permissions from its own config, so the field would only mislead.
-
-Then pass the credential to the publish workflow:
-
-```yaml
-- name: Prepare for publishing
-  uses: mui/mui-public/.github/actions/publish-prepare@<sha>
-  with:
-    mui-npm-auth: ${{ secrets.MUI_NPM_AUTH }}
-```
-
-No `.npmrc` is committed to the repo.

--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -37,6 +37,9 @@ This is stored in the `docs` top-level directory.
 
 Whenever new packages are added to the repo (that will get published to npm) or a private package is turned into a public one, follow the below steps before invoking the publish workflow of the previous section.
 
+> [!NOTE]
+> This applies to packages published to npm, which is where Trusted Publishing needs the package to already exist. Packages that set `publishConfig.registry` to another registry are skipped by this check and need none of these steps — see [Publishing to the self-hosted registry](#publishing-to-the-self-hosted-registry).
+
 1. Go to your repo's code base on your system, then log in to npm using
 
 ```bash
@@ -67,3 +70,35 @@ pnpm code-infra publish-new-package --otp=123456
 7. Finally, save the changes by clicking on `Update Package Settings` button.
 
 After following these steps, the `Publish` workflow can be invoked again.
+
+### Publishing to the self-hosted registry
+
+Some packages are published to `https://npm.mui.com`, a self-hosted registry that serves the `@base-ui-private` scope to a small set of external consumers. It has no Trusted Publishing and no provenance; publishing is authenticated with a `ci-publisher` credential.
+
+Point each package at it in its `package.json`:
+
+```json
+{
+  "publishConfig": {
+    "registry": "https://npm.mui.com/"
+  }
+}
+```
+
+Leave `access` out — the registry derives permissions from its own config, so the field would only mislead.
+
+Then give the publish workflow the credential. `publish-prepare` takes it from there, routing the scope and authenticating it for the rest of the job:
+
+```yaml
+- name: Prepare for publishing
+  uses: ./.github/actions/publish-prepare
+  with:
+    mui-npm-auth: ${{ secrets.MUI_NPM_AUTH }}
+```
+
+That is the whole setup — no `.npmrc` in the repo. Two things are worth knowing about why:
+
+- The credential **cannot** live in a committed `.npmrc`. pnpm refuses to expand environment variables in auth values read from a project-level file, on the grounds that the file is committed and could leak the secret to an attacker-controlled registry. A `//npm.mui.com/:_auth=${VAR}` line there is dropped with a warning and the publish goes out unauthenticated. `publish-prepare` writes to the npm user config instead, which pnpm trusts.
+- The `@base-ui-private:registry=` line matters even though every package sets `publishConfig.registry`. pnpm's "is this version already published?" pre-check resolves through the registries it knows from npmrc, not through `publishConfig`. Without it, the first publish succeeds and every re-run fails with a 409.
+
+Publishing to this registry does not need `id-token: write`; OIDC is npm-only and just adds a failed token exchange per package.

--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -87,13 +87,13 @@ Point each package at it in its `package.json`:
 
 Leave `access` out — the registry derives permissions from its own config, so the field would only mislead.
 
-Then give the publish workflow the credential. `publish-prepare` takes it from there, routing the scope and authenticating it for the rest of the job:
+Then pass the credential to the publish workflow:
 
 ```yaml
 - name: Prepare for publishing
-  uses: ./.github/actions/publish-prepare
+  uses: mui/mui-public/.github/actions/publish-prepare@<sha>
   with:
     mui-npm-auth: ${{ secrets.MUI_NPM_AUTH }}
 ```
 
-That is the whole setup — no `.npmrc` in the repo.
+No `.npmrc` is committed to the repo.

--- a/packages/code-infra/README.md
+++ b/packages/code-infra/README.md
@@ -96,9 +96,4 @@ Then give the publish workflow the credential. `publish-prepare` takes it from t
     mui-npm-auth: ${{ secrets.MUI_NPM_AUTH }}
 ```
 
-That is the whole setup — no `.npmrc` in the repo. Two things are worth knowing about why:
-
-- The credential **cannot** live in a committed `.npmrc`. pnpm refuses to expand environment variables in auth values read from a project-level file, on the grounds that the file is committed and could leak the secret to an attacker-controlled registry. A `//npm.mui.com/:_auth=${VAR}` line there is dropped with a warning and the publish goes out unauthenticated. `publish-prepare` writes to the npm user config instead, which pnpm trusts.
-- The `@base-ui-private:registry=` line matters even though every package sets `publishConfig.registry`. pnpm's "is this version already published?" pre-check resolves through the registries it knows from npmrc, not through `publishConfig`. Without it, the first publish succeeds and every re-run fails with a 409.
-
-Publishing to this registry does not need `id-token: write`; OIDC is npm-only and just adds a failed token exchange per package.
+That is the whole setup — no `.npmrc` in the repo.


### PR DESCRIPTION
Packages published to `https://npm.mui.com` (the self-hosted registry serving `@base-ui-private`) authenticate with a Basic credential rather than npm's OIDC trusted publishing. This adds a `mui-npm-auth` input to `publish-prepare`, so a consuming repo needs nothing but the secret:

```yaml
- uses: ./.github/actions/publish-prepare
  with:
    mui-npm-auth: ${{ secrets.MUI_NPM_AUTH }}
```

No `.npmrc` in the repo. Two non-obvious reasons it's built this way:

- **The credential can't live in a committed `.npmrc`.** pnpm drops auth values containing `${VAR}` when they come from a project-level file — deliberately, since that file is committed and could leak the secret to an attacker-controlled registry. A publish configured that way goes out unauthenticated and fails with E401. It lands in the npm user config instead, which pnpm trusts and which `setup-node` already points `NPM_CONFIG_USERCONFIG` at.
- **The scope line is needed even though packages set `publishConfig.registry`.** pnpm's already-published pre-check resolves through npmrc registries, not `publishConfig`. Without it the first publish succeeds and every re-run 409s.

No effect on existing repos — the step is skipped when the input is unset.

> [!IMPORTANT]
> **Depends on #1695, and should merge after it.** The README note added here says packages targeting another registry are skipped by the "new packages need a manual publish first" check. That skip is implemented in #1695; on `master` alone the note describes behaviour that does not exist yet. (Thanks Copilot — correct catch.)

Verified end to end against a local Verdaccio running the production ACL config: publishes with no project `.npmrc`, re-runs are a clean no-op, and the credential file ends up mode 600.

Downstream consumer: mui/base-ui-mosaic#376.