### PR TITLE
[docs-infra] Implement alternate lite version of demo loader

### DIFF
--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -81,7 +81,8 @@
     "./pipeline/transformTypescriptToJavascript": "./src/pipeline/transformTypescriptToJavascript/index.ts",
     "./lite/loaders/demo": "./src/lite/loaders/demo/index.ts",
     "./lite/buildtime/transformMarkdownDemos": "./src/lite/buildtime/transformMarkdownDemos.ts",
-    "./lite/runtime": "./src/lite/runtime/index.ts"
+    "./lite/runtime": "./src/lite/runtime/index.ts",
+    "./syntax.css": "./src/syntax.css"
   },
   "keywords": [
     "react",
@@ -107,7 +108,7 @@
   },
   "homepage": "https://github.com/mui/mui-public/tree/master/packages/docs-infra",
   "scripts": {
-    "build": "code-infra build --tsgo --bundle esm",
+    "build": "code-infra build --tsgo --bundle esm --copy src/syntax.css",
     "release": "pnpm build && pnpm publish --no-git-checks",
     "test": "pnpm -w test --project @mui/internal-docs-infra",
     "test:watch": "pnpm -w test:watch --project @mui/internal-docs-infra",

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -80,6 +80,8 @@
     "./pipeline/transformMarkdownRelativePaths": "./src/pipeline/transformMarkdownRelativePaths/index.ts",
     "./pipeline/transformTypescriptToJavascript": "./src/pipeline/transformTypescriptToJavascript/index.ts",
     "./lite/loaders/demo": "./src/lite/loaders/demo/index.ts",
+    "./lite/buildtime/transformHtmlCode": "./src/lite/buildtime/transformHtmlCode.ts",
+    "./lite/buildtime/transformMarkdownCode": "./src/lite/buildtime/transformMarkdownCode.ts",
     "./lite/buildtime/transformMarkdownDemos": "./src/lite/buildtime/transformMarkdownDemos.ts",
     "./lite/runtime": "./src/lite/runtime/index.ts",
     "./syntax.css": "./src/syntax.css"
@@ -123,6 +125,7 @@
     "@lezer/common": "^1.5.2",
     "@lezer/css": "^1.3.4",
     "@lezer/highlight": "^1.2.3",
+    "@lezer/html": "^1.3.13",
     "@lezer/javascript": "1.5.4",
     "@lezer/json": "^1.0.3",
     "@orama/orama": "^3.1.18",

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -78,7 +78,10 @@
     "./pipeline/transformMarkdownMetadata": "./src/pipeline/transformMarkdownMetadata/index.ts",
     "./pipeline/transformMarkdownMetadata/types": "./src/pipeline/transformMarkdownMetadata/types.ts",
     "./pipeline/transformMarkdownRelativePaths": "./src/pipeline/transformMarkdownRelativePaths/index.ts",
-    "./pipeline/transformTypescriptToJavascript": "./src/pipeline/transformTypescriptToJavascript/index.ts"
+    "./pipeline/transformTypescriptToJavascript": "./src/pipeline/transformTypescriptToJavascript/index.ts",
+    "./lite/loaders/demo": "./src/lite/loaders/demo/index.ts",
+    "./lite/buildtime/transformMarkdownDemos": "./src/lite/buildtime/transformMarkdownDemos.ts",
+    "./lite/runtime": "./src/lite/runtime/index.ts"
   },
   "keywords": [
     "react",
@@ -116,6 +119,11 @@
     "@csstools/postcss-light-dark-function": "^3.0.2",
     "@csstools/postcss-relative-color-syntax": "^4.0.7",
     "@csstools/postcss-stepped-value-functions": "^5.0.4",
+    "@lezer/common": "^1.5.2",
+    "@lezer/css": "^1.3.4",
+    "@lezer/highlight": "^1.2.3",
+    "@lezer/javascript": "1.5.4",
+    "@lezer/json": "^1.0.3",
     "@orama/orama": "^3.1.18",
     "@orama/plugin-qps": "^3.1.18",
     "@orama/stemmers": "^3.1.18",
@@ -126,6 +134,7 @@
     "clipboard-copy": "^4.0.1",
     "es-toolkit": "^1.49.0",
     "fflate": "^0.8.3",
+    "hast-util-to-html": "9.0.5",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "hast-util-to-text": "^4.0.2",
     "icss-utils": "^5.1.0",

--- a/packages/docs-infra/src/lite/buildtime/transformCode.integration.test.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformCode.integration.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { Element, Root } from 'hast';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { transformMarkdownCode } from './transformMarkdownCode';
+import { transformHtmlCode } from './transformHtmlCode';
+
+describe('lite MDX code pipeline', () => {
+  it('transforms realistic Markdown fences and inline code', async () => {
+    const markdown = [
+      'Use `string` in this example.',
+      '',
+      '```tsx title="Example"',
+      'const value = true; // @highlight',
+      '```',
+    ].join('\n');
+    const processor = unified()
+      .use(remarkParse)
+      .use(transformMarkdownCode)
+      .use(remarkRehype)
+      .use(transformHtmlCode);
+    const tree = (await processor.run(processor.parse(markdown))) as Root;
+    const paragraph = tree.children[0] as Element;
+    const inlineCode = paragraph.children.find(
+      (child): child is Element => child.type === 'element' && child.tagName === 'code',
+    );
+    const pre = tree.children.find(
+      (child): child is Element => child.type === 'element' && child.tagName === 'pre',
+    );
+
+    expect(inlineCode?.properties.dataInline).toBe('');
+    expect(JSON.stringify(inlineCode)).toContain('pl-bt');
+    expect(pre?.properties.dataContentProps).toBe('{"title":"Example"}');
+    const precompute = JSON.parse(String(pre?.properties.dataPrecompute));
+    expect(precompute.Default.language).toBe('tsx');
+    expect(JSON.stringify(precompute.Default.source)).toContain('dataHl');
+    expect(JSON.stringify(precompute.Default.source)).not.toContain('@highlight');
+  });
+});

--- a/packages/docs-infra/src/lite/buildtime/transformHtmlCode.test.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformHtmlCode.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest';
+import type { Element, Root, RootContent } from 'hast';
+import { transformHtmlCode } from './transformHtmlCode';
+
+function textContent(node: RootContent | Root): string {
+  if (node.type === 'text') {
+    return node.value;
+  }
+  if ('children' in node) {
+    return node.children.map((child) => textContent(child)).join('');
+  }
+  return '';
+}
+
+function codeBlock(source: string, language = 'tsx', properties: Element['properties'] = {}): Root {
+  return {
+    type: 'root',
+    children: [
+      {
+        type: 'element',
+        tagName: 'pre',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'code',
+            properties: { className: [`language-${language}`], ...properties },
+            children: [{ type: 'text', value: source }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function transform(tree: Root): Promise<Root> {
+  const transformer = transformHtmlCode();
+  transformer(tree);
+  return tree;
+}
+
+function precomputeOf(tree: Root) {
+  const pre = tree.children[0] as Element;
+  return JSON.parse(String(pre.properties.dataPrecompute)) as {
+    Default: {
+      source: Root & {
+        data: { totalLines: number; focusedLines: number; collapsible: boolean };
+      };
+      language?: string;
+      fileName?: string;
+      totalLines: number;
+      focusedLines: number;
+      collapsible: boolean;
+    };
+  };
+}
+
+describe('transformHtmlCode', () => {
+  it('highlights fenced code with the lite parser and preserves content props', async () => {
+    const tree = await transform(
+      codeBlock(['const value = 1; // @highlight', 'console.log(value);'].join('\n'), 'tsx', {
+        dataTitle: 'Example',
+      }),
+    );
+    const pre = tree.children[0] as Element;
+    const variant = precomputeOf(tree).Default;
+
+    expect(variant.language).toBe('tsx');
+    expect(variant.totalLines).toBe(2);
+    expect(textContent(variant.source)).toBe('const value = 1;\nconsole.log(value);');
+    expect(JSON.stringify(variant.source)).toContain('pl-k');
+    expect(JSON.stringify(variant.source)).toContain('dataHl');
+    expect(pre.properties.dataContentProps).toBe('{"title":"Example"}');
+  });
+
+  it('splits a late focus range and exposes its line counts', async () => {
+    const source = [
+      ...Array.from({ length: 14 }, (unused, index) => `const value${index} = ${index};`),
+      '// @focus-start',
+      'const focused = true;',
+      '// @focus-end',
+      'console.log(focused);',
+    ].join('\n');
+    const variant = precomputeOf(await transform(codeBlock(source))).Default;
+
+    expect(variant.source.children).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          properties: expect.objectContaining({ dataFrameType: 'focus' }),
+        }),
+      ]),
+    );
+    expect(variant.focusedLines).toBe(1);
+    expect(variant.totalLines).toBe(16);
+    expect(variant.collapsible).toBe(true);
+  });
+
+  it('preserves emphasis comments when displayComments is enabled', async () => {
+    const tree = await transform(
+      codeBlock('const value = 1; // @highlight', 'ts', { dataDisplayComments: 'true' }),
+    );
+
+    expect(textContent(precomputeOf(tree).Default.source)).toContain('@highlight');
+  });
+
+  it('preserves filenames and excludes reserved metadata from content props', async () => {
+    const tree = await transform(
+      codeBlock('const value: string = "test";', 'ts', {
+        dataFilename: 'example.ts',
+        dataVariant: 'main',
+        dataTransform: 'true',
+        dataTitle: 'Example',
+      }),
+    );
+    const pre = tree.children[0] as Element;
+
+    expect(precomputeOf(tree).Default.fileName).toBe('example.ts');
+    expect(pre.properties.dataContentProps).toBe('{"title":"Example"}');
+  });
+
+  it('serializes display flags as booleans', async () => {
+    const tree = await transform(
+      codeBlock('const value = 1;', 'ts', {
+        dataCollapseToEmpty: 'false',
+        dataInitialExpanded: '',
+      }),
+    );
+    const pre = tree.children[0] as Element;
+
+    expect(JSON.parse(String(pre.properties.dataContentProps))).toEqual({
+      collapseToEmpty: false,
+      initialExpanded: true,
+    });
+  });
+
+  it('does not emit content props when none were provided', async () => {
+    const tree = await transform(codeBlock('const value = 1;', 'ts'));
+    const pre = tree.children[0] as Element;
+
+    expect(pre.properties.dataContentProps).toBeUndefined();
+  });
+
+  it('extracts nested source text without losing whitespace', async () => {
+    const tree = codeBlock('', 'js');
+    const pre = tree.children[0] as Element;
+    const code = pre.children[0] as Element;
+    code.children = [
+      { type: 'text', value: 'const ' },
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: {},
+        children: [{ type: 'text', value: 'x' }],
+      },
+      { type: 'text', value: ' = 42;' },
+    ];
+    await transform(tree);
+
+    expect(textContent(precomputeOf(tree).Default.source)).toBe('const x = 42;');
+  });
+
+  it('processes empty and untyped fenced code', async () => {
+    const tree = codeBlock('   ', '', { className: [] });
+    const variant = precomputeOf(await transform(tree)).Default;
+
+    expect(variant.language).toBeUndefined();
+    expect(textContent(variant.source)).toBe('   ');
+  });
+
+  it('transforms every fenced block independently', async () => {
+    const first = codeBlock('const first = 1;', 'js').children[0];
+    const second = codeBlock('const second = 2;', 'ts').children[0];
+    const tree: Root = { type: 'root', children: [first, second] };
+    await transform(tree);
+
+    for (const child of tree.children) {
+      expect((child as Element).properties.dataPrecompute).toBeTruthy();
+    }
+  });
+
+  it('leaves non-code pre elements and existing precomputes unchanged', async () => {
+    const plain: Element = {
+      type: 'element',
+      tagName: 'pre',
+      properties: {},
+      children: [{ type: 'text', value: 'plain' }],
+    };
+    const existing: Element = {
+      type: 'element',
+      tagName: 'pre',
+      properties: { dataPrecompute: '{}' },
+      children: [
+        {
+          type: 'element',
+          tagName: 'code',
+          properties: { className: ['language-ts'] },
+          children: [{ type: 'text', value: 'const value = 1;' }],
+        },
+      ],
+    };
+    const tree: Root = { type: 'root', children: [plain, existing] };
+    await transform(tree);
+
+    expect(plain.children).toEqual([{ type: 'text', value: 'plain' }]);
+    expect(existing.properties.dataPrecompute).toBe('{}');
+    expect(textContent(existing)).toBe('const value = 1;');
+  });
+
+  it('highlights HTML fences', async () => {
+    const variant = precomputeOf(
+      await transform(codeBlock('<button type="button">Save</button>', 'html')),
+    ).Default;
+
+    expect(JSON.stringify(variant.source)).toContain('pl-ent');
+    expect(JSON.stringify(variant.source)).toContain('pl-ak');
+  });
+
+  it('highlights inline code with the lite parser', async () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'p',
+          properties: {},
+          children: [
+            {
+              type: 'element',
+              tagName: 'code',
+              properties: { className: ['language-ts'] },
+              children: [{ type: 'text', value: 'string' }],
+            },
+          ],
+        },
+      ],
+    };
+    await transform(tree);
+    const paragraph = tree.children[0] as Element;
+    const code = paragraph.children[0] as Element;
+
+    expect(code.properties.dataInline).toBe('');
+    expect(code.children).toEqual([
+      expect.objectContaining({ properties: { className: ['pl-c1', 'pl-bt'] } }),
+    ]);
+  });
+
+  it('leaves unsupported inline languages unchanged', async () => {
+    const code: Element = {
+      type: 'element',
+      tagName: 'code',
+      properties: { className: ['language-bash'] },
+      children: [{ type: 'text', value: 'pnpm install' }],
+    };
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'p', properties: {}, children: [code] }],
+    };
+    await transform(tree);
+
+    expect(code.children).toEqual([{ type: 'text', value: 'pnpm install' }]);
+    expect(code.properties).not.toHaveProperty('dataInline');
+  });
+
+  it.each([
+    ['ts', 'const value: string = "test";'],
+    ['js', 'function run() { return 42; }'],
+    ['tsx', '<Button disabled />'],
+    ['css', '.root { color: red; }'],
+    ['json', '{ "key": true }'],
+    ['html', '<button disabled>Save</button>'],
+  ])('highlights inline %s while preserving its text', async (language, source) => {
+    const code: Element = {
+      type: 'element',
+      tagName: 'code',
+      properties: { className: [`language-${language}`] },
+      children: [{ type: 'text', value: source }],
+    };
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'p', properties: {}, children: [code] }],
+    };
+    await transform(tree);
+
+    expect(code.properties.dataInline).toBe('');
+    expect(textContent(code)).toBe(source);
+    expect(code.children.some((child) => child.type === 'element')).toBe(true);
+  });
+
+  it('handles whitespace and multiline inline code', async () => {
+    const source = '{\n  foo: string;\n  bar: number;\n}';
+    const code: Element = {
+      type: 'element',
+      tagName: 'code',
+      properties: { className: ['language-ts'] },
+      children: [{ type: 'text', value: source }],
+    };
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'p', properties: {}, children: [code] }],
+    };
+    await transform(tree);
+
+    expect(textContent(code)).toBe(source);
+    expect(code.properties.dataInline).toBe('');
+  });
+});

--- a/packages/docs-infra/src/lite/buildtime/transformHtmlCode.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformHtmlCode.ts
@@ -1,0 +1,166 @@
+import type { Element, Root, RootContent } from 'hast';
+import { visit } from 'unist-util-visit';
+import { parseSource, parseSourceInline, splitFocusFrameRange } from '../shared/syntax/parseSource';
+
+const DEFAULT_FOCUS_FRAMES_MAX_SIZE = 60;
+const RESERVED_DATA_PROPS = new Set([
+  'dataFilename',
+  'dataVariant',
+  'dataTransform',
+  'dataPrecompute',
+  'dataContentProps',
+  'dataName',
+  'dataSlug',
+  'dataDisplayComments',
+]);
+
+export interface TransformHtmlCodeOptions {
+  /** Maximum number of lines retained in an explicit focus frame. @default 60 */
+  focusFramesMaxSize?: number;
+}
+
+function textContent(node: RootContent): string {
+  if (node.type === 'text') {
+    return node.value;
+  }
+  if ('children' in node) {
+    return node.children.map((child) => textContent(child)).join('');
+  }
+  return '';
+}
+
+function languageOf(code: Element): string | undefined {
+  const className = code.properties.className;
+  const classes = Array.isArray(className) ? className : [className];
+  const languageClass = classes.find(
+    (value): value is string => typeof value === 'string' && value.startsWith('language-'),
+  );
+  return languageClass?.slice('language-'.length);
+}
+
+function userPropsOf(code: Element): Record<string, string | boolean> | undefined {
+  const userProps: Record<string, string | boolean> = {};
+  for (const [key, value] of Object.entries(code.properties)) {
+    if (!key.startsWith('data') || key.length <= 4 || RESERVED_DATA_PROPS.has(key)) {
+      continue;
+    }
+    const name = key.charAt(4).toLowerCase() + key.slice(5);
+    if (name === 'collapseToEmpty' || name === 'initialExpanded') {
+      if (value === true || value === 'true' || value === '') {
+        userProps[name] = true;
+      } else if (value === false || value === 'false') {
+        userProps[name] = false;
+      }
+    } else {
+      userProps[name] = String(value);
+    }
+  }
+  return Object.keys(userProps).length > 0 ? userProps : undefined;
+}
+
+function stripJsxExpressionSemicolon(source: string): string {
+  if (source.endsWith('>;\n')) {
+    return source.slice(0, -2);
+  }
+  return source.endsWith('>;') ? source.slice(0, -1) : source;
+}
+
+/** Highlights fenced and inline MDX code with the lite Lezer syntax parser. */
+export function transformHtmlCode(options: TransformHtmlCodeOptions = {}) {
+  const focusFramesMaxSize = Math.max(
+    1,
+    options.focusFramesMaxSize ?? DEFAULT_FOCUS_FRAMES_MAX_SIZE,
+  );
+
+  return (tree: Root): void => {
+    visit(tree, 'element', (pre: Element) => {
+      if (pre.tagName !== 'pre' || pre.properties.dataPrecompute !== undefined) {
+        return;
+      }
+      const code = pre.children.find(
+        (child): child is Element => child.type === 'element' && child.tagName === 'code',
+      );
+      if (!code) {
+        return;
+      }
+
+      const language = languageOf(code);
+      const fileName =
+        typeof code.properties.dataFilename === 'string' ? code.properties.dataFilename : undefined;
+      let source = code.children.map((child) => textContent(child)).join('');
+      if (language === 'jsx' || language === 'tsx') {
+        source = stripJsxExpressionSemicolon(source);
+      }
+
+      const highlighted = parseSource(source, fileName, language, {
+        emphasis: code.properties.dataDisplayComments !== 'true',
+      });
+      const focusRange = highlighted.data.focusRange;
+      const focusEnd = focusRange
+        ? Math.min(focusRange.end, focusRange.start + focusFramesMaxSize - 1)
+        : highlighted.data.totalLines;
+      const focusedLines = focusRange ? focusEnd - focusRange.start + 1 : focusEnd;
+      const collapsible = focusedLines < highlighted.data.totalLines;
+      const framed = focusRange
+        ? splitFocusFrameRange(highlighted, focusRange.start, focusEnd)
+        : highlighted;
+      const precomputedSource = {
+        ...framed,
+        data: { ...framed.data, focusedLines, collapsible },
+      };
+      const variant = {
+        source: precomputedSource,
+        ...(language ? { language } : {}),
+        ...(fileName ? { fileName } : {}),
+        totalLines: highlighted.data.totalLines,
+        focusedLines,
+        collapsible,
+      };
+
+      pre.children = [
+        {
+          type: 'text',
+          value:
+            'Error: expected pre tag with precomputed data to be handled by the CodeHighlighter component',
+        },
+      ];
+      pre.properties.dataPrecompute = JSON.stringify({ Default: variant });
+      if (code.properties.dataName) {
+        pre.properties.dataName = code.properties.dataName;
+      }
+      if (code.properties.dataSlug) {
+        pre.properties.dataSlug = code.properties.dataSlug;
+      }
+      const userProps = userPropsOf(code);
+      if (userProps) {
+        pre.properties.dataContentProps = JSON.stringify(userProps);
+      }
+    });
+
+    visit(tree, 'element', (code: Element, index, parent) => {
+      if (
+        code.tagName !== 'code' ||
+        (parent?.type === 'element' && parent.tagName === 'pre') ||
+        code.children.length === 0
+      ) {
+        return;
+      }
+      const language = languageOf(code);
+      if (!language) {
+        return;
+      }
+      const source = code.children.map((child) => textContent(child)).join('');
+      if (!source) {
+        return;
+      }
+      const highlighted = parseSourceInline(source, language);
+      if (!highlighted) {
+        return;
+      }
+      code.children = highlighted;
+      code.properties.dataInline = '';
+    });
+  };
+}
+
+export default transformHtmlCode;

--- a/packages/docs-infra/src/lite/buildtime/transformMarkdownCode.test.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformMarkdownCode.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import type { Root } from 'mdast';
+import { transformMarkdownCode } from './transformMarkdownCode';
+
+describe('transformMarkdownCode', () => {
+  it('passes fence language and metadata to rehype', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'tsx',
+          meta: 'title="Example" displayComments collapse-to-empty=false',
+          value: 'const value = 1;',
+        },
+      ],
+    };
+    transformMarkdownCode()(tree);
+    const code = tree.children[0];
+
+    expect(code.data?.hProperties).toEqual({
+      className: ['language-tsx'],
+      dataTitle: 'Example',
+      dataDisplayComments: 'true',
+      dataCollapseToEmpty: 'false',
+    });
+  });
+
+  it('adds the default inline language and preserves existing classes', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'inlineCode',
+              value: 'string',
+              data: { hProperties: { className: ['existing'] } },
+            },
+          ],
+        },
+      ],
+    };
+    transformMarkdownCode()(tree);
+    const paragraph = tree.children[0];
+    const code = paragraph.type === 'paragraph' ? paragraph.children[0] : undefined;
+
+    expect(code?.data?.hProperties).toEqual({ className: ['existing', 'language-tsx'] });
+  });
+
+  it('uses and strips an explicit inline language suffix', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'inlineCode', value: 'color{:css}' }] }],
+    };
+    transformMarkdownCode({ defaultInlineCodeLanguage: false })(tree);
+    const paragraph = tree.children[0];
+    const code = paragraph.type === 'paragraph' ? paragraph.children[0] : undefined;
+
+    expect(code).toMatchObject({
+      value: 'color',
+      data: { hProperties: { className: ['language-css'] } },
+    });
+  });
+
+  it('leaves bare inline code untyped when the default is disabled', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'inlineCode', value: 'value' }] }],
+    };
+    transformMarkdownCode({ defaultInlineCodeLanguage: false })(tree);
+    const paragraph = tree.children[0];
+    const code = paragraph.type === 'paragraph' ? paragraph.children[0] : undefined;
+
+    expect(code?.data).toBeUndefined();
+  });
+
+  it('applies a custom default to every inline code node', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'inlineCode', value: 'first' },
+            { type: 'text', value: ' and ' },
+            { type: 'inlineCode', value: 'second' },
+          ],
+        },
+      ],
+    };
+    transformMarkdownCode({ defaultInlineCodeLanguage: 'ts' })(tree);
+    const paragraph = tree.children[0];
+
+    expect(paragraph.type === 'paragraph' ? paragraph.children : []).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ data: { hProperties: { className: ['language-ts'] } } }),
+        expect.objectContaining({ data: { hProperties: { className: ['language-ts'] } } }),
+      ]),
+    );
+  });
+
+  it.each([
+    ['<Component />{:jsx}', '<Component />', 'jsx'],
+    ['const value: number = 1{:ts}', 'const value: number = 1', 'ts'],
+    ['.root { color: red }{:css}', '.root { color: red }', 'css'],
+    ['npm install{:sh}', 'npm install', 'sh'],
+    ['{ key: value }{:js}', '{ key: value }', 'js'],
+  ])('parses the inline suffix in %s', (value, expectedValue, language) => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'inlineCode', value }] }],
+    };
+    transformMarkdownCode()(tree);
+    const paragraph = tree.children[0];
+    const code = paragraph.type === 'paragraph' ? paragraph.children[0] : undefined;
+
+    expect(code).toMatchObject({
+      value: expectedValue,
+      data: { hProperties: { className: [`language-${language}`] } },
+    });
+  });
+
+  it('preserves invalid inline suffixes and applies the default language', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'inlineCode', value: 'code{:}' }] }],
+    };
+    transformMarkdownCode()(tree);
+    const paragraph = tree.children[0];
+    const code = paragraph.type === 'paragraph' ? paragraph.children[0] : undefined;
+
+    expect(code).toMatchObject({
+      value: 'code{:}',
+      data: { hProperties: { className: ['language-tsx'] } },
+    });
+  });
+
+  it('does not parse inline suffix syntax inside fenced code', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'code', lang: 'js', value: 'const value = 1{:ts}' }],
+    };
+    transformMarkdownCode()(tree);
+
+    expect(tree.children[0]).toMatchObject({
+      value: 'const value = 1{:ts}',
+      data: { hProperties: { className: ['language-js'] } },
+    });
+  });
+
+  it('ignores invalid standalone fence metadata', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [
+        { type: 'code', lang: 'tsx', meta: 'title="Example" {2}', value: 'const value = 1;' },
+      ],
+    };
+    transformMarkdownCode()(tree);
+
+    expect(tree.children[0].data?.hProperties).toEqual({
+      className: ['language-tsx'],
+      dataTitle: 'Example',
+    });
+  });
+});

--- a/packages/docs-infra/src/lite/buildtime/transformMarkdownCode.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformMarkdownCode.ts
@@ -1,0 +1,85 @@
+import type { Code, InlineCode, Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+const INLINE_LANGUAGE_SUFFIX = /^([\s\S]+)\{:(\w+)\}$/;
+const META_KEY_VALUE = /([A-Za-z][\w-]*)=("(?:[^"\\]|\\.)*"|[^\s]+)/g;
+const META_FLAG = /^[A-Za-z][\w-]*$/;
+
+export interface TransformMarkdownCodeOptions {
+  /** Language assigned to inline code without an explicit `{:language}` suffix. @default 'tsx' */
+  defaultInlineCodeLanguage?: string | false;
+}
+
+function addLanguageClass(node: Code | InlineCode, language: string): void {
+  node.data ??= {};
+  node.data.hProperties ??= {};
+  const properties = node.data.hProperties as Record<string, unknown>;
+  let existing: string[] = [];
+  if (Array.isArray(properties.className)) {
+    existing = properties.className.filter((value): value is string => typeof value === 'string');
+  } else if (typeof properties.className === 'string') {
+    existing = [properties.className];
+  }
+  const languageClass = `language-${language}`;
+  properties.className = existing.includes(languageClass) ? existing : [...existing, languageClass];
+}
+
+function dataProperty(key: string): string {
+  return `data${key
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')}`;
+}
+
+function addMetadata(node: Code): void {
+  if (!node.meta) {
+    return;
+  }
+  node.data ??= {};
+  node.data.hProperties ??= {};
+  const properties = node.data.hProperties as Record<string, unknown>;
+  const consumed: Array<{ start: number; end: number }> = [];
+  let match = META_KEY_VALUE.exec(node.meta);
+  while (match) {
+    const [, key, rawValue] = match;
+    const value = rawValue.startsWith('"') ? rawValue.slice(1, -1) : rawValue;
+    properties[dataProperty(key)] = value;
+    consumed.push({ start: match.index, end: match.index + match[0].length });
+    match = META_KEY_VALUE.exec(node.meta);
+  }
+
+  let remaining = node.meta;
+  for (const range of consumed.reverse()) {
+    remaining = remaining.slice(0, range.start) + remaining.slice(range.end);
+  }
+  for (const flag of remaining.split(/\s+/)) {
+    if (META_FLAG.test(flag)) {
+      properties[dataProperty(flag)] = 'true';
+    }
+  }
+}
+
+/** Passes MDX code languages and fence metadata to the lite rehype highlighter. */
+export function transformMarkdownCode(options: TransformMarkdownCodeOptions = {}) {
+  const defaultInlineCodeLanguage = options.defaultInlineCodeLanguage ?? 'tsx';
+  return (tree: Root): void => {
+    visit(tree, 'code', (node: Code) => {
+      if (node.lang) {
+        addLanguageClass(node, node.lang);
+      }
+      addMetadata(node);
+    });
+
+    visit(tree, 'inlineCode', (node: InlineCode) => {
+      const explicit = INLINE_LANGUAGE_SUFFIX.exec(node.value);
+      if (explicit) {
+        node.value = explicit[1];
+        addLanguageClass(node, explicit[2]);
+      } else if (defaultInlineCodeLanguage !== false) {
+        addLanguageClass(node, defaultInlineCodeLanguage);
+      }
+    });
+  };
+}
+
+export default transformMarkdownCode;

--- a/packages/docs-infra/src/lite/buildtime/transformMarkdownDemos.test.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformMarkdownDemos.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkMdx from 'remark-mdx';
+import type { Root } from 'mdast';
+import transformMarkdownDemosPlugin from './transformMarkdownDemos';
+import type { TransformMarkdownDemosOptions } from './transformMarkdownDemos';
+
+interface MdxAttribute {
+  name?: string;
+}
+
+interface MdxNode {
+  type: string;
+  name?: string | null;
+  attributes?: MdxAttribute[];
+  children?: MdxNode[];
+}
+
+function transform(mdx: string, options?: TransformMarkdownDemosOptions): Root {
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkMdx)
+    .use(transformMarkdownDemosPlugin, options);
+  return processor.runSync(processor.parse(mdx)) as Root;
+}
+
+function jsxElements(tree: Root): Array<[string | null, boolean]> {
+  const elements: Array<[string | null, boolean]> = [];
+  const visit = (node: MdxNode) => {
+    if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+      elements.push([
+        node.name ?? null,
+        (node.attributes ?? []).some((attribute) => attribute.name === 'preloadSources'),
+      ]);
+    }
+    for (const child of node.children ?? []) {
+      visit(child);
+    }
+  };
+  visit(tree as unknown as MdxNode);
+  return elements;
+}
+
+describe('transformMarkdownDemos', () => {
+  it('marks the first N imported demo components in document order', () => {
+    const tree = transform(
+      [
+        "import { AlphaDemo } from './demos/alpha';",
+        "import { BetaDemo } from './demos/beta';",
+        "import { Callout } from '../components/Callout';",
+        '',
+        '<Callout><AlphaDemo /></Callout>',
+        '',
+        '<BetaDemo />',
+      ].join('\n'),
+      { preloadSources: 1 },
+    );
+    expect(jsxElements(tree)).toEqual([
+      ['Callout', false],
+      ['AlphaDemo', true],
+      ['BetaDemo', false],
+    ]);
+  });
+
+  it('supports default imports and does not duplicate the attribute', () => {
+    const tree = transform(
+      ["import AlphaDemo from './demos/alpha';", '', '<AlphaDemo preloadSources />'].join('\n'),
+      { preloadSources: 2 },
+    );
+    expect(jsxElements(tree)).toEqual([['AlphaDemo', true]]);
+    const demo = (tree.children as unknown as MdxNode[]).find(
+      (node) => node.type === 'mdxJsxFlowElement',
+    );
+    expect(
+      demo?.attributes?.filter((attribute) => attribute.name === 'preloadSources'),
+    ).toHaveLength(1);
+  });
+
+  it('leaves the tree untouched when preloading is disabled', () => {
+    const mdx = ["import { AlphaDemo } from './demos/alpha';", '', '<AlphaDemo />'].join('\n');
+    expect(jsxElements(transform(mdx))).toEqual([['AlphaDemo', false]]);
+    expect(jsxElements(transform(mdx, { preloadSources: 0 }))).toEqual([['AlphaDemo', false]]);
+  });
+});

--- a/packages/docs-infra/src/lite/buildtime/transformMarkdownDemos.ts
+++ b/packages/docs-infra/src/lite/buildtime/transformMarkdownDemos.ts
@@ -1,0 +1,96 @@
+import type { Plugin } from 'unified';
+import type { Root } from 'mdast';
+
+export interface TransformMarkdownDemosOptions {
+  /** Number of demos per page whose deferred sources should be preloaded. */
+  preloadSources?: number;
+}
+
+const DEMO_IMPORT_PATTERN = /(^|\/)demos\/[^/]+$/;
+
+interface JsxAttribute {
+  type: string;
+  name?: string;
+  value?: unknown;
+}
+
+interface JsxElementNode {
+  type: string;
+  name?: string | null;
+  attributes?: JsxAttribute[];
+  children?: JsxElementNode[];
+  data?: {
+    estree?: {
+      body?: Array<{
+        type: string;
+        source?: { value?: unknown };
+        specifiers?: Array<{ local?: { name?: string } }>;
+      }>;
+    };
+  };
+}
+
+function collectDemoImportNames(tree: Root): Set<string> {
+  const names = new Set<string>();
+  for (const node of tree.children as unknown as JsxElementNode[]) {
+    if (node.type !== 'mdxjsEsm') {
+      continue;
+    }
+    for (const statement of node.data?.estree?.body ?? []) {
+      if (
+        statement.type !== 'ImportDeclaration' ||
+        !DEMO_IMPORT_PATTERN.test(String(statement.source?.value ?? ''))
+      ) {
+        continue;
+      }
+      for (const specifier of statement.specifiers ?? []) {
+        if (specifier.local?.name) {
+          names.add(specifier.local.name);
+        }
+      }
+    }
+  }
+  return names;
+}
+
+function visitJsxElements(
+  node: JsxElementNode,
+  onElement: (element: JsxElementNode) => void,
+): void {
+  if (node.type === 'mdxJsxFlowElement' || node.type === 'mdxJsxTextElement') {
+    onElement(node);
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      visitJsxElements(child, onElement);
+    }
+  }
+}
+
+/** Marks the first N imported demo elements with `preloadSources`. */
+const transformMarkdownDemos: Plugin<[TransformMarkdownDemosOptions?], Root> = (options = {}) => {
+  const { preloadSources = 0 } = options;
+  return function transform(tree) {
+    if (preloadSources <= 0) {
+      return;
+    }
+    const demoNames = collectDemoImportNames(tree);
+    if (demoNames.size === 0) {
+      return;
+    }
+    let remaining = preloadSources;
+    visitJsxElements(tree as unknown as JsxElementNode, (element) => {
+      if (remaining <= 0 || !element.name || !demoNames.has(element.name)) {
+        return;
+      }
+      remaining -= 1;
+      const attributes = element.attributes ?? (element.attributes = []);
+      if (attributes.some((attribute) => attribute.name === 'preloadSources')) {
+        return;
+      }
+      attributes.push({ type: 'mdxJsxAttribute', name: 'preloadSources', value: null });
+    });
+  };
+};
+
+export default transformMarkdownDemos;

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
@@ -105,6 +105,13 @@ function precomputeOf(output: string): LoaderPrecompute {
   return JSON.parse(output.slice(start + marker.length, end)) as LoaderPrecompute;
 }
 
+function focusFrameLines(html: string): number {
+  const focusStart = html.indexOf('data-frame-type="focus"');
+  const nextFrame = html.indexOf('<span class="frame"', focusStart);
+  const focusFrame = html.slice(focusStart, nextFrame === -1 ? undefined : nextFrame);
+  return focusFrame.match(/class="line"/g)?.length ?? 0;
+}
+
 const BUTTON_SOURCE = [
   "import * as React from 'react';",
   '',
@@ -402,6 +409,40 @@ describe('loadDemo', () => {
   });
 
   describe('focus windows', () => {
+    it('focuses at most 10 lines by default', async () => {
+      const root = await writeFixture({
+        'app/section/demos/default-focus/index.ts': DEMO_INDEX,
+        'app/section/demos/default-focus/Button.tsx': [
+          'export default function Button() {',
+          ...Array.from({ length: 8 }, (unused, index) => `  const value${index} = ${index};`),
+          '  return null;',
+          '}',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/default-focus/index.ts');
+      const { output } = await runLoader(root, entry);
+
+      expect(focusFrameLines(precomputeOf(output).variants.Default.html)).toBe(10);
+    });
+
+    it('supports a custom focusFramesMaxSize', async () => {
+      const root = await writeFixture({
+        'app/section/demos/custom-focus/index.ts': DEMO_INDEX,
+        'app/section/demos/custom-focus/Button.tsx': [
+          'export default function Button() {',
+          ...Array.from({ length: 8 }, (unused, index) => `  const value${index} = ${index};`),
+          '  return null;',
+          '}',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/custom-focus/index.ts');
+      const { output } = await runLoader(root, entry, {
+        emphasisOptions: { focusFramesMaxSize: 6 },
+      });
+
+      expect(focusFrameLines(precomputeOf(output).variants.Default.html)).toBe(6);
+    });
+
     it('splits the collapsed panel window around @focus comments', async () => {
       const root = await writeFixture({
         'app/section/demos/focused/index.ts': DEMO_INDEX,
@@ -421,6 +462,26 @@ describe('loadDemo', () => {
       const variant = precomputeOf(output).variants.Default;
       expect(variant.html).toContain('data-frame-type="focus"');
       expect(variant.html).not.toContain('@focus');
+    });
+
+    it('limits an explicit focus range to focusFramesMaxSize', async () => {
+      const root = await writeFixture({
+        'app/section/demos/focused-limit/index.ts': DEMO_INDEX,
+        'app/section/demos/focused-limit/Button.tsx': [
+          'export default function Button() {',
+          '  // @focus-start',
+          ...Array.from({ length: 8 }, (unused, index) => `  const value${index} = ${index};`),
+          '  // @focus-end',
+          '  return null;',
+          '}',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/focused-limit/index.ts');
+      const { output } = await runLoader(root, entry, {
+        emphasisOptions: { focusFramesMaxSize: 6 },
+      });
+
+      expect(focusFrameLines(precomputeOf(output).variants.Default.html)).toBe(6);
     });
   });
 

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
@@ -483,6 +483,31 @@ describe('loadDemo', () => {
 
       expect(focusFrameLines(precomputeOf(output).variants.Default.html)).toBe(6);
     });
+
+    it('keeps an explicit focus range below the initial SSR window', async () => {
+      const root = await writeFixture({
+        'app/section/demos/focused-late/index.ts': DEMO_INDEX,
+        'app/section/demos/focused-late/Button.tsx': [
+          'export default function Button() {',
+          ...Array.from({ length: 14 }, (unused, index) => `  const value${index} = ${index};`),
+          '  // @focus-start',
+          '  const focused = true;',
+          '  // @focus-end',
+          '  return focused;',
+          '}',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/focused-late/index.ts');
+      const { output } = await runLoader(root, entry, {
+        assetDir: 'assets',
+        urlPrefix: '/assets/',
+      });
+
+      const variant = precomputeOf(output).variants.Default;
+      expect(variant.html).toContain('data-frame-type="focus"');
+      expect(variant.html).toContain('focused');
+      expect(variant.html).not.toContain('value0');
+    });
   });
 
   describe('deferred sources', () => {

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
@@ -1,0 +1,643 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { loadDemo } from './demoLoader';
+import type { DemoLoaderContext, LoadDemoOptions } from './demoLoader';
+
+/** Writes fixture files into a fresh temp directory and returns its root. */
+async function writeFixture(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'load-demo-test-'));
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, content]) => {
+      const filePath = path.join(root, relativePath);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, content);
+    }),
+  );
+  return root;
+}
+
+interface LoaderRun {
+  output: string;
+  dependencies: string[];
+}
+
+interface LoaderVariant {
+  fileName: string;
+  exportName: string;
+  language: string;
+  totalLines: number;
+  html: string;
+  extraFiles?: Record<string, { language: string; totalLines: number }>;
+}
+
+interface LoaderPrecompute {
+  variants: Record<string, LoaderVariant>;
+  deferredUrl?: string;
+}
+
+// Emulates the bundler's resolver over the fixture filesystem.
+const RESOLVE_SUFFIXES = ['', '.tsx', '.ts', '.jsx', '.js', '/index.tsx', '/index.ts'];
+async function resolveRequest(context: string, request: string): Promise<string> {
+  const base = path.resolve(context, request);
+  const candidates = await Promise.all(
+    RESOLVE_SUFFIXES.map(async (suffix) => {
+      const candidate = base + suffix;
+      try {
+        return (await fs.stat(candidate)).isFile() ? candidate : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  const found = candidates.find((candidate): candidate is string => candidate !== null);
+  if (!found) {
+    throw new Error(`cannot resolve "${request}" from "${context}"`);
+  }
+  return found;
+}
+
+/** Invokes the loader with a minimal webpack-style loader context. */
+async function runLoader(
+  rootContext: string,
+  resourcePath: string,
+  options: LoadDemoOptions = {},
+  emitFile?: (name: string, content: string) => void,
+  compilerContext: Pick<DemoLoaderContext, 'mode' | '_compiler'> = {},
+): Promise<LoaderRun> {
+  const source = await fs.readFile(resourcePath, 'utf8');
+  const dependencies: string[] = [];
+  return new Promise((resolve, reject) => {
+    const context: DemoLoaderContext = {
+      resourcePath,
+      rootContext,
+      cacheable() {},
+      addDependency(file) {
+        dependencies.push(file);
+      },
+      emitFile,
+      ...compilerContext,
+      getOptions: () => options,
+      getResolve: () => resolveRequest,
+      async() {
+        return (error, output) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve({ output: output ?? '', dependencies });
+          }
+        };
+      },
+    };
+    loadDemo.call(context, source);
+  });
+}
+
+/** Extracts the parsed `__docsInfraPrecompute` payload appended by the loader. */
+function precomputeOf(output: string): LoaderPrecompute {
+  const marker = '__docsInfraPrecompute: ';
+  const start = output.lastIndexOf(marker);
+  if (start === -1) {
+    throw new Error('no precompute assignment found in loader output');
+  }
+  const end = output.lastIndexOf(' });');
+  return JSON.parse(output.slice(start + marker.length, end)) as LoaderPrecompute;
+}
+
+const BUTTON_SOURCE = [
+  "import * as React from 'react';",
+  '',
+  'export default function Button() {',
+  '  return <button type="button">Click</button>;',
+  '}',
+  '',
+].join('\n');
+
+const DEMO_INDEX = [
+  "import { createDemo } from '../createDemo';",
+  "import Button from './Button';",
+  '',
+  'export const ButtonDemo = createDemo(import.meta.url, Button);',
+  '',
+].join('\n');
+
+describe('loadDemo', () => {
+  describe('module recognition', () => {
+    it('passes through modules without a createDemo call unchanged', async () => {
+      const root = await writeFixture({
+        'app/section/demos/basic/index.ts': [
+          "import { createDemoPerformance } from '../wrappers';",
+          "import Page from './page';",
+          '',
+          'export const Perf = createDemoPerformance(import.meta.url, Page);',
+          '',
+        ].join('\n'),
+        'app/section/demos/basic/page.tsx': BUTTON_SOURCE,
+      });
+      const entry = path.join(root, 'app/section/demos/basic/index.ts');
+      const { output, dependencies } = await runLoader(root, entry);
+      expect(output).toBe(await fs.readFile(entry, 'utf8'));
+      expect(dependencies).toEqual([]);
+    });
+
+    it('rejects when a variant import does not resolve to a file', async () => {
+      const root = await writeFixture({
+        'app/section/demos/broken/index.ts': [
+          "import { createDemo } from '../createDemo';",
+          "import Missing from './Missing';",
+          '',
+          'export const BrokenDemo = createDemo(import.meta.url, Missing);',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/broken/index.ts');
+      await expect(runLoader(root, entry)).rejects.toThrow('Default');
+    });
+  });
+
+  describe('single-component demos', () => {
+    it('appends a precompute assignment for the demo export', async () => {
+      const root = await writeFixture({
+        'app/section/demos/basic/index.ts': DEMO_INDEX,
+        'app/section/demos/basic/Button.tsx': BUTTON_SOURCE,
+      });
+      const entry = path.join(root, 'app/section/demos/basic/index.ts');
+      const { output, dependencies } = await runLoader(root, entry);
+
+      expect(output.startsWith(DEMO_INDEX)).toBe(true);
+      expect(output).toContain('Object.assign(ButtonDemo, { __docsInfraPrecompute:');
+      expect(dependencies).toContain(path.join(root, 'app/section/demos/basic/Button.tsx'));
+
+      const precompute = precomputeOf(output);
+      const variant = precompute.variants.Default;
+      expect(variant.fileName).toBe('Button.tsx');
+      expect(variant.exportName).toBe('default');
+      expect(variant.language).toBe('tsx');
+      expect(variant.totalLines).toBe(5);
+      expect(variant.html).toContain('class="frame"');
+      expect(variant.html).toContain('Click');
+      expect(precompute.deferredUrl).toBeUndefined();
+    });
+
+    it('collects relative imports as extra files, flattening their display paths', async () => {
+      const root = await writeFixture({
+        'app/section/demos/extra/index.ts': DEMO_INDEX,
+        'app/section/demos/extra/Button.tsx': [
+          "import { helper } from './helper';",
+          "import '../../shared/_theme.css';",
+          '',
+          'export default function Button() {',
+          '  return <button type="button">{helper()}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/extra/helper.ts': "export const helper = () => 'ok';\n",
+        'app/section/shared/_theme.css': '.demo { color: red; }\n',
+      });
+      const entry = path.join(root, 'app/section/demos/extra/index.ts');
+      const { output, dependencies } = await runLoader(root, entry);
+
+      const variant = precomputeOf(output).variants.Default;
+      expect(Object.keys(variant.extraFiles ?? {})).toEqual(['helper.ts', 'theme.css']);
+      expect(variant.html).toContain('./theme.css');
+      expect(variant.html).not.toContain('_theme.css');
+      expect(dependencies).toContain(path.join(root, 'app/section/shared/_theme.css'));
+    });
+
+    it('rewrites directory imports to the resolved index file display name', async () => {
+      const root = await writeFixture({
+        'app/section/demos/directory/index.ts': DEMO_INDEX,
+        'app/section/demos/directory/Button.tsx': [
+          "import { label } from './parts';",
+          '',
+          'export default function Button() {',
+          '  return <button type="button">{label}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/directory/parts/index.tsx': "export const label = 'Click';\n",
+      });
+      const entry = path.join(root, 'app/section/demos/directory/index.ts');
+      const { output } = await runLoader(root, entry);
+
+      const variant = precomputeOf(output).variants.Default;
+      expect(Object.keys(variant.extraFiles ?? {})).toEqual(['index.tsx']);
+      expect(variant.html).toContain('./index.tsx');
+      expect(variant.html).not.toContain('./parts');
+    });
+
+    it('keeps imported index files distinct from an index entry file', async () => {
+      const root = await writeFixture({
+        'app/section/demos/directory-entry/index.ts': [
+          "import { createDemo } from '../createDemo';",
+          "import Demo from './variant';",
+          '',
+          'export const DirectoryDemo = createDemo(import.meta.url, Demo);',
+          '',
+        ].join('\n'),
+        'app/section/demos/directory-entry/variant/index.tsx': [
+          "import { label } from '../parts';",
+          '',
+          'export default function Demo() {',
+          '  return <button type="button">{label}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/directory-entry/parts/index.tsx': "export const label = 'Click';\n",
+      });
+      const entry = path.join(root, 'app/section/demos/directory-entry/index.ts');
+      const { output } = await runLoader(root, entry);
+
+      const variant = precomputeOf(output).variants.Default;
+      expect(variant.fileName).toBe('index.tsx');
+      expect(Object.keys(variant.extraFiles ?? {})).toEqual(['parts/index.tsx']);
+      expect(variant.html).toContain('./parts/index.tsx');
+    });
+
+    it('renames colliding extra file names by their parent directory', async () => {
+      const root = await writeFixture({
+        'app/section/demos/collide/index.ts': DEMO_INDEX,
+        'app/section/demos/collide/Button.tsx': [
+          "import { first } from './helper';",
+          "import { second } from '../../shared/helper';",
+          '',
+          'export default function Button() {',
+          '  return <button type="button">{first()}{second()}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/collide/helper.ts': 'export const first = () => 1;\n',
+        'app/section/shared/helper.ts': 'export const second = () => 2;\n',
+      });
+      const entry = path.join(root, 'app/section/demos/collide/index.ts');
+      const { output } = await runLoader(root, entry);
+      const variant = precomputeOf(output).variants.Default;
+      expect(Object.keys(variant.extraFiles ?? {})).toEqual(['helper.ts', 'shared/helper.ts']);
+    });
+
+    it('rewrites colliding index imports to their final display names', async () => {
+      const root = await writeFixture({
+        'app/section/demos/indexes/index.ts': DEMO_INDEX,
+        'app/section/demos/indexes/Button.tsx': [
+          "import { first } from './first';",
+          "import { second } from './second';",
+          '',
+          'export default function Button() {',
+          '  return <button type="button">{first}{second}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/indexes/first/index.tsx': "export const first = 'First';\n",
+        'app/section/demos/indexes/second/index.tsx': "export const second = 'Second';\n",
+      });
+      const entry = path.join(root, 'app/section/demos/indexes/index.ts');
+      const { output } = await runLoader(root, entry);
+
+      const variant = precomputeOf(output).variants.Default;
+      expect(Object.keys(variant.extraFiles ?? {})).toEqual(['index.tsx', 'second/index.tsx']);
+      expect(variant.html).toContain('./index.tsx');
+      expect(variant.html).toContain('./second/index.tsx');
+      expect(variant.html).not.toContain('./first');
+    });
+
+    it('stops collecting imports beyond the depth limit', async () => {
+      const root = await writeFixture({
+        'app/section/demos/deep/index.ts': DEMO_INDEX,
+        'app/section/demos/deep/Button.tsx': [
+          "import { a } from './a';",
+          '',
+          'export default function Button() {',
+          '  return <button type="button">{a()}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/deep/a.ts': "import { b } from './b';\n\nexport const a = () => b();\n",
+        'app/section/demos/deep/b.ts': "import { c } from './c';\n\nexport const b = () => c();\n",
+        'app/section/demos/deep/c.ts': "import { d } from './d';\n\nexport const c = () => d();\n",
+        'app/section/demos/deep/d.ts': 'export const d = () => 4;\n',
+      });
+      const entry = path.join(root, 'app/section/demos/deep/index.ts');
+      const { output } = await runLoader(root, entry);
+      const variant = precomputeOf(output).variants.Default;
+      expect(Object.keys(variant.extraFiles ?? {})).toEqual(['a.ts', 'b.ts', 'c.ts']);
+    });
+  });
+
+  describe('single-component demos with named imports', () => {
+    it('resolves a named-imported component to its module', async () => {
+      const root = await writeFixture({
+        'app/section/demos/named/index.ts': [
+          "import { createDemo } from '../createDemo';",
+          "import { Button } from './Button';",
+          '',
+          'export const ButtonDemo = createDemo(import.meta.url, Button);',
+          '',
+        ].join('\n'),
+        'app/section/demos/named/Button.tsx': [
+          "import * as React from 'react';",
+          '',
+          'export function Button() {',
+          '  return <button type="button">Click</button>;',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/named/index.ts');
+      const { output } = await runLoader(root, entry);
+      const variant = precomputeOf(output).variants.Default;
+      expect(variant.fileName).toBe('Button.tsx');
+      expect(variant.exportName).toBe('Button');
+      expect(variant.html).toContain('Click');
+    });
+
+    it('records the original export name of an aliased named import', async () => {
+      const root = await writeFixture({
+        'app/section/demos/aliased/index.ts': [
+          "import { createDemo } from '../createDemo';",
+          "import { Button as BaseButton } from './Button';",
+          '',
+          'export const ButtonDemo = createDemo(import.meta.url, BaseButton);',
+          '',
+        ].join('\n'),
+        'app/section/demos/aliased/Button.tsx': [
+          "import * as React from 'react';",
+          '',
+          'export function Button() {',
+          '  return <button type="button">Click</button>;',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/aliased/index.ts');
+      const { output } = await runLoader(root, entry);
+      expect(precomputeOf(output).variants.Default.exportName).toBe('Button');
+    });
+  });
+
+  describe('variant demos', () => {
+    it('loads each variant of createDemoWithVariants, supporting shorthand and renamed keys', async () => {
+      const root = await writeFixture({
+        'app/section/demos/variants/index.ts': [
+          "import { createDemoWithVariants } from '../createDemo';",
+          "import Css from './css/index';",
+          "import TailwindImpl from './tailwind/index';",
+          '',
+          'export const VariantsDemo = createDemoWithVariants(import.meta.url, {',
+          '  Css,',
+          '  Tailwind: TailwindImpl,',
+          '});',
+          '',
+        ].join('\n'),
+        'app/section/demos/variants/css/index.tsx': BUTTON_SOURCE,
+        'app/section/demos/variants/tailwind/index.tsx': BUTTON_SOURCE,
+      });
+      const entry = path.join(root, 'app/section/demos/variants/index.ts');
+      const { output } = await runLoader(root, entry);
+      const { variants } = precomputeOf(output);
+      expect(Object.keys(variants)).toEqual(['Css', 'Tailwind']);
+      expect(variants.Css.fileName).toBe('index.tsx');
+      expect(variants.Tailwind.html).toContain('Click');
+    });
+  });
+
+  describe('focus windows', () => {
+    it('splits the collapsed panel window around @focus comments', async () => {
+      const root = await writeFixture({
+        'app/section/demos/focused/index.ts': DEMO_INDEX,
+        'app/section/demos/focused/Button.tsx': [
+          "import * as React from 'react';",
+          '',
+          'export default function Button() {',
+          '  // @focus-start',
+          '  return <button type="button">Click</button>;',
+          '  // @focus-end',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/focused/index.ts');
+      const { output } = await runLoader(root, entry);
+      const variant = precomputeOf(output).variants.Default;
+      expect(variant.html).toContain('data-frame-type="focus"');
+      expect(variant.html).not.toContain('@focus');
+    });
+  });
+
+  describe('deferred sources', () => {
+    it('truncates long sources in the precompute and emits the full html as a JSON asset', async () => {
+      const longBody = Array.from(
+        { length: 20 },
+        (unused, index) => `  const v${index} = ${index};`,
+      );
+      const root = await writeFixture({
+        'app/section/demos/long/index.ts': DEMO_INDEX,
+        'app/section/demos/long/Button.tsx': [
+          'export default function Button() {',
+          ...longBody,
+          '  return null;',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/long/index.ts');
+      const { output } = await runLoader(root, entry, {
+        assetDir: 'assets',
+        urlPrefix: '/assets/',
+      });
+
+      const precompute = precomputeOf(output);
+      expect(precompute.deferredUrl).toMatch(/^\/assets\/section-long\.[0-9a-f]{8}\.json$/);
+      expect(precompute.variants.Default.html).toContain('v0');
+      expect(precompute.variants.Default.html).not.toContain('v19');
+
+      const assetPath = path.join(root, 'assets', path.basename(precompute.deferredUrl ?? ''));
+      const deferred = JSON.parse(await fs.readFile(assetPath, 'utf8')) as Record<
+        string,
+        { source?: string; extraFiles?: Record<string, string> }
+      >;
+      expect(deferred.Default.source).toContain('v19');
+    });
+
+    it('defers extra file sources while keeping their metadata inline', async () => {
+      const root = await writeFixture({
+        'app/section/demos/meta/index.ts': DEMO_INDEX,
+        'app/section/demos/meta/Button.tsx': [
+          "import { helper } from './helper';",
+          '',
+          'export default function Button() {',
+          '  return <button type="button">{helper()}</button>;',
+          '}',
+          '',
+        ].join('\n'),
+        'app/section/demos/meta/helper.ts': "export const helper = () => 'ok';\n",
+      });
+      const entry = path.join(root, 'app/section/demos/meta/index.ts');
+      const { output } = await runLoader(root, entry, {
+        assetDir: 'assets',
+        urlPrefix: '/assets/',
+      });
+
+      const precompute = precomputeOf(output);
+      const variant = precompute.variants.Default;
+      expect(variant.extraFiles?.['helper.ts'].language).toBe('ts');
+      expect(variant.extraFiles?.['helper.ts']).not.toHaveProperty('html');
+
+      const assetPath = path.join(root, 'assets', path.basename(precompute.deferredUrl ?? ''));
+      const deferred = JSON.parse(await fs.readFile(assetPath, 'utf8')) as Record<
+        string,
+        { source?: string; extraFiles?: Record<string, string> }
+      >;
+      expect(deferred.Default.extraFiles?.['helper.ts']).toContain('helper');
+    });
+
+    it('emits the JSON through emitFile when the loader context provides it', async () => {
+      const longBody = Array.from(
+        { length: 20 },
+        (unused, index) => `  const v${index} = ${index};`,
+      );
+      const root = await writeFixture({
+        'app/section/demos/emitted/index.ts': DEMO_INDEX,
+        'app/section/demos/emitted/Button.tsx': [
+          'export default function Button() {',
+          ...longBody,
+          '  return null;',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/emitted/index.ts');
+      const emitted: Array<{ name: string; content: string }> = [];
+      const { output } = await runLoader(
+        root,
+        entry,
+        {},
+        (name, content) => {
+          emitted.push({ name, content });
+        },
+        { _compiler: { name: 'client' } },
+      );
+
+      const precompute = precomputeOf(output);
+      expect(precompute.deferredUrl).toMatch(
+        /^\/_next\/static\/demo-sources\/section-emitted\.[0-9a-f]{8}\.json$/,
+      );
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].name).toBe(
+        `static/demo-sources/${path.basename(precompute.deferredUrl ?? '')}`,
+      );
+      const deferred = JSON.parse(emitted[0].content) as Record<string, { source?: string }>;
+      expect(deferred.Default.source).toContain('v19');
+      await expect(fs.access(path.join(root, 'public'))).rejects.toThrow();
+    });
+
+    it('honors emitDir and urlPrefix overrides when emitting', async () => {
+      const longBody = Array.from(
+        { length: 20 },
+        (unused, index) => `  const v${index} = ${index};`,
+      );
+      const root = await writeFixture({
+        'app/section/demos/server/index.ts': DEMO_INDEX,
+        'app/section/demos/server/Button.tsx': [
+          'export default function Button() {',
+          ...longBody,
+          '  return null;',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/server/index.ts');
+      const emitted: string[] = [];
+      const { output } = await runLoader(
+        root,
+        entry,
+        { emitDir: '../static/demo-sources', urlPrefix: '/assets/' },
+        (name) => {
+          emitted.push(name);
+        },
+        { _compiler: { name: 'server' } },
+      );
+
+      const precompute = precomputeOf(output);
+      expect(precompute.deferredUrl).toMatch(/^\/assets\/section-server\.[0-9a-f]{8}\.json$/);
+      expect(emitted).toEqual([
+        `../static/demo-sources/${path.basename(precompute.deferredUrl ?? '')}`,
+      ]);
+    });
+
+    it('derives the emit dir from the compiler so assets land in <distDir>/static', async () => {
+      const longBody = Array.from(
+        { length: 20 },
+        (unused, index) => `  const v${index} = ${index};`,
+      );
+      const files = {
+        'app/section/demos/layered/index.ts': DEMO_INDEX,
+        'app/section/demos/layered/Button.tsx': [
+          'export default function Button() {',
+          ...longBody,
+          '  return null;',
+          '}',
+          '',
+        ].join('\n'),
+      };
+      const cases = [
+        { compiler: 'server', mode: 'production', expected: '../../static/demo-sources' },
+        { compiler: 'server', mode: 'development', expected: '../static/demo-sources' },
+        { compiler: 'edge-server', mode: 'production', expected: '../static/demo-sources' },
+        { compiler: 'client', mode: 'production', expected: 'static/demo-sources' },
+      ];
+      for (const { compiler, mode, expected } of cases) {
+        // eslint-disable-next-line no-await-in-loop -- sequential fixture reuse keeps cases readable
+        const root = await writeFixture(files);
+        const entry = path.join(root, 'app/section/demos/layered/index.ts');
+        const emitted: string[] = [];
+        // eslint-disable-next-line no-await-in-loop -- see above
+        const { output } = await runLoader(root, entry, {}, (name) => emitted.push(name), {
+          mode,
+          _compiler: { name: compiler },
+        });
+        const precompute = precomputeOf(output);
+        expect(precompute.deferredUrl).toMatch(
+          /^\/_next\/static\/demo-sources\/section-layered\.[0-9a-f]{8}\.json$/,
+        );
+        expect(emitted).toEqual([`${expected}/${path.basename(precompute.deferredUrl ?? '')}`]);
+      }
+    });
+
+    it('falls back to the filesystem write when emitFile lacks a compiler name', async () => {
+      const longBody = Array.from(
+        { length: 20 },
+        (unused, index) => `  const v${index} = ${index};`,
+      );
+      const root = await writeFixture({
+        'app/section/demos/shim/index.ts': DEMO_INDEX,
+        'app/section/demos/shim/Button.tsx': [
+          'export default function Button() {',
+          ...longBody,
+          '  return null;',
+          '}',
+          '',
+        ].join('\n'),
+      });
+      const entry = path.join(root, 'app/section/demos/shim/index.ts');
+      const emitted: string[] = [];
+      const { output } = await runLoader(root, entry, {}, (name) => emitted.push(name));
+
+      const precompute = precomputeOf(output);
+      expect(emitted).toEqual([]);
+      expect(precompute.deferredUrl).toMatch(
+        /^\/build\/demo-sources\/section-shim\.[0-9a-f]{8}\.json$/,
+      );
+      const assetPath = path.join(
+        root,
+        'public/build/demo-sources',
+        path.basename(precompute.deferredUrl ?? ''),
+      );
+      const deferred = JSON.parse(await fs.readFile(assetPath, 'utf8')) as Record<
+        string,
+        { source?: string }
+      >;
+      expect(deferred.Default.source).toContain('v19');
+    });
+  });
+});

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.test.ts
@@ -37,27 +37,6 @@ interface LoaderPrecompute {
   deferredUrl?: string;
 }
 
-// Emulates the bundler's resolver over the fixture filesystem.
-const RESOLVE_SUFFIXES = ['', '.tsx', '.ts', '.jsx', '.js', '/index.tsx', '/index.ts'];
-async function resolveRequest(context: string, request: string): Promise<string> {
-  const base = path.resolve(context, request);
-  const candidates = await Promise.all(
-    RESOLVE_SUFFIXES.map(async (suffix) => {
-      const candidate = base + suffix;
-      try {
-        return (await fs.stat(candidate)).isFile() ? candidate : null;
-      } catch {
-        return null;
-      }
-    }),
-  );
-  const found = candidates.find((candidate): candidate is string => candidate !== null);
-  if (!found) {
-    throw new Error(`cannot resolve "${request}" from "${context}"`);
-  }
-  return found;
-}
-
 /** Invokes the loader with a minimal webpack-style loader context. */
 async function runLoader(
   rootContext: string,
@@ -79,7 +58,6 @@ async function runLoader(
       emitFile,
       ...compilerContext,
       getOptions: () => options,
-      getResolve: () => resolveRequest,
       async() {
         return (error, output) => {
           if (error) {

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
@@ -16,6 +16,12 @@ export interface LoadDemoOptions {
   assetDir?: string;
   emitDir?: string;
   urlPrefix?: string;
+  emphasisOptions?: DemoEmphasisOptions;
+}
+
+export interface DemoEmphasisOptions {
+  /** Maximum number of lines kept in the collapsed focus window. @default 10 */
+  focusFramesMaxSize?: number;
 }
 
 type Resolver = (context: string, request: string) => Promise<string | false>;
@@ -54,7 +60,7 @@ interface ResolvedRelativeImport extends RelativeImport {
 
 const EXTRA_FILE_EXTENSIONS = new Set(['.tsx', '.ts', '.jsx', '.js', '.css', '.json']);
 const MAX_DEPTH = 3;
-const FOCUS_FRAME_LINES = 6;
+const DEFAULT_FOCUS_FRAMES_MAX_SIZE = 10;
 const SSR_VISIBLE_LINES = 12;
 const JS_EXTENSIONS = /\.(tsx|ts|jsx|js)$/;
 
@@ -107,6 +113,7 @@ function toVariantFile(
   source: string,
   imports: ResolvedRelativeImport[] | undefined,
   displayNames: Map<string, string>,
+  emphasisOptions: DemoEmphasisOptions,
 ): VariantFile {
   const fileName = path.basename(filePath);
   const displaySource = JS_EXTENSIONS.test(filePath)
@@ -114,10 +121,18 @@ function toVariantFile(
     : source;
   const highlighted = parseSource(displaySource, fileName);
   const focusRange = highlighted.data.focusRange;
+  const focusFramesMaxSize = Math.max(
+    1,
+    emphasisOptions.focusFramesMaxSize ?? DEFAULT_FOCUS_FRAMES_MAX_SIZE,
+  );
   return {
     source: focusRange
-      ? splitFocusFrameRange(highlighted, focusRange.start, focusRange.end)
-      : splitFocusFrame(highlighted, FOCUS_FRAME_LINES),
+      ? splitFocusFrameRange(
+          highlighted,
+          focusRange.start,
+          Math.min(focusRange.end, focusRange.start + focusFramesMaxSize - 1),
+        )
+      : splitFocusFrame(highlighted, focusFramesMaxSize),
     language: path.extname(filePath).slice(1),
     totalLines: highlighted.data.totalLines,
   };
@@ -128,6 +143,7 @@ async function loadVariant(
   entryPath: string,
   addDependency: (file: string) => void,
   resolve: Resolver,
+  emphasisOptions: DemoEmphasisOptions,
 ): Promise<Omit<Variant, 'exportName'>> {
   const entrySource = await fs.readFile(entryPath, 'utf8');
   addDependency(entryPath);
@@ -185,13 +201,19 @@ async function loadVariant(
   const extraFiles = Object.fromEntries(
     Object.entries(collectedFiles).map(([displayName, { filePath, source }]) => [
       displayName,
-      toVariantFile(filePath, source, importsByFile.get(filePath), displayNames),
+      toVariantFile(filePath, source, importsByFile.get(filePath), displayNames, emphasisOptions),
     ]),
   );
 
   return {
     fileName: path.basename(entryPath),
-    ...toVariantFile(entryPath, entrySource, importsByFile.get(entryPath), displayNames),
+    ...toVariantFile(
+      entryPath,
+      entrySource,
+      importsByFile.get(entryPath),
+      displayNames,
+      emphasisOptions,
+    ),
     ...(Object.keys(extraFiles).length > 0 ? { extraFiles } : {}),
   };
 }
@@ -261,6 +283,7 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
   const callback = this.async();
 
   try {
+    const options = this.getOptions?.() ?? {};
     const parsed = parseDemoIndex(source);
     if (!parsed) {
       callback(null, source);
@@ -279,7 +302,12 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
                 `which does not resolve to a file from ${demoDir}.`,
             );
           }
-          const variant = await loadVariant(entryPath, (file) => this.addDependency(file), resolve);
+          const variant = await loadVariant(
+            entryPath,
+            (file) => this.addDependency(file),
+            resolve,
+            options.emphasisOptions ?? {},
+          );
           return [variantName, { ...variant, exportName: importName }];
         },
       ),
@@ -287,7 +315,6 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
     const { visible, deferred } = splitDeferredSources(Object.fromEntries(entries));
     let deferredUrl: string | undefined;
     if (deferred) {
-      const options = this.getOptions?.() ?? {};
       const json = JSON.stringify(deferred);
       const hash = createHash('sha256').update(json).digest('hex').slice(0, 8);
       const scope = path.basename(path.dirname(path.dirname(demoDir)));

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
@@ -246,27 +246,53 @@ async function loadVariant(
 }
 
 function truncateHast(root: ParseSourceRoot, maxLines: number): ParseSourceRoot {
-  let lines = 0;
+  let totalLines = 0;
+  let focusStart = Number.POSITIVE_INFINITY;
+  let focusEnd = 0;
+  for (const frame of root.children) {
+    if (frame.type !== 'element') {
+      continue;
+    }
+    const focused = frame.properties.dataFrameType === 'focus';
+    for (const child of frame.children) {
+      const line = child.type === 'element' ? child.properties.dataLn : undefined;
+      if (typeof line !== 'number') {
+        continue;
+      }
+      totalLines = Math.max(totalLines, line);
+      if (focused) {
+        focusStart = Math.min(focusStart, line);
+        focusEnd = Math.max(focusEnd, line);
+      }
+    }
+  }
+
+  const focusLines = focusEnd > 0 ? focusEnd - focusStart + 1 : 0;
+  const contextBefore = Math.floor(Math.max(0, maxLines - focusLines) / 2);
+  let startLine = focusEnd > 0 ? Math.max(1, focusStart - contextBefore) : 1;
+  const endLine = Math.min(totalLines, startLine + maxLines - 1);
+  startLine = Math.max(1, endLine - maxLines + 1);
+
   const children: ParseSourceRoot['children'] = [];
   for (const frame of root.children) {
-    if (lines >= maxLines) {
-      break;
-    }
     if (frame.type !== 'element') {
       children.push(frame);
       continue;
     }
     const frameChildren: typeof frame.children = [];
+    let keepLine = false;
     for (const child of frame.children) {
       if (child.type === 'element') {
-        if (lines >= maxLines) {
-          break;
-        }
-        lines += 1;
+        const line = child.properties.dataLn;
+        keepLine = typeof line === 'number' && line >= startLine && line <= endLine;
       }
-      frameChildren.push(child);
+      if (keepLine) {
+        frameChildren.push(child);
+      }
     }
-    children.push({ ...frame, children: frameChildren });
+    if (frameChildren.length > 0) {
+      children.push({ ...frame, children: frameChildren });
+    }
   }
   return { ...root, children };
 }

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
@@ -11,17 +11,30 @@ import type { ParseSourceRoot } from '../../shared/syntax/parseSource';
 import { getRelativeImports, parseDemoIndex } from '../../shared/parsers/parseDemoIndex';
 import type { RelativeImport } from '../../shared/parsers/parseDemoIndex';
 import type { DeferredSources, VariantCode } from '../../runtime/types';
+import {
+  createPerformanceLogger,
+  logPerformance,
+  nameMark,
+  performanceMeasure,
+} from '../../../pipeline/loadPrecomputedCodeHighlighter/performanceLogger';
 
 export interface LoadDemoOptions {
   assetDir?: string;
   emitDir?: string;
   urlPrefix?: string;
   emphasisOptions?: DemoEmphasisOptions;
+  performance?: DemoPerformanceOptions;
 }
 
 export interface DemoEmphasisOptions {
   /** Maximum number of lines kept in the collapsed focus window. @default 10 */
   focusFramesMaxSize?: number;
+}
+
+export interface DemoPerformanceOptions {
+  logging?: boolean;
+  notableMs?: number;
+  showWrapperMeasures?: boolean;
 }
 
 type Resolver = (context: string, request: string) => Promise<string | false>;
@@ -63,6 +76,7 @@ const MAX_DEPTH = 3;
 const DEFAULT_FOCUS_FRAMES_MAX_SIZE = 10;
 const SSR_VISIBLE_LINES = 12;
 const JS_EXTENSIONS = /\.(tsx|ts|jsx|js)$/;
+const FUNCTION_NAME = 'Lite Demo Loader';
 
 async function resolveRelative(
   resolve: Resolver,
@@ -144,6 +158,8 @@ async function loadVariant(
   addDependency: (file: string) => void,
   resolve: Resolver,
   emphasisOptions: DemoEmphasisOptions,
+  startMark: string,
+  performanceContext: string[],
 ): Promise<Omit<Variant, 'exportName'>> {
   const entrySource = await fs.readFile(entryPath, 'utf8');
   addDependency(entryPath);
@@ -198,6 +214,11 @@ async function loadVariant(
     }
   };
   await collect(entryPath, entrySource, 0);
+  const sourceGraphMark = performanceMeasure(
+    startMark,
+    { mark: 'Source Graph Loaded', measure: 'Source Graph Loading' },
+    performanceContext,
+  );
   const extraFiles = Object.fromEntries(
     Object.entries(collectedFiles).map(([displayName, { filePath, source }]) => [
       displayName,
@@ -205,7 +226,7 @@ async function loadVariant(
     ]),
   );
 
-  return {
+  const variant = {
     fileName: path.basename(entryPath),
     ...toVariantFile(
       entryPath,
@@ -216,6 +237,12 @@ async function loadVariant(
     ),
     ...(Object.keys(extraFiles).length > 0 ? { extraFiles } : {}),
   };
+  performanceMeasure(
+    sourceGraphMark,
+    { mark: 'Syntax Highlighted', measure: 'Syntax Highlighting' },
+    performanceContext,
+  );
+  return variant;
 }
 
 function truncateHast(root: ParseSourceRoot, maxLines: number): ParseSourceRoot {
@@ -281,12 +308,45 @@ function splitDeferredSources(variants: Record<string, Variant>): {
 export async function loadDemo(this: DemoLoaderContext, source: string): Promise<void> {
   this.cacheable?.();
   const callback = this.async();
+  const options = this.getOptions?.() ?? {};
+  const relativePath = path.relative(this.rootContext || process.cwd(), this.resourcePath);
+  const performanceNotableMs = options.performance?.notableMs ?? 100;
+  const performanceShowWrapperMeasures = options.performance?.showWrapperMeasures ?? false;
+  let observer: PerformanceObserver | undefined;
+  if (options.performance?.logging) {
+    observer = new PerformanceObserver(
+      createPerformanceLogger(performanceNotableMs, performanceShowWrapperMeasures, relativePath),
+    );
+    observer.observe({ entryTypes: ['measure'] });
+  }
+  const performanceContext = [FUNCTION_NAME, relativePath];
+  const startMark = nameMark(FUNCTION_NAME, 'Started', [relativePath], true);
+  performance.mark(startMark);
+  const finish = (error: Error | null, output?: string) => {
+    performanceMeasure(
+      startMark,
+      { mark: 'Completed', measure: 'Complete Loading' },
+      performanceContext,
+      true,
+    );
+    observer
+      ?.takeRecords()
+      .forEach((entry) =>
+        logPerformance(entry, performanceNotableMs, performanceShowWrapperMeasures, relativePath),
+      );
+    observer?.disconnect();
+    callback(error, output);
+  };
 
   try {
-    const options = this.getOptions?.() ?? {};
     const parsed = parseDemoIndex(source);
+    let currentMark = performanceMeasure(
+      startMark,
+      { mark: 'Demo Parsed', measure: 'Demo Parsing' },
+      performanceContext,
+    );
     if (!parsed) {
-      callback(null, source);
+      finish(null, source);
       return;
     }
 
@@ -295,7 +355,20 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
     const entries = await Promise.all(
       Object.entries(parsed.variants).map(
         async ([variantName, { specifier, importName }]): Promise<[string, Variant]> => {
+          const variantContext = [FUNCTION_NAME, variantName, relativePath];
+          const variantStartMark = nameMark(
+            FUNCTION_NAME,
+            'Variant Started',
+            [variantName, relativePath],
+            true,
+          );
+          performance.mark(variantStartMark);
           const entryPath = await resolveRelative(resolve, demoDir, specifier);
+          const pathResolvedMark = performanceMeasure(
+            variantStartMark,
+            { mark: 'Path Resolved', measure: 'Path Resolution' },
+            variantContext,
+          );
           if (!entryPath) {
             throw new Error(
               `docs-infra: demo variant "${variantName}" imports "${specifier}", ` +
@@ -307,12 +380,31 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
             (file) => this.addDependency(file),
             resolve,
             options.emphasisOptions ?? {},
+            pathResolvedMark,
+            variantContext,
+          );
+          performanceMeasure(
+            variantStartMark,
+            { mark: 'Variant Loaded', measure: 'Variant Loading' },
+            variantContext,
+            true,
           );
           return [variantName, { ...variant, exportName: importName }];
         },
       ),
     );
+    currentMark = performanceMeasure(
+      currentMark,
+      { mark: 'All Variants Loaded', measure: 'Complete Variants Loading' },
+      performanceContext,
+      true,
+    );
     const { visible, deferred } = splitDeferredSources(Object.fromEntries(entries));
+    currentMark = performanceMeasure(
+      currentMark,
+      { mark: 'HTML Serialized', measure: 'HTML Serialization' },
+      performanceContext,
+    );
     let deferredUrl: string | undefined;
     if (deferred) {
       const json = JSON.stringify(deferred);
@@ -338,17 +430,27 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
         await fs.writeFile(path.join(outDir, fileName), json);
         deferredUrl = `${urlPrefix}${fileName}`;
       }
+      currentMark = performanceMeasure(
+        currentMark,
+        { mark: 'Deferred Asset Emitted', measure: 'Deferred Asset Emission' },
+        performanceContext,
+      );
     }
     const precompute = JSON.stringify({
       variants: visible,
       ...(deferredUrl ? { deferredUrl } : {}),
     });
-    callback(
+    performanceMeasure(
+      currentMark,
+      { mark: 'Precompute Serialized', measure: 'Precompute Serialization' },
+      performanceContext,
+    );
+    finish(
       null,
       `${source}\nObject.assign(${parsed.exportName}, { __docsInfraPrecompute: ${precompute} });\n`,
     );
   } catch (error) {
-    callback(error instanceof Error ? error : new Error(String(error)));
+    finish(error instanceof Error ? error : new Error(String(error)));
   }
 }
 

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
@@ -1,0 +1,328 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { toHtml } from 'hast-util-to-html';
+import {
+  parseSource,
+  splitFocusFrame,
+  splitFocusFrameRange,
+} from '../../shared/syntax/parseSource';
+import type { ParseSourceRoot } from '../../shared/syntax/parseSource';
+import { getRelativeImports, parseDemoIndex } from '../../shared/parsers/parseDemoIndex';
+import type { RelativeImport } from '../../shared/parsers/parseDemoIndex';
+import type { DeferredSources, VariantCode } from '../../runtime/types';
+
+export interface LoadDemoOptions {
+  assetDir?: string;
+  emitDir?: string;
+  urlPrefix?: string;
+}
+
+type Resolver = (context: string, request: string) => Promise<string | false>;
+
+/** The loader context surface shared by webpack, Turbopack, and tests. */
+export interface DemoLoaderContext {
+  resourcePath: string;
+  rootContext?: string;
+  cacheable?: () => void;
+  addDependency: (file: string) => void;
+  emitFile?: (name: string, content: string) => void;
+  mode?: string;
+  _compiler?: { name?: string };
+  getOptions?: () => LoadDemoOptions;
+  getResolve: (options?: object) => Resolver;
+  async: () => (error: Error | null, output?: string) => void;
+}
+
+interface VariantFile {
+  source: ParseSourceRoot;
+  language: string;
+  totalLines: number;
+}
+
+interface Variant extends VariantFile {
+  fileName: string;
+  exportName: string;
+  extraFiles?: Record<string, VariantFile>;
+}
+
+type VisibleVariant = VariantCode;
+
+interface ResolvedRelativeImport extends RelativeImport {
+  resolvedPath: string | null;
+}
+
+const EXTRA_FILE_EXTENSIONS = new Set(['.tsx', '.ts', '.jsx', '.js', '.css', '.json']);
+const MAX_DEPTH = 3;
+const FOCUS_FRAME_LINES = 6;
+const SSR_VISIBLE_LINES = 12;
+const JS_EXTENSIONS = /\.(tsx|ts|jsx|js)$/;
+
+async function resolveRelative(
+  resolve: Resolver,
+  fromDir: string,
+  specifier: string,
+): Promise<string | null> {
+  try {
+    const resolved = await resolve(fromDir, specifier);
+    return typeof resolved === 'string' ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function flattenSpecifier(specifier: string): string | null {
+  const name = (specifier.split('/').pop() ?? '').replace(/^_/, '');
+  if (!name || name === '.' || name === '..') {
+    return null;
+  }
+  const flat = `./${name}`;
+  return flat === specifier ? null : flat;
+}
+
+function rewriteRelativeImports(
+  source: string,
+  imports: Array<RelativeImport | ResolvedRelativeImport>,
+  displayNames: Map<string, string>,
+): string {
+  let output = '';
+  let last = 0;
+  for (const relativeImport of imports) {
+    const { specifier, start, end } = relativeImport;
+    const displayName =
+      'resolvedPath' in relativeImport && relativeImport.resolvedPath
+        ? displayNames.get(relativeImport.resolvedPath)
+        : undefined;
+    const flat = displayName ? `./${displayName}` : flattenSpecifier(specifier);
+    if (flat) {
+      output += source.slice(last, start) + flat;
+      last = end;
+    }
+  }
+  return output + source.slice(last);
+}
+
+function toVariantFile(
+  filePath: string,
+  source: string,
+  imports: ResolvedRelativeImport[] | undefined,
+  displayNames: Map<string, string>,
+): VariantFile {
+  const fileName = path.basename(filePath);
+  const displaySource = JS_EXTENSIONS.test(filePath)
+    ? rewriteRelativeImports(source, imports ?? getRelativeImports(source), displayNames)
+    : source;
+  const highlighted = parseSource(displaySource, fileName);
+  const focusRange = highlighted.data.focusRange;
+  return {
+    source: focusRange
+      ? splitFocusFrameRange(highlighted, focusRange.start, focusRange.end)
+      : splitFocusFrame(highlighted, FOCUS_FRAME_LINES),
+    language: path.extname(filePath).slice(1),
+    totalLines: highlighted.data.totalLines,
+  };
+}
+
+/** Loads a variant entry and its supported relative import tree. */
+async function loadVariant(
+  entryPath: string,
+  addDependency: (file: string) => void,
+  resolve: Resolver,
+): Promise<Omit<Variant, 'exportName'>> {
+  const entrySource = await fs.readFile(entryPath, 'utf8');
+  addDependency(entryPath);
+  const collectedFiles: Record<string, { filePath: string; source: string }> = {};
+  const displayNames = new Map<string, string>();
+  const importsByFile = new Map<string, ResolvedRelativeImport[]>();
+  const visited = new Set([entryPath]);
+
+  const collect = async (filePath: string, source: string, depth: number): Promise<void> => {
+    if (depth >= MAX_DEPTH) {
+      return;
+    }
+    const fromDir = path.dirname(filePath);
+    const imports = getRelativeImports(source);
+    const resolved = await Promise.all(
+      imports.map(({ specifier }) => resolveRelative(resolve, fromDir, specifier)),
+    );
+    importsByFile.set(
+      filePath,
+      imports.map((relativeImport, index) => ({
+        ...relativeImport,
+        resolvedPath: resolved[index],
+      })),
+    );
+    const fresh: string[] = [];
+    for (const file of resolved) {
+      if (!file || visited.has(file)) {
+        continue;
+      }
+      visited.add(file);
+      if (EXTRA_FILE_EXTENSIONS.has(path.extname(file))) {
+        fresh.push(file);
+      }
+    }
+    const sources = await Promise.all(fresh.map((file) => fs.readFile(file, 'utf8')));
+
+    // Keep import order deterministic for insertion order and collision renames.
+    fresh.forEach((file, index) => {
+      addDependency(file);
+      let displayName = path.basename(file).replace(/^_/, '');
+      if (displayName === path.basename(entryPath) || displayName in collectedFiles) {
+        displayName = `${path.basename(path.dirname(file))}/${displayName}`;
+      }
+      displayNames.set(file, displayName);
+      collectedFiles[displayName] = { filePath: file, source: sources[index] };
+    });
+    for (let index = 0; index < fresh.length; index += 1) {
+      if (JS_EXTENSIONS.test(fresh[index])) {
+        // eslint-disable-next-line no-await-in-loop -- traversal order is part of the output
+        await collect(fresh[index], sources[index], depth + 1);
+      }
+    }
+  };
+  await collect(entryPath, entrySource, 0);
+  const extraFiles = Object.fromEntries(
+    Object.entries(collectedFiles).map(([displayName, { filePath, source }]) => [
+      displayName,
+      toVariantFile(filePath, source, importsByFile.get(filePath), displayNames),
+    ]),
+  );
+
+  return {
+    fileName: path.basename(entryPath),
+    ...toVariantFile(entryPath, entrySource, importsByFile.get(entryPath), displayNames),
+    ...(Object.keys(extraFiles).length > 0 ? { extraFiles } : {}),
+  };
+}
+
+function truncateHast(root: ParseSourceRoot, maxLines: number): ParseSourceRoot {
+  let lines = 0;
+  const children: ParseSourceRoot['children'] = [];
+  for (const frame of root.children) {
+    if (lines >= maxLines) {
+      break;
+    }
+    if (frame.type !== 'element') {
+      children.push(frame);
+      continue;
+    }
+    const frameChildren: typeof frame.children = [];
+    for (const child of frame.children) {
+      if (child.type === 'element') {
+        if (lines >= maxLines) {
+          break;
+        }
+        lines += 1;
+      }
+      frameChildren.push(child);
+    }
+    children.push({ ...frame, children: frameChildren });
+  }
+  return { ...root, children };
+}
+
+function splitDeferredSources(variants: Record<string, Variant>): {
+  visible: Record<string, VisibleVariant>;
+  deferred: DeferredSources | null;
+} {
+  const visible: Record<string, VisibleVariant> = {};
+  const deferred: DeferredSources = {};
+  for (const [variantName, variant] of Object.entries(variants)) {
+    const { source, extraFiles, ...meta } = variant;
+    const deferredEntry: DeferredSources[string] = {};
+    const entry: VisibleVariant = { ...meta, html: '' };
+    if (variant.totalLines <= SSR_VISIBLE_LINES) {
+      entry.html = toHtml(source);
+    } else {
+      entry.html = toHtml(truncateHast(source, SSR_VISIBLE_LINES));
+      deferredEntry.source = toHtml(source);
+    }
+    if (extraFiles) {
+      entry.extraFiles = {};
+      deferredEntry.extraFiles = {};
+      for (const [fileName, file] of Object.entries(extraFiles)) {
+        const { source: fileSource, ...fileMeta } = file;
+        entry.extraFiles[fileName] = fileMeta;
+        deferredEntry.extraFiles[fileName] = toHtml(fileSource);
+      }
+    }
+    if (deferredEntry.source !== undefined || deferredEntry.extraFiles !== undefined) {
+      deferred[variantName] = deferredEntry;
+    }
+    visible[variantName] = entry;
+  }
+  return { visible, deferred: Object.keys(deferred).length > 0 ? deferred : null };
+}
+
+/** Webpack/Turbopack loader that appends demo source precompute metadata. */
+export async function loadDemo(this: DemoLoaderContext, source: string): Promise<void> {
+  this.cacheable?.();
+  const callback = this.async();
+
+  try {
+    const parsed = parseDemoIndex(source);
+    if (!parsed) {
+      callback(null, source);
+      return;
+    }
+
+    const demoDir = path.dirname(this.resourcePath);
+    const resolve = this.getResolve({});
+    const entries = await Promise.all(
+      Object.entries(parsed.variants).map(
+        async ([variantName, { specifier, importName }]): Promise<[string, Variant]> => {
+          const entryPath = await resolveRelative(resolve, demoDir, specifier);
+          if (!entryPath) {
+            throw new Error(
+              `docs-infra: demo variant "${variantName}" imports "${specifier}", ` +
+                `which does not resolve to a file from ${demoDir}.`,
+            );
+          }
+          const variant = await loadVariant(entryPath, (file) => this.addDependency(file), resolve);
+          return [variantName, { ...variant, exportName: importName }];
+        },
+      ),
+    );
+    const { visible, deferred } = splitDeferredSources(Object.fromEntries(entries));
+    let deferredUrl: string | undefined;
+    if (deferred) {
+      const options = this.getOptions?.() ?? {};
+      const json = JSON.stringify(deferred);
+      const hash = createHash('sha256').update(json).digest('hex').slice(0, 8);
+      const scope = path.basename(path.dirname(path.dirname(demoDir)));
+      const fileName = `${scope}-${path.basename(demoDir)}.${hash}.json`;
+      // eslint-disable-next-line no-underscore-dangle
+      const compiler = this._compiler?.name;
+      if (this.emitFile && compiler) {
+        const isServerCompiler = compiler === 'server' || compiler === 'edge-server';
+        const climb = this.mode === 'development' || compiler === 'edge-server' ? '../' : '../../';
+        const {
+          emitDir = `${isServerCompiler ? climb : ''}static/demo-sources`,
+          urlPrefix = '/_next/static/demo-sources/',
+        } = options;
+        this.emitFile(path.posix.join(emitDir, fileName), json);
+        deferredUrl = `${urlPrefix}${fileName}`;
+      } else {
+        const { assetDir = 'public/build/demo-sources', urlPrefix = '/build/demo-sources/' } =
+          options;
+        const outDir = path.resolve(this.rootContext || process.cwd(), assetDir);
+        await fs.mkdir(outDir, { recursive: true });
+        await fs.writeFile(path.join(outDir, fileName), json);
+        deferredUrl = `${urlPrefix}${fileName}`;
+      }
+    }
+    const precompute = JSON.stringify({
+      variants: visible,
+      ...(deferredUrl ? { deferredUrl } : {}),
+    });
+    callback(
+      null,
+      `${source}\nObject.assign(${parsed.exportName}, { __docsInfraPrecompute: ${precompute} });\n`,
+    );
+  } catch (error) {
+    callback(error instanceof Error ? error : new Error(String(error)));
+  }
+}
+
+export default loadDemo;

--- a/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/demoLoader.ts
@@ -37,8 +37,6 @@ export interface DemoPerformanceOptions {
   showWrapperMeasures?: boolean;
 }
 
-type Resolver = (context: string, request: string) => Promise<string | false>;
-
 /** The loader context surface shared by webpack, Turbopack, and tests. */
 export interface DemoLoaderContext {
   resourcePath: string;
@@ -49,7 +47,6 @@ export interface DemoLoaderContext {
   mode?: string;
   _compiler?: { name?: string };
   getOptions?: () => LoadDemoOptions;
-  getResolve: (options?: object) => Resolver;
   async: () => (error: Error | null, output?: string) => void;
 }
 
@@ -78,17 +75,23 @@ const SSR_VISIBLE_LINES = 12;
 const JS_EXTENSIONS = /\.(tsx|ts|jsx|js)$/;
 const FUNCTION_NAME = 'Lite Demo Loader';
 
-async function resolveRelative(
-  resolve: Resolver,
-  fromDir: string,
-  specifier: string,
-): Promise<string | null> {
-  try {
-    const resolved = await resolve(fromDir, specifier);
-    return typeof resolved === 'string' ? resolved : null;
-  } catch {
-    return null;
-  }
+const RESOLVE_SUFFIXES = ['', '.tsx', '.ts', '.jsx', '.js', '/index.tsx', '/index.ts'];
+
+// Demo imports are always relative paths, so plain fs probing resolves them without
+// queueing on the bundler's shared resolver (which keeps invocations open for seconds
+// during a cold build's make phase).
+async function resolveRelative(fromDir: string, specifier: string): Promise<string | null> {
+  const base = path.resolve(fromDir, specifier);
+  const candidates = await Promise.all(
+    RESOLVE_SUFFIXES.map(async (suffix) => {
+      try {
+        return (await fs.stat(base + suffix)).isFile() ? base + suffix : null;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return candidates.find((candidate) => candidate !== null) ?? null;
 }
 
 function flattenSpecifier(specifier: string): string | null {
@@ -156,7 +159,6 @@ function toVariantFile(
 async function loadVariant(
   entryPath: string,
   addDependency: (file: string) => void,
-  resolve: Resolver,
   emphasisOptions: DemoEmphasisOptions,
   startMark: string,
   performanceContext: string[],
@@ -175,7 +177,7 @@ async function loadVariant(
     const fromDir = path.dirname(filePath);
     const imports = getRelativeImports(source);
     const resolved = await Promise.all(
-      imports.map(({ specifier }) => resolveRelative(resolve, fromDir, specifier)),
+      imports.map(({ specifier }) => resolveRelative(fromDir, specifier)),
     );
     importsByFile.set(
       filePath,
@@ -377,7 +379,6 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
     }
 
     const demoDir = path.dirname(this.resourcePath);
-    const resolve = this.getResolve({});
     const entries = await Promise.all(
       Object.entries(parsed.variants).map(
         async ([variantName, { specifier, importName }]): Promise<[string, Variant]> => {
@@ -389,7 +390,7 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
             true,
           );
           performance.mark(variantStartMark);
-          const entryPath = await resolveRelative(resolve, demoDir, specifier);
+          const entryPath = await resolveRelative(demoDir, specifier);
           const pathResolvedMark = performanceMeasure(
             variantStartMark,
             { mark: 'Path Resolved', measure: 'Path Resolution' },
@@ -404,7 +405,6 @@ export async function loadDemo(this: DemoLoaderContext, source: string): Promise
           const variant = await loadVariant(
             entryPath,
             (file) => this.addDependency(file),
-            resolve,
             options.emphasisOptions ?? {},
             pathResolvedMark,
             variantContext,

--- a/packages/docs-infra/src/lite/loaders/demo/index.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/index.ts
@@ -1,2 +1,2 @@
 export { loadDemo, default } from './demoLoader';
-export type { DemoLoaderContext, LoadDemoOptions } from './demoLoader';
+export type { DemoEmphasisOptions, DemoLoaderContext, LoadDemoOptions } from './demoLoader';

--- a/packages/docs-infra/src/lite/loaders/demo/index.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/index.ts
@@ -1,0 +1,2 @@
+export { loadDemo, default } from './demoLoader';
+export type { DemoLoaderContext, LoadDemoOptions } from './demoLoader';

--- a/packages/docs-infra/src/lite/loaders/demo/index.ts
+++ b/packages/docs-infra/src/lite/loaders/demo/index.ts
@@ -1,2 +1,7 @@
 export { loadDemo, default } from './demoLoader';
-export type { DemoEmphasisOptions, DemoLoaderContext, LoadDemoOptions } from './demoLoader';
+export type {
+  DemoEmphasisOptions,
+  DemoLoaderContext,
+  DemoPerformanceOptions,
+  LoadDemoOptions,
+} from './demoLoader';

--- a/packages/docs-infra/src/lite/runtime/CodeHighlighter.tsx
+++ b/packages/docs-infra/src/lite/runtime/CodeHighlighter.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import type { CodeHighlighterProps } from './types';
+
+/** Bridges build-time precompute data to an application's Content component. */
+export function CodeHighlighter<T extends object = {}>(
+  props: CodeHighlighterProps<T>,
+): React.ReactNode {
+  const { Content, contentProps, precompute, components, name, slug, url } = props;
+  return (
+    <Content
+      {...(contentProps as T)}
+      code={precompute}
+      components={components}
+      name={name}
+      slug={slug}
+      url={url}
+    />
+  );
+}

--- a/packages/docs-infra/src/lite/runtime/abstractCreateDemo.test.tsx
+++ b/packages/docs-infra/src/lite/runtime/abstractCreateDemo.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import { createDemoFactory, createDemoWithVariantsFactory } from './abstractCreateDemo';
+import type { ContentProps } from './types';
+
+function DemoContent(props: ContentProps<{ preloadSources?: boolean }>) {
+  return (
+    <section
+      data-name={props.name}
+      data-slug={props.slug}
+      data-url={props.url}
+      data-preload={props.preloadSources || undefined}
+    >
+      {Object.values(props.components)}
+    </section>
+  );
+}
+
+const precompute = {
+  variants: {
+    Default: {
+      fileName: 'Demo.tsx',
+      exportName: 'default',
+      html: '<span>demo</span>',
+      language: 'tsx',
+      totalLines: 1,
+    },
+  },
+};
+
+describe('createDemoFactory', () => {
+  it('derives identity from import.meta.url and renders DemoContent directly', () => {
+    const createDemo = createDemoFactory({ DemoContent });
+    const Demo = createDemo('file:///project/demos/button-group/index.ts', () => <button />);
+    // The loader attaches this static after the factory call is evaluated.
+    // eslint-disable-next-line no-underscore-dangle
+    Demo.__docsInfraPrecompute = precompute;
+
+    expect(ReactDOMServer.renderToStaticMarkup(<Demo />)).toBe(
+      '<section data-name="Button Group" data-slug="button-group" data-url="file:///project/demos/button-group/index.ts"><button></button></section>',
+    );
+  });
+
+  it('throws at render when the loader did not attach precompute data', () => {
+    const createDemo = createDemoFactory({ DemoContent });
+    const Demo = createDemo('file:///project/demos/basic/index.ts', () => null);
+
+    expect(() => ReactDOMServer.renderToStaticMarkup(<Demo />)).toThrow(
+      'did not attach __docsInfraPrecompute',
+    );
+  });
+
+  it('forwards the source preload marker to DemoContent', () => {
+    const createDemo = createDemoFactory({ DemoContent });
+    const Demo = createDemo('file:///project/demos/basic/index.ts', () => null);
+    // eslint-disable-next-line no-underscore-dangle
+    Demo.__docsInfraPrecompute = precompute;
+
+    expect(ReactDOMServer.renderToStaticMarkup(<Demo preloadSources />)).toContain(
+      'data-preload="true"',
+    );
+  });
+
+  it('rejects malformed source URLs', () => {
+    const createDemo = createDemoFactory({ DemoContent });
+
+    expect(() => createDemo('index.ts', () => null)).toThrow('requires import.meta.url');
+  });
+});
+
+describe('createDemoWithVariantsFactory', () => {
+  it('renders every variant component', () => {
+    const createDemoWithVariants = createDemoWithVariantsFactory({ DemoContent });
+    const Demo = createDemoWithVariants('file:///project/demos/basic/index.ts', {
+      Default: () => <span>default</span>,
+      Alternate: () => <span>alternate</span>,
+    });
+    // eslint-disable-next-line no-underscore-dangle
+    Demo.__docsInfraPrecompute = {
+      variants: {
+        ...precompute.variants,
+        Alternate: {
+          fileName: 'Alternate.tsx',
+          exportName: 'default',
+          html: '<span>alternate</span>',
+          language: 'tsx',
+          totalLines: 1,
+        },
+      },
+    };
+
+    expect(ReactDOMServer.renderToStaticMarkup(<Demo />)).toContain(
+      '<span>default</span><span>alternate</span>',
+    );
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/abstractCreateDemo.tsx
+++ b/packages/docs-infra/src/lite/runtime/abstractCreateDemo.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+import type { CodePrecompute, ContentProps } from './types';
+
+export interface CreateDemoConfig {
+  DemoContent: React.ComponentType<ContentProps<DemoComponentProps>>;
+}
+
+export interface DemoComponentProps {
+  preloadSources?: boolean;
+}
+
+export type DemoComponent = React.ComponentType<DemoComponentProps> & {
+  __docsInfraPrecompute?: CodePrecompute;
+};
+
+function getDemoIdentity(sourceUrl: string): { name: string; slug: string } {
+  let directory: string;
+  try {
+    const segments = new URL(sourceUrl).pathname.split('/').filter(Boolean);
+    if (segments.length < 2) {
+      throw new Error();
+    }
+    directory = decodeURIComponent(segments[segments.length - 2]);
+  } catch {
+    throw new Error(
+      `docs-infra: createDemo requires import.meta.url with a parent directory; received ${JSON.stringify(sourceUrl)}.`,
+    );
+  }
+  const words = directory.split(/[-_]/).filter(Boolean);
+  const slug = directory
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  if (!slug || words.length === 0) {
+    throw new Error(
+      `docs-infra: createDemo could not derive a demo name from ${JSON.stringify(sourceUrl)}.`,
+    );
+  }
+  const name = words.map((word) => word[0].toUpperCase() + word.slice(1)).join(' ');
+  return { name, slug };
+}
+
+function makeDemo(
+  config: CreateDemoConfig,
+  sourceUrl: string,
+  variants: Record<string, React.ComponentType>,
+): DemoComponent {
+  const { DemoContent } = config;
+  const { name, slug } = getDemoIdentity(sourceUrl);
+  const components = Object.fromEntries(
+    Object.entries(variants).map(([variantName, Component]) => [variantName, <Component />]),
+  );
+
+  function Demo({ preloadSources }: DemoComponentProps) {
+    // eslint-disable-next-line no-underscore-dangle
+    const code = (Demo as DemoComponent).__docsInfraPrecompute;
+    if (!code) {
+      throw new Error(
+        `docs-infra: the demo loader did not attach __docsInfraPrecompute to the demo from ${sourceUrl}.`,
+      );
+    }
+    return (
+      <DemoContent
+        code={code}
+        components={components}
+        name={name}
+        preloadSources={preloadSources}
+        slug={slug}
+        url={sourceUrl}
+      />
+    );
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    Demo.displayName = `Demo(${name})`;
+  }
+  return Demo as DemoComponent;
+}
+
+export function createDemoFactory(config: CreateDemoConfig) {
+  return function createDemo(sourceUrl: string, component: React.ComponentType): DemoComponent {
+    return makeDemo(config, sourceUrl, { Default: component });
+  };
+}
+
+export function createDemoWithVariantsFactory(config: CreateDemoConfig) {
+  return function createDemoWithVariants(
+    sourceUrl: string,
+    variants: Record<string, React.ComponentType>,
+  ): DemoComponent {
+    return makeDemo(config, sourceUrl, variants);
+  };
+}

--- a/packages/docs-infra/src/lite/runtime/createCodeSandbox.test.ts
+++ b/packages/docs-infra/src/lite/runtime/createCodeSandbox.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import LZString from 'lz-string';
+import { createCodeSandbox } from './createCodeSandbox';
+
+function decodeParameters(parameters: string): Record<string, { content: string }> {
+  const base64 = parameters.replaceAll('-', '+').replaceAll('_', '/');
+  const json = LZString.decompressFromBase64(base64);
+  return (JSON.parse(json) as { files: Record<string, { content: string }> }).files;
+}
+
+describe('createCodeSandbox', () => {
+  it('wraps a demo in the same Vite project used by StackBlitz', () => {
+    const { url, formData } = createCodeSandbox({
+      title: 'Button',
+      files: {
+        'Button.tsx': 'export default function Button() { return <button>Click</button>; }',
+      },
+      entryFileName: 'Button.tsx',
+    });
+    const files = decodeParameters(formData.parameters);
+
+    expect(url).toBe('https://codesandbox.io/api/v1/sandboxes/define');
+    expect(formData.query).toBe('file=src/Button.tsx');
+    expect(Object.keys(files)).toMatchInlineSnapshot(`
+      [
+        "package.json",
+        "index.html",
+        "vite.config.ts",
+        "tsconfig.json",
+        "src/main.tsx",
+        "src/Button.tsx",
+      ]
+    `);
+    expect(files['src/main.tsx'].content).toContain("import Demo from './Button';");
+  });
+
+  it('preserves dependency overrides, extra files, and HTML head markup', () => {
+    const { formData } = createCodeSandbox({
+      title: 'Demo',
+      files: {
+        'Demo.jsx': "import value from 'some-library'; export default value;",
+      },
+      entryFileName: 'Demo.jsx',
+      dependencies: { 'some-library': '^2.0.0' },
+      extraFiles: { 'public/demo.css': 'body { margin: 0; }' },
+      htmlHead: '<link rel="stylesheet" href="/demo.css" />',
+    });
+    const files = decodeParameters(formData.parameters);
+    const packageJson = JSON.parse(files['package.json'].content) as {
+      dependencies: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies['some-library']).toBe('^2.0.0');
+    expect(files['public/demo.css'].content).toContain('margin');
+    expect(files['index.html'].content).toContain('/demo.css');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/createCodeSandbox.test.ts
+++ b/packages/docs-infra/src/lite/runtime/createCodeSandbox.test.ts
@@ -9,7 +9,7 @@ function decodeParameters(parameters: string): Record<string, { content: string 
 }
 
 describe('createCodeSandbox', () => {
-  it('wraps a demo in the same Vite project used by StackBlitz', () => {
+  it('wraps a TypeScript demo in a Create React App project', () => {
     const { url, formData } = createCodeSandbox({
       title: 'Button',
       files: {
@@ -24,14 +24,22 @@ describe('createCodeSandbox', () => {
     expect(Object.keys(files)).toMatchInlineSnapshot(`
       [
         "package.json",
-        "index.html",
-        "vite.config.ts",
+        "public/index.html",
         "tsconfig.json",
-        "src/main.tsx",
         "src/Button.tsx",
+        "src/index.tsx",
       ]
     `);
-    expect(files['src/main.tsx'].content).toContain("import Demo from './Button';");
+    expect(files['src/index.tsx'].content).toContain("import App from './Button';");
+    expect(files['public/index.html'].content).not.toContain('<script');
+    const packageJson = JSON.parse(files['package.json'].content) as {
+      type?: string;
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+    };
+    expect(packageJson.type).toBeUndefined();
+    expect(packageJson.scripts.start).toBe('react-scripts start');
+    expect(packageJson.devDependencies['react-scripts']).toBe('latest');
   });
 
   it('preserves dependency overrides, extra files, and HTML head markup', () => {
@@ -52,6 +60,19 @@ describe('createCodeSandbox', () => {
 
     expect(packageJson.dependencies['some-library']).toBe('^2.0.0');
     expect(files['public/demo.css'].content).toContain('margin');
-    expect(files['index.html'].content).toContain('/demo.css');
+    expect(files['public/index.html'].content).toContain('/demo.css');
+  });
+
+  it('renames an index demo to App and selects the demo source', () => {
+    const { formData } = createCodeSandbox({
+      title: 'Demo',
+      files: { 'index.tsx': 'export default function Demo() { return null; }' },
+      entryFileName: 'index.tsx',
+    });
+    const files = decodeParameters(formData.parameters);
+
+    expect(formData.query).toBe('file=src/App.tsx');
+    expect(files['src/App.tsx'].content).toContain('function Demo');
+    expect(files['src/index.tsx'].content).toContain("import App from './App';");
   });
 });

--- a/packages/docs-infra/src/lite/runtime/createCodeSandbox.ts
+++ b/packages/docs-infra/src/lite/runtime/createCodeSandbox.ts
@@ -1,0 +1,52 @@
+import LZString from 'lz-string';
+import { createSandboxFileSystem } from './createSandboxFileSystem';
+import type { CreateSandboxFileSystemOptions } from './createSandboxFileSystem';
+
+export type CreateCodeSandboxOptions = CreateSandboxFileSystemOptions;
+
+export interface CodeSandboxProject {
+  url: string;
+  formData: Record<string, string>;
+}
+
+function compress(value: object): string {
+  return LZString.compressToBase64(JSON.stringify(value))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replace(/=+$/, '');
+}
+
+/** Builds a CodeSandbox Define API payload for a demo. */
+export function createCodeSandbox(options: CreateCodeSandboxOptions): CodeSandboxProject {
+  const files = Object.fromEntries(
+    Object.entries(createSandboxFileSystem(options)).map(([fileName, content]) => [
+      fileName,
+      { content },
+    ]),
+  );
+  return {
+    url: 'https://codesandbox.io/api/v1/sandboxes/define',
+    formData: {
+      parameters: compress({ files }),
+      query: `file=src/${options.entryFileName}`,
+    },
+  };
+}
+
+/** Opens a CodeSandbox project with a browser form POST. */
+export function openCodeSandbox({ url, formData }: CodeSandboxProject): void {
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.target = '_blank';
+  form.action = url;
+  for (const [name, value] of Object.entries(formData)) {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  document.body.appendChild(form);
+  form.submit();
+  form.remove();
+}

--- a/packages/docs-infra/src/lite/runtime/createCodeSandbox.ts
+++ b/packages/docs-infra/src/lite/runtime/createCodeSandbox.ts
@@ -1,5 +1,5 @@
 import LZString from 'lz-string';
-import { createSandboxFileSystem } from './createSandboxFileSystem';
+import { createCodeSandboxFileSystem } from './createCodeSandboxFileSystem';
 import type { CreateSandboxFileSystemOptions } from './createSandboxFileSystem';
 
 export type CreateCodeSandboxOptions = CreateSandboxFileSystemOptions;
@@ -18,17 +18,15 @@ function compress(value: object): string {
 
 /** Builds a CodeSandbox Define API payload for a demo. */
 export function createCodeSandbox(options: CreateCodeSandboxOptions): CodeSandboxProject {
+  const { fileSystem, rootFile } = createCodeSandboxFileSystem(options);
   const files = Object.fromEntries(
-    Object.entries(createSandboxFileSystem(options)).map(([fileName, content]) => [
-      fileName,
-      { content },
-    ]),
+    Object.entries(fileSystem).map(([fileName, content]) => [fileName, { content }]),
   );
   return {
     url: 'https://codesandbox.io/api/v1/sandboxes/define',
     formData: {
       parameters: compress({ files }),
-      query: `file=src/${options.entryFileName}`,
+      query: `file=${rootFile}`,
     },
   };
 }

--- a/packages/docs-infra/src/lite/runtime/createCodeSandboxFileSystem.ts
+++ b/packages/docs-infra/src/lite/runtime/createCodeSandboxFileSystem.ts
@@ -1,0 +1,152 @@
+import { collectSandboxPackages } from './createSandboxFileSystem';
+import type { CreateSandboxFileSystemOptions, SandboxFileSystem } from './createSandboxFileSystem';
+
+const JS_FILES = /\.(tsx|ts|jsx|js)$/;
+const TS_FILES = /\.(tsx|ts)$/;
+
+function escapeHtml(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('"', '&quot;');
+}
+
+function htmlTemplate(
+  title: string,
+  description: string | undefined,
+  htmlHead: string | undefined,
+): string {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '  <head>',
+    '    <meta charset="utf-8" />',
+    `    <title>${escapeHtml(title)}</title>`,
+    ...(description
+      ? [`    <meta name="description" content="${escapeHtml(description)}" />`]
+      : []),
+    '    <meta name="viewport" content="initial-scale=1, width=device-width" />',
+    ...(htmlHead ? htmlHead.split('\n').map((line) => `    ${line}`) : []),
+    '  </head>',
+    '  <body>',
+    '    <div id="root"></div>',
+    '  </body>',
+    '</html>',
+    '',
+  ].join('\n');
+}
+
+function sourceFileName(options: CreateSandboxFileSystemOptions, useTypescript: boolean): string {
+  const { entryFileName, files } = options;
+  const extension = useTypescript ? 'tsx' : 'jsx';
+  if (entryFileName !== `index.${extension}`) {
+    return entryFileName;
+  }
+  const candidates = [`App.${extension}`, `entrypoint.${extension}`, `main.${extension}`];
+  return (
+    candidates.find((candidate) => files[candidate] === undefined) ?? `index-entry.${extension}`
+  );
+}
+
+function rootIndexTemplate(sourceFile: string, exportName: string, useTypescript: boolean): string {
+  const modulePath = `./${sourceFile.replace(JS_FILES, '')}`;
+  const demoImport =
+    exportName === 'default'
+      ? `import App from '${modulePath}';`
+      : `import { ${exportName} as App } from '${modulePath}';`;
+  return [
+    "import * as React from 'react';",
+    "import * as ReactDOM from 'react-dom/client';",
+    demoImport,
+    '',
+    `ReactDOM.createRoot(document.getElementById('root')${useTypescript ? '!' : ''}).render(`,
+    '  <React.StrictMode>',
+    '    <App />',
+    '  </React.StrictMode>,',
+    ');',
+    '',
+  ].join('\n');
+}
+
+/** Builds the Create React App filesystem used by CodeSandbox. */
+export function createCodeSandboxFileSystem(options: CreateSandboxFileSystemOptions): {
+  fileSystem: SandboxFileSystem;
+  rootFile: string;
+} {
+  const { title, description, files, exportName = 'default' } = options;
+  const useTypescript = Object.keys(files).some((fileName) => TS_FILES.test(fileName));
+  const extension = useTypescript ? 'tsx' : 'jsx';
+  const sourceFile = sourceFileName(options, useTypescript);
+  const detected = Object.fromEntries(
+    collectSandboxPackages(files)
+      .filter((name) => name !== 'react' && name !== 'react-dom')
+      .map((name) => [name, 'latest']),
+  );
+  const packageJson = {
+    private: true,
+    name: title.toLowerCase().replace(/[^a-z0-9]/g, '-'),
+    version: '0.0.0',
+    description,
+    scripts: {
+      start: 'react-scripts start',
+      build: 'react-scripts build',
+      test: 'react-scripts test',
+      eject: 'react-scripts eject',
+    },
+    dependencies: {
+      react: '^19',
+      'react-dom': '^19',
+      ...detected,
+      ...options.dependencies,
+    },
+    devDependencies: {
+      'react-scripts': 'latest',
+      ...(useTypescript
+        ? {
+            typescript: 'latest',
+            '@types/react': '^19',
+            '@types/react-dom': '^19',
+          }
+        : {}),
+    },
+  };
+  const fileSystem: SandboxFileSystem = {
+    'package.json': `${JSON.stringify(packageJson, null, 2)}\n`,
+    'public/index.html': htmlTemplate(title, description, options.htmlHead),
+    ...(useTypescript
+      ? {
+          'tsconfig.json': `${JSON.stringify(
+            {
+              compilerOptions: {
+                target: 'ES2020',
+                useDefineForClassFields: true,
+                lib: ['ES2020', 'DOM', 'DOM.Iterable'],
+                module: 'ESNext',
+                skipLibCheck: true,
+                moduleResolution: 'node',
+                allowImportingTsExtensions: true,
+                resolveJsonModule: true,
+                isolatedModules: true,
+                noEmit: true,
+                jsx: 'react',
+                strict: true,
+                noUnusedLocals: true,
+                noUnusedParameters: true,
+                noFallthroughCasesInSwitch: true,
+                allowJs: true,
+                esModuleInterop: true,
+                allowSyntheticDefaultImports: true,
+                forceConsistentCasingInFileNames: true,
+              },
+              include: ['src'],
+            },
+            null,
+            2,
+          )}\n`,
+        }
+      : {}),
+  };
+  for (const [fileName, source] of Object.entries(files)) {
+    fileSystem[`src/${fileName === options.entryFileName ? sourceFile : fileName}`] = source;
+  }
+  fileSystem[`src/index.${extension}`] = rootIndexTemplate(sourceFile, exportName, useTypescript);
+  Object.assign(fileSystem, options.extraFiles);
+  return { fileSystem, rootFile: `src/${sourceFile}` };
+}

--- a/packages/docs-infra/src/lite/runtime/createSandboxFileSystem.test.ts
+++ b/packages/docs-infra/src/lite/runtime/createSandboxFileSystem.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createSandboxFileSystem } from './createSandboxFileSystem';
+
+describe('createSandboxFileSystem', () => {
+  it('builds a path-to-content mapping for a Vite React project', () => {
+    const files = createSandboxFileSystem({
+      title: 'Button Demo',
+      files: {
+        'Button.tsx': "import { Button } from 'some-library'; export default Button;",
+      },
+      entryFileName: 'Button.tsx',
+      dependencies: { 'some-library': '^2.0.0' },
+      extraFiles: { 'public/demo.css': 'body { margin: 0; }' },
+      htmlHead: '<link rel="stylesheet" href="/demo.css" />',
+    });
+    const packageJson = JSON.parse(files['package.json']) as {
+      dependencies: Record<string, string>;
+    };
+
+    expect(Object.keys(files)).toMatchInlineSnapshot(`
+      [
+        "package.json",
+        "index.html",
+        "vite.config.ts",
+        "tsconfig.json",
+        "src/main.tsx",
+        "src/Button.tsx",
+        "public/demo.css",
+      ]
+    `);
+    expect(files['src/main.tsx']).toContain("import Demo from './Button';");
+    expect(files['index.html']).toContain('/demo.css');
+    expect(packageJson.dependencies['some-library']).toBe('^2.0.0');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/createSandboxFileSystem.ts
+++ b/packages/docs-infra/src/lite/runtime/createSandboxFileSystem.ts
@@ -1,0 +1,174 @@
+export type SandboxFileSystem = Record<string, string>;
+
+export interface CreateSandboxFileSystemOptions {
+  title: string;
+  description?: string;
+  files: SandboxFileSystem;
+  entryFileName: string;
+  exportName?: string;
+  dependencies?: Record<string, string>;
+  extraFiles?: SandboxFileSystem;
+  htmlHead?: string;
+}
+
+const JS_FILES = /\.(tsx|ts|jsx|js)$/;
+const TS_FILES = /\.(tsx|ts)$/;
+const IMPORT_SPECIFIERS =
+  /\bimport\s+['"]([^'"]+)['"]|\bfrom\s+['"]([^'"]+)['"]|\bimport\(\s*['"]([^'"]+)['"]/g;
+
+function toPackageName(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.includes(':')) {
+    return null;
+  }
+  const [first, second] = specifier.split('/');
+  if (first.startsWith('@')) {
+    return second && first.length > 1 ? `${first}/${second}` : null;
+  }
+  return first || null;
+}
+
+function collectPackages(files: SandboxFileSystem): string[] {
+  const packages = new Set<string>();
+  for (const [fileName, source] of Object.entries(files)) {
+    if (!JS_FILES.test(fileName)) {
+      continue;
+    }
+    for (const match of source.matchAll(IMPORT_SPECIFIERS)) {
+      const packageName = toPackageName(match[1] ?? match[2] ?? match[3] ?? '');
+      if (packageName) {
+        packages.add(packageName);
+      }
+    }
+  }
+  return [...packages].sort();
+}
+
+function escapeHtml(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('"', '&quot;');
+}
+
+function htmlTemplate(
+  title: string,
+  description: string | undefined,
+  mainFile: string,
+  htmlHead: string | undefined,
+): string {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '  <head>',
+    '    <meta charset="utf-8" />',
+    `    <title>${escapeHtml(title)}</title>`,
+    ...(description
+      ? [`    <meta name="description" content="${escapeHtml(description)}" />`]
+      : []),
+    '    <meta name="viewport" content="initial-scale=1, width=device-width" />',
+    ...(htmlHead ? htmlHead.split('\n').map((line) => `    ${line}`) : []),
+    '  </head>',
+    '  <body>',
+    '    <div id="root"></div>',
+    `    <script type="module" src="/src/${mainFile}"></script>`,
+    '  </body>',
+    '</html>',
+    '',
+  ].join('\n');
+}
+
+function mainTemplate(entryFileName: string, exportName: string, useTypescript: boolean): string {
+  const modulePath = `./${entryFileName.replace(JS_FILES, '')}`;
+  const demoImport =
+    exportName === 'default'
+      ? `import Demo from '${modulePath}';`
+      : `import { ${exportName} as Demo } from '${modulePath}';`;
+  return [
+    "import * as React from 'react';",
+    "import { createRoot } from 'react-dom/client';",
+    demoImport,
+    '',
+    `createRoot(document.getElementById('root')${useTypescript ? '!' : ''}).render(`,
+    '  <React.StrictMode>',
+    '    <Demo />',
+    '  </React.StrictMode>,',
+    ');',
+    '',
+  ].join('\n');
+}
+
+const VITE_CONFIG = [
+  "import { defineConfig } from 'vite';",
+  "import react from '@vitejs/plugin-react';",
+  '',
+  'export default defineConfig({',
+  '  plugins: [react()],',
+  '});',
+  '',
+].join('\n');
+
+const TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2022',
+    lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    jsx: 'react-jsx',
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  },
+  include: ['src'],
+};
+
+/** Builds a path-to-content mapping for a Vite React demo project. */
+export function createSandboxFileSystem(
+  options: CreateSandboxFileSystemOptions,
+): SandboxFileSystem {
+  const { title, description, files, entryFileName, exportName = 'default' } = options;
+  const useTypescript = Object.keys(files).some((fileName) => TS_FILES.test(fileName));
+  const extension = useTypescript ? 'tsx' : 'jsx';
+  const mainFile = `main.${extension}` in files ? `bootstrap.${extension}` : `main.${extension}`;
+  const detected = Object.fromEntries(
+    collectPackages(files)
+      .filter((name) => name !== 'react' && name !== 'react-dom')
+      .map((name) => [name, 'latest']),
+  );
+  const packageJson = {
+    name:
+      title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '') || 'demo',
+    private: true,
+    version: '0.0.0',
+    type: 'module',
+    scripts: { dev: 'vite', build: 'vite build', preview: 'vite preview' },
+    dependencies: {
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      ...detected,
+      ...options.dependencies,
+    },
+    devDependencies: {
+      vite: 'latest',
+      '@vitejs/plugin-react': 'latest',
+      ...(useTypescript
+        ? {
+            typescript: 'latest',
+            '@types/react': '^19.0.0',
+            '@types/react-dom': '^19.0.0',
+          }
+        : {}),
+    },
+  };
+  const fileSystem: SandboxFileSystem = {
+    'package.json': `${JSON.stringify(packageJson, null, 2)}\n`,
+    'index.html': htmlTemplate(title, description, mainFile, options.htmlHead),
+    [`vite.config.${useTypescript ? 'ts' : 'js'}`]: VITE_CONFIG,
+    ...(useTypescript ? { 'tsconfig.json': `${JSON.stringify(TSCONFIG, null, 2)}\n` } : {}),
+    [`src/${mainFile}`]: mainTemplate(entryFileName, exportName, useTypescript),
+  };
+  for (const [fileName, source] of Object.entries(files)) {
+    fileSystem[`src/${fileName}`] = source;
+  }
+  Object.assign(fileSystem, options.extraFiles);
+  return fileSystem;
+}

--- a/packages/docs-infra/src/lite/runtime/createSandboxFileSystem.ts
+++ b/packages/docs-infra/src/lite/runtime/createSandboxFileSystem.ts
@@ -27,7 +27,7 @@ function toPackageName(specifier: string): string | null {
   return first || null;
 }
 
-function collectPackages(files: SandboxFileSystem): string[] {
+export function collectSandboxPackages(files: SandboxFileSystem): string[] {
   const packages = new Set<string>();
   for (const [fileName, source] of Object.entries(files)) {
     if (!JS_FILES.test(fileName)) {
@@ -127,7 +127,7 @@ export function createSandboxFileSystem(
   const extension = useTypescript ? 'tsx' : 'jsx';
   const mainFile = `main.${extension}` in files ? `bootstrap.${extension}` : `main.${extension}`;
   const detected = Object.fromEntries(
-    collectPackages(files)
+    collectSandboxPackages(files)
       .filter((name) => name !== 'react' && name !== 'react-dom')
       .map((name) => [name, 'latest']),
   );

--- a/packages/docs-infra/src/lite/runtime/createStackBlitz.test.ts
+++ b/packages/docs-infra/src/lite/runtime/createStackBlitz.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { createStackBlitz } from './createStackBlitz';
+
+const BUTTON_SOURCE = [
+  "import * as React from 'react';",
+  '',
+  'export default function Button() {',
+  '  return <button type="button">Click</button>;',
+  '}',
+  '',
+].join('\n');
+
+interface PackageJsonShape {
+  name: string;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+}
+
+function packageJsonOf(formData: Record<string, string>): PackageJsonShape {
+  return JSON.parse(formData['project[files][package.json]']) as PackageJsonShape;
+}
+
+describe('createStackBlitz', () => {
+  it('wraps a TypeScript demo in a Vite project', () => {
+    const { url, formData } = createStackBlitz({
+      title: 'Button',
+      files: { 'Button.tsx': BUTTON_SOURCE },
+      entryFileName: 'Button.tsx',
+    });
+    expect(url).toBe('https://stackblitz.com/run?file=src/Button.tsx');
+    expect(Object.keys(formData).filter((key) => key.startsWith('project[files]')))
+      .toMatchInlineSnapshot(`
+      [
+        "project[files][package.json]",
+        "project[files][index.html]",
+        "project[files][vite.config.ts]",
+        "project[files][tsconfig.json]",
+        "project[files][src/main.tsx]",
+        "project[files][src/Button.tsx]",
+      ]
+    `);
+    expect(formData['project[files][src/main.tsx]']).toContain("import Demo from './Button';");
+  });
+
+  it('bootstraps named exports and JavaScript-only demos', () => {
+    const { formData } = createStackBlitz({
+      title: 'Toggle',
+      files: { 'Toggle.jsx': 'export function Toggle() { return null; }\n' },
+      entryFileName: 'Toggle.jsx',
+      exportName: 'Toggle',
+    });
+    expect(formData['project[files][src/main.jsx]']).toContain(
+      "import { Toggle as Demo } from './Toggle';",
+    );
+    expect(formData['project[files][vite.config.js]']).toBeDefined();
+    expect(formData['project[files][tsconfig.json]']).toBeUndefined();
+  });
+
+  it('adds package imports and applies dependency overrides', () => {
+    const { formData } = createStackBlitz({
+      title: 'Demo',
+      files: {
+        'Demo.tsx': [
+          "import * as React from 'react';",
+          "import { thing } from 'some-library/subpath';",
+          "import { widget } from '@scope/widgets/button';",
+          "import './styles.css';",
+          'export default thing;',
+        ].join('\n'),
+      },
+      entryFileName: 'Demo.tsx',
+      dependencies: { 'some-library': '^2.0.0', extra: '^1.0.0' },
+    });
+    expect(packageJsonOf(formData).dependencies).toMatchObject({
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      '@scope/widgets': 'latest',
+      'some-library': '^2.0.0',
+      extra: '^1.0.0',
+    });
+  });
+
+  it('merges extra files and head markup into the scaffold', () => {
+    const { formData } = createStackBlitz({
+      title: 'Button',
+      description: 'A button demo',
+      files: { 'Button.tsx': BUTTON_SOURCE },
+      entryFileName: 'Button.tsx',
+      extraFiles: { 'public/demo.css': 'body { margin: 0; }\n' },
+      htmlHead: '<link rel="stylesheet" href="/demo.css" />',
+    });
+    expect(formData['project[files][public/demo.css]']).toContain('margin');
+    expect(formData['project[files][index.html]']).toContain('/demo.css');
+    expect(packageJsonOf(formData).name).toBe('button');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/createStackBlitz.ts
+++ b/packages/docs-infra/src/lite/runtime/createStackBlitz.ts
@@ -1,188 +1,27 @@
+import { createSandboxFileSystem } from './createSandboxFileSystem';
+import type { CreateSandboxFileSystemOptions } from './createSandboxFileSystem';
+
+export type CreateStackBlitzOptions = CreateSandboxFileSystemOptions;
+
 export interface StackBlitzProject {
   url: string;
   formData: Record<string, string>;
 }
 
-export interface CreateStackBlitzOptions {
-  title: string;
-  description?: string;
-  files: Record<string, string>;
-  entryFileName: string;
-  exportName?: string;
-  dependencies?: Record<string, string>;
-  extraFiles?: Record<string, string>;
-  htmlHead?: string;
-}
-
-const JS_FILES = /\.(tsx|ts|jsx|js)$/;
-const TS_FILES = /\.(tsx|ts)$/;
-const IMPORT_SPECIFIERS =
-  /\bimport\s+['"]([^'"]+)['"]|\bfrom\s+['"]([^'"]+)['"]|\bimport\(\s*['"]([^'"]+)['"]/g;
-
-function toPackageName(specifier: string): string | null {
-  if (specifier.startsWith('.') || specifier.includes(':')) {
-    return null;
-  }
-  const [first, second] = specifier.split('/');
-  if (first.startsWith('@')) {
-    return second && first.length > 1 ? `${first}/${second}` : null;
-  }
-  return first || null;
-}
-
-function collectPackages(files: Record<string, string>): string[] {
-  const packages = new Set<string>();
-  for (const [fileName, source] of Object.entries(files)) {
-    if (!JS_FILES.test(fileName)) {
-      continue;
-    }
-    for (const match of source.matchAll(IMPORT_SPECIFIERS)) {
-      const packageName = toPackageName(match[1] ?? match[2] ?? match[3] ?? '');
-      if (packageName) {
-        packages.add(packageName);
-      }
-    }
-  }
-  return [...packages].sort();
-}
-
-function escapeHtml(text: string): string {
-  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('"', '&quot;');
-}
-
-function htmlTemplate(
-  title: string,
-  description: string | undefined,
-  mainFile: string,
-  htmlHead: string | undefined,
-): string {
-  return [
-    '<!doctype html>',
-    '<html lang="en">',
-    '  <head>',
-    '    <meta charset="utf-8" />',
-    `    <title>${escapeHtml(title)}</title>`,
-    ...(description
-      ? [`    <meta name="description" content="${escapeHtml(description)}" />`]
-      : []),
-    '    <meta name="viewport" content="initial-scale=1, width=device-width" />',
-    ...(htmlHead ? htmlHead.split('\n').map((line) => `    ${line}`) : []),
-    '  </head>',
-    '  <body>',
-    '    <div id="root"></div>',
-    `    <script type="module" src="/src/${mainFile}"></script>`,
-    '  </body>',
-    '</html>',
-    '',
-  ].join('\n');
-}
-
-function mainTemplate(entryFileName: string, exportName: string, useTypescript: boolean): string {
-  const modulePath = `./${entryFileName.replace(JS_FILES, '')}`;
-  const demoImport =
-    exportName === 'default'
-      ? `import Demo from '${modulePath}';`
-      : `import { ${exportName} as Demo } from '${modulePath}';`;
-  return [
-    "import * as React from 'react';",
-    "import { createRoot } from 'react-dom/client';",
-    demoImport,
-    '',
-    `createRoot(document.getElementById('root')${useTypescript ? '!' : ''}).render(`,
-    '  <React.StrictMode>',
-    '    <Demo />',
-    '  </React.StrictMode>,',
-    ');',
-    '',
-  ].join('\n');
-}
-
-const VITE_CONFIG = [
-  "import { defineConfig } from 'vite';",
-  "import react from '@vitejs/plugin-react';",
-  '',
-  'export default defineConfig({',
-  '  plugins: [react()],',
-  '});',
-  '',
-].join('\n');
-
-const TSCONFIG = {
-  compilerOptions: {
-    target: 'ES2022',
-    lib: ['ES2022', 'DOM', 'DOM.Iterable'],
-    module: 'ESNext',
-    moduleResolution: 'bundler',
-    jsx: 'react-jsx',
-    strict: true,
-    skipLibCheck: true,
-    noEmit: true,
-  },
-  include: ['src'],
-};
-
-/** Builds a StackBlitz Vite + React project form payload for a demo. */
+/** Builds a StackBlitz form payload from a sandbox file system. */
 export function createStackBlitz(options: CreateStackBlitzOptions): StackBlitzProject {
-  const { title, description, files, entryFileName, exportName = 'default' } = options;
-  const useTypescript = Object.keys(files).some((fileName) => TS_FILES.test(fileName));
-  const extension = useTypescript ? 'tsx' : 'jsx';
-  const mainFile = `main.${extension}` in files ? `bootstrap.${extension}` : `main.${extension}`;
-
-  const detected = Object.fromEntries(
-    collectPackages(files)
-      .filter((name) => name !== 'react' && name !== 'react-dom')
-      .map((name) => [name, 'latest']),
-  );
-  const packageJson = {
-    name:
-      title
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '') || 'demo',
-    private: true,
-    version: '0.0.0',
-    type: 'module',
-    scripts: { dev: 'vite', build: 'vite build', preview: 'vite preview' },
-    dependencies: {
-      react: '^19.0.0',
-      'react-dom': '^19.0.0',
-      ...detected,
-      ...options.dependencies,
-    },
-    devDependencies: {
-      vite: 'latest',
-      '@vitejs/plugin-react': 'latest',
-      ...(useTypescript
-        ? {
-            typescript: 'latest',
-            '@types/react': '^19.0.0',
-            '@types/react-dom': '^19.0.0',
-          }
-        : {}),
-    },
-  };
-
-  const projectFiles: Record<string, string> = {
-    'package.json': `${JSON.stringify(packageJson, null, 2)}\n`,
-    'index.html': htmlTemplate(title, description, mainFile, options.htmlHead),
-    [`vite.config.${useTypescript ? 'ts' : 'js'}`]: VITE_CONFIG,
-    ...(useTypescript ? { 'tsconfig.json': `${JSON.stringify(TSCONFIG, null, 2)}\n` } : {}),
-    [`src/${mainFile}`]: mainTemplate(entryFileName, exportName, useTypescript),
-  };
-  for (const [fileName, source] of Object.entries(files)) {
-    projectFiles[`src/${fileName}`] = source;
-  }
-  Object.assign(projectFiles, options.extraFiles);
-
   const formData: Record<string, string> = {
     'project[template]': 'node',
-    'project[title]': title,
-    ...(description ? { 'project[description]': description } : {}),
+    'project[title]': options.title,
+    ...(options.description ? { 'project[description]': options.description } : {}),
   };
-  for (const [fileName, source] of Object.entries(projectFiles)) {
+  for (const [fileName, source] of Object.entries(createSandboxFileSystem(options))) {
     formData[`project[files][${fileName}]`] = source;
   }
-  return { url: `https://stackblitz.com/run?file=src/${entryFileName}`, formData };
+  return {
+    url: `https://stackblitz.com/run?file=src/${options.entryFileName}`,
+    formData,
+  };
 }
 
 /** Opens a StackBlitz project with a browser form POST. */

--- a/packages/docs-infra/src/lite/runtime/createStackBlitz.ts
+++ b/packages/docs-infra/src/lite/runtime/createStackBlitz.ts
@@ -1,0 +1,204 @@
+export interface StackBlitzProject {
+  url: string;
+  formData: Record<string, string>;
+}
+
+export interface CreateStackBlitzOptions {
+  title: string;
+  description?: string;
+  files: Record<string, string>;
+  entryFileName: string;
+  exportName?: string;
+  dependencies?: Record<string, string>;
+  extraFiles?: Record<string, string>;
+  htmlHead?: string;
+}
+
+const JS_FILES = /\.(tsx|ts|jsx|js)$/;
+const TS_FILES = /\.(tsx|ts)$/;
+const IMPORT_SPECIFIERS =
+  /\bimport\s+['"]([^'"]+)['"]|\bfrom\s+['"]([^'"]+)['"]|\bimport\(\s*['"]([^'"]+)['"]/g;
+
+function toPackageName(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.includes(':')) {
+    return null;
+  }
+  const [first, second] = specifier.split('/');
+  if (first.startsWith('@')) {
+    return second && first.length > 1 ? `${first}/${second}` : null;
+  }
+  return first || null;
+}
+
+function collectPackages(files: Record<string, string>): string[] {
+  const packages = new Set<string>();
+  for (const [fileName, source] of Object.entries(files)) {
+    if (!JS_FILES.test(fileName)) {
+      continue;
+    }
+    for (const match of source.matchAll(IMPORT_SPECIFIERS)) {
+      const packageName = toPackageName(match[1] ?? match[2] ?? match[3] ?? '');
+      if (packageName) {
+        packages.add(packageName);
+      }
+    }
+  }
+  return [...packages].sort();
+}
+
+function escapeHtml(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('"', '&quot;');
+}
+
+function htmlTemplate(
+  title: string,
+  description: string | undefined,
+  mainFile: string,
+  htmlHead: string | undefined,
+): string {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '  <head>',
+    '    <meta charset="utf-8" />',
+    `    <title>${escapeHtml(title)}</title>`,
+    ...(description
+      ? [`    <meta name="description" content="${escapeHtml(description)}" />`]
+      : []),
+    '    <meta name="viewport" content="initial-scale=1, width=device-width" />',
+    ...(htmlHead ? htmlHead.split('\n').map((line) => `    ${line}`) : []),
+    '  </head>',
+    '  <body>',
+    '    <div id="root"></div>',
+    `    <script type="module" src="/src/${mainFile}"></script>`,
+    '  </body>',
+    '</html>',
+    '',
+  ].join('\n');
+}
+
+function mainTemplate(entryFileName: string, exportName: string, useTypescript: boolean): string {
+  const modulePath = `./${entryFileName.replace(JS_FILES, '')}`;
+  const demoImport =
+    exportName === 'default'
+      ? `import Demo from '${modulePath}';`
+      : `import { ${exportName} as Demo } from '${modulePath}';`;
+  return [
+    "import * as React from 'react';",
+    "import { createRoot } from 'react-dom/client';",
+    demoImport,
+    '',
+    `createRoot(document.getElementById('root')${useTypescript ? '!' : ''}).render(`,
+    '  <React.StrictMode>',
+    '    <Demo />',
+    '  </React.StrictMode>,',
+    ');',
+    '',
+  ].join('\n');
+}
+
+const VITE_CONFIG = [
+  "import { defineConfig } from 'vite';",
+  "import react from '@vitejs/plugin-react';",
+  '',
+  'export default defineConfig({',
+  '  plugins: [react()],',
+  '});',
+  '',
+].join('\n');
+
+const TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2022',
+    lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+    module: 'ESNext',
+    moduleResolution: 'bundler',
+    jsx: 'react-jsx',
+    strict: true,
+    skipLibCheck: true,
+    noEmit: true,
+  },
+  include: ['src'],
+};
+
+/** Builds a StackBlitz Vite + React project form payload for a demo. */
+export function createStackBlitz(options: CreateStackBlitzOptions): StackBlitzProject {
+  const { title, description, files, entryFileName, exportName = 'default' } = options;
+  const useTypescript = Object.keys(files).some((fileName) => TS_FILES.test(fileName));
+  const extension = useTypescript ? 'tsx' : 'jsx';
+  const mainFile = `main.${extension}` in files ? `bootstrap.${extension}` : `main.${extension}`;
+
+  const detected = Object.fromEntries(
+    collectPackages(files)
+      .filter((name) => name !== 'react' && name !== 'react-dom')
+      .map((name) => [name, 'latest']),
+  );
+  const packageJson = {
+    name:
+      title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '') || 'demo',
+    private: true,
+    version: '0.0.0',
+    type: 'module',
+    scripts: { dev: 'vite', build: 'vite build', preview: 'vite preview' },
+    dependencies: {
+      react: '^19.0.0',
+      'react-dom': '^19.0.0',
+      ...detected,
+      ...options.dependencies,
+    },
+    devDependencies: {
+      vite: 'latest',
+      '@vitejs/plugin-react': 'latest',
+      ...(useTypescript
+        ? {
+            typescript: 'latest',
+            '@types/react': '^19.0.0',
+            '@types/react-dom': '^19.0.0',
+          }
+        : {}),
+    },
+  };
+
+  const projectFiles: Record<string, string> = {
+    'package.json': `${JSON.stringify(packageJson, null, 2)}\n`,
+    'index.html': htmlTemplate(title, description, mainFile, options.htmlHead),
+    [`vite.config.${useTypescript ? 'ts' : 'js'}`]: VITE_CONFIG,
+    ...(useTypescript ? { 'tsconfig.json': `${JSON.stringify(TSCONFIG, null, 2)}\n` } : {}),
+    [`src/${mainFile}`]: mainTemplate(entryFileName, exportName, useTypescript),
+  };
+  for (const [fileName, source] of Object.entries(files)) {
+    projectFiles[`src/${fileName}`] = source;
+  }
+  Object.assign(projectFiles, options.extraFiles);
+
+  const formData: Record<string, string> = {
+    'project[template]': 'node',
+    'project[title]': title,
+    ...(description ? { 'project[description]': description } : {}),
+  };
+  for (const [fileName, source] of Object.entries(projectFiles)) {
+    formData[`project[files][${fileName}]`] = source;
+  }
+  return { url: `https://stackblitz.com/run?file=src/${entryFileName}`, formData };
+}
+
+/** Opens a StackBlitz project with a browser form POST. */
+export function openStackBlitz({ url, formData }: StackBlitzProject): void {
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.target = '_blank';
+  form.action = url;
+  for (const [name, value] of Object.entries(formData)) {
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = value;
+    form.appendChild(input);
+  }
+  document.body.appendChild(form);
+  form.submit();
+  form.remove();
+}

--- a/packages/docs-infra/src/lite/runtime/generateFileSlug.test.ts
+++ b/packages/docs-infra/src/lite/runtime/generateFileSlug.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { toKebabCase, generateFileSlug } from './generateFileSlug';
+
+describe('toKebabCase', () => {
+  it('normalizes component and file names', () => {
+    expect(toKebabCase('myComponent')).toBe('my-component');
+    expect(toKebabCase('Some Name_here')).toBe('some-name-here');
+    expect(toKebabCase('file.name')).toBe('file.name');
+    expect(toKebabCase('__weird__')).toBe('weird');
+  });
+});
+
+describe('generateFileSlug', () => {
+  it('preserves extensions and adds non-default variants', () => {
+    expect(generateFileSlug('demo', 'MyComponent.tsx', 'Default')).toBe('demo:my-component.tsx');
+    expect(generateFileSlug('demo', 'MyComponent.tsx', 'DarkMode')).toBe(
+      'demo:dark-mode:my-component.tsx',
+    );
+    expect(generateFileSlug('', 'MyComponent.tsx', 'DarkMode')).toBe('my-component.tsx');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/generateFileSlug.ts
+++ b/packages/docs-infra/src/lite/runtime/generateFileSlug.ts
@@ -1,0 +1,22 @@
+export function toKebabCase(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Generates a stable variant/file anchor slug. */
+export function generateFileSlug(mainSlug: string, fileName: string, variantName: string): string {
+  const lastDotIndex = fileName.lastIndexOf('.');
+  const baseName = lastDotIndex !== -1 ? fileName.slice(0, lastDotIndex) : fileName;
+  const extension = lastDotIndex !== -1 ? fileName.slice(lastDotIndex) : '';
+  const kebabFileName = `${toKebabCase(baseName)}${extension}`;
+  if (!mainSlug) {
+    return kebabFileName;
+  }
+  if (variantName === 'Default') {
+    return `${mainSlug}:${kebabFileName}`;
+  }
+  return `${mainSlug}:${toKebabCase(variantName)}:${kebabFileName}`;
+}

--- a/packages/docs-infra/src/lite/runtime/index.ts
+++ b/packages/docs-infra/src/lite/runtime/index.ts
@@ -1,0 +1,26 @@
+export {
+  createDemoFactory,
+  createDemoWithVariantsFactory,
+  type CreateDemoConfig,
+  type DemoComponent,
+  type DemoComponentProps,
+} from './abstractCreateDemo';
+export { CodeHighlighter } from './CodeHighlighter';
+export {
+  createStackBlitz,
+  openStackBlitz,
+  type CreateStackBlitzOptions,
+  type StackBlitzProject,
+} from './createStackBlitz';
+export type {
+  CodeHighlighterProps,
+  CodePrecompute,
+  ContentProps,
+  DeferredSources,
+  DeferredVariant,
+  VariantCode,
+  VariantExtraFile,
+  VariantExtraFiles,
+} from './types';
+export { useDemo, type UseDemoOptions, type UseDemoResult } from './useDemo';
+export { usePreference } from './usePreference';

--- a/packages/docs-infra/src/lite/runtime/index.ts
+++ b/packages/docs-infra/src/lite/runtime/index.ts
@@ -7,6 +7,17 @@ export {
 } from './abstractCreateDemo';
 export { CodeHighlighter } from './CodeHighlighter';
 export {
+  createCodeSandbox,
+  openCodeSandbox,
+  type CodeSandboxProject,
+  type CreateCodeSandboxOptions,
+} from './createCodeSandbox';
+export {
+  createSandboxFileSystem,
+  type CreateSandboxFileSystemOptions,
+  type SandboxFileSystem,
+} from './createSandboxFileSystem';
+export {
   createStackBlitz,
   openStackBlitz,
   type CreateStackBlitzOptions,

--- a/packages/docs-infra/src/lite/runtime/renderCodeToReact.test.tsx
+++ b/packages/docs-infra/src/lite/runtime/renderCodeToReact.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import * as ReactDOMServer from 'react-dom/server';
+import { renderCodeToReact } from './renderCodeToReact';
+
+describe('renderCodeToReact', () => {
+  it('renders variant html inside pre > code with the language class', () => {
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        renderCodeToReact('<span>hello</span>', 'ts', { preClassName: 'my-pre' }),
+      ),
+    ).toMatchInlineSnapshot(
+      `"<pre class="my-pre"><code class="language-ts"><span>hello</span></code></pre>"`,
+    );
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/renderCodeToReact.tsx
+++ b/packages/docs-infra/src/lite/runtime/renderCodeToReact.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import * as React from 'react';
+
+export interface RenderCodeConfig {
+  preClassName?: string;
+}
+
+/** Renders loader output as a `<pre><code>` React node. */
+export function renderCodeToReact(
+  html: string,
+  language: string,
+  { preClassName }: RenderCodeConfig = {},
+): React.ReactNode {
+  return (
+    <pre className={preClassName}>
+      <code
+        className={`language-${language}`}
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </pre>
+  );
+}

--- a/packages/docs-infra/src/lite/runtime/types.ts
+++ b/packages/docs-infra/src/lite/runtime/types.ts
@@ -1,0 +1,47 @@
+import type * as React from 'react';
+
+export interface VariantExtraFile {
+  language: string;
+  totalLines: number;
+}
+
+export type VariantExtraFiles = Record<string, VariantExtraFile>;
+
+export interface VariantCode {
+  fileName: string;
+  exportName: string;
+  html: string;
+  language: string;
+  totalLines: number;
+  extraFiles?: VariantExtraFiles;
+}
+
+export interface CodePrecompute {
+  variants: Record<string, VariantCode>;
+  deferredUrl?: string;
+}
+
+export interface DeferredVariant {
+  source?: string;
+  extraFiles?: Record<string, string>;
+}
+
+export type DeferredSources = Record<string, DeferredVariant>;
+
+export type ContentProps<T extends object = {}> = T & {
+  name: string;
+  slug: string;
+  url: string;
+  code: CodePrecompute;
+  components: Record<string, React.ReactNode>;
+};
+
+export interface CodeHighlighterProps<T extends object = {}> {
+  name: string;
+  slug: string;
+  url: string;
+  precompute: CodePrecompute;
+  components: Record<string, React.ReactNode>;
+  Content: React.ComponentType<ContentProps<T>>;
+  contentProps?: T;
+}

--- a/packages/docs-infra/src/lite/runtime/useDeferredSources.test.tsx
+++ b/packages/docs-infra/src/lite/runtime/useDeferredSources.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDeferredSources } from './useDeferredSources';
+import type { CodePrecompute, DeferredSources } from './types';
+
+function code(deferredUrl: string, html: string): CodePrecompute {
+  return {
+    deferredUrl,
+    variants: {
+      Default: {
+        fileName: 'Demo.tsx',
+        exportName: 'default',
+        html,
+        language: 'tsx',
+        totalLines: 20,
+      },
+    },
+  };
+}
+
+function response(sources: DeferredSources) {
+  return { ok: true, json: () => Promise.resolve(sources) };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useDeferredSources', () => {
+  it('loads new sources when the deferred URL changes', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(response({ Default: { source: '<span>old-full</span>' } }))
+      .mockResolvedValueOnce(response({ Default: { source: '<span>new-full</span>' } }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { result, rerender } = renderHook(({ rawCode }) => useDeferredSources(rawCode), {
+      initialProps: { rawCode: code('/old.json', '<span>old-preview</span>') },
+    });
+
+    await act(() => result.current.loadDeferredSources());
+    expect(result.current.code.variants.Default.html).toContain('old-full');
+
+    rerender({ rawCode: code('/new.json', '<span>new-preview</span>') });
+    expect(result.current.deferredSources).toBeNull();
+    expect(result.current.code.variants.Default.html).toContain('new-preview');
+
+    await act(() => result.current.loadDeferredSources());
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/old.json');
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/new.json');
+    expect(result.current.code.variants.Default.html).toContain('new-full');
+  });
+
+  it('ignores an old request that resolves after the current request', async () => {
+    const oldRequest = deferred<ReturnType<typeof response>>();
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockResolvedValueOnce(response({ Default: { source: '<span>new-full</span>' } }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { result, rerender } = renderHook(({ rawCode }) => useDeferredSources(rawCode), {
+      initialProps: { rawCode: code('/old.json', '<span>old-preview</span>') },
+    });
+
+    let oldLoad!: Promise<DeferredSources | null>;
+    act(() => {
+      oldLoad = result.current.loadDeferredSources();
+    });
+    rerender({ rawCode: code('/new.json', '<span>new-preview</span>') });
+    await act(() => result.current.loadDeferredSources());
+    expect(result.current.code.variants.Default.html).toContain('new-full');
+
+    oldRequest.resolve(response({ Default: { source: '<span>old-full</span>' } }));
+    await act(() => oldLoad);
+    expect(result.current.code.variants.Default.html).toContain('new-full');
+    expect(result.current.code.variants.Default.html).not.toContain('old-full');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/useDeferredSources.ts
+++ b/packages/docs-infra/src/lite/runtime/useDeferredSources.ts
@@ -15,6 +15,17 @@ type RenderableCode = Omit<CodePrecompute, 'variants'> & {
   variants: Record<string, RenderableVariant>;
 };
 
+interface DeferredState {
+  url: string | undefined;
+  sources: DeferredSources | null;
+  error: Error | null;
+}
+
+interface DeferredRequest {
+  url: string;
+  promise: Promise<DeferredSources | null>;
+}
+
 function mergeDeferredSources(code: CodePrecompute, deferred: DeferredSources): RenderableCode {
   const variants: Record<string, RenderableVariant> = {};
   for (const [variantName, variant] of Object.entries(code.variants)) {
@@ -46,38 +57,69 @@ function mergeDeferredSources(code: CodePrecompute, deferred: DeferredSources): 
 export function useDeferredSources(rawCode: CodePrecompute): {
   code: RenderableCode;
   deferredSources: DeferredSources | null;
+  deferredSourcesError: Error | null;
   loadDeferredSources: () => Promise<DeferredSources | null>;
 } {
-  const [deferredSources, setDeferredSources] = React.useState<DeferredSources | null>(null);
   const deferredUrl = rawCode.deferredUrl;
-  const fetchRef = React.useRef<Promise<DeferredSources | null> | null>(null);
+  const [state, setState] = React.useState<DeferredState>({
+    url: deferredUrl,
+    sources: null,
+    error: null,
+  });
+  const requestRef = React.useRef<DeferredRequest | null>(null);
+  const deferredSources = state.url === deferredUrl ? state.sources : null;
+  const deferredSourcesError = state.url === deferredUrl ? state.error : null;
 
   const loadDeferredSources = React.useCallback(async () => {
     if (!deferredUrl) {
       return null;
     }
-    if (!fetchRef.current) {
-      fetchRef.current = (async () => {
-        try {
-          const response = await fetch(deferredUrl);
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-          }
-          const sources = (await response.json()) as DeferredSources;
-          setDeferredSources(sources);
-          return sources;
-        } catch {
-          fetchRef.current = null;
+    if (requestRef.current?.url === deferredUrl) {
+      return requestRef.current.promise;
+    }
+
+    setState({ url: deferredUrl, sources: null, error: null });
+    const request: DeferredRequest = {
+      url: deferredUrl,
+      promise: Promise.resolve(null),
+    };
+    requestRef.current = request;
+    request.promise = (async () => {
+      try {
+        const response = await fetch(deferredUrl);
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const sources = (await response.json()) as DeferredSources;
+        if (requestRef.current !== request) {
           return null;
         }
-      })();
-    }
-    return fetchRef.current;
+        setState({ url: deferredUrl, sources, error: null });
+        return sources;
+      } catch (error) {
+        if (requestRef.current !== request) {
+          return null;
+        }
+        requestRef.current = null;
+        setState({
+          url: deferredUrl,
+          sources: null,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+        return null;
+      }
+    })();
+    return request.promise;
   }, [deferredUrl]);
 
   const code = React.useMemo(
     () => (deferredSources ? mergeDeferredSources(rawCode, deferredSources) : rawCode),
     [rawCode, deferredSources],
   );
-  return { code, deferredSources, loadDeferredSources };
+  return {
+    code,
+    deferredSources,
+    deferredSourcesError,
+    loadDeferredSources,
+  };
 }

--- a/packages/docs-infra/src/lite/runtime/useDeferredSources.ts
+++ b/packages/docs-infra/src/lite/runtime/useDeferredSources.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import * as React from 'react';
+import type { CodePrecompute, DeferredSources, VariantCode, VariantExtraFile } from './types';
+
+interface RenderableExtraFile extends VariantExtraFile {
+  html?: string;
+}
+
+type RenderableVariant = Omit<VariantCode, 'extraFiles'> & {
+  extraFiles?: Record<string, RenderableExtraFile>;
+};
+
+type RenderableCode = Omit<CodePrecompute, 'variants'> & {
+  variants: Record<string, RenderableVariant>;
+};
+
+function mergeDeferredSources(code: CodePrecompute, deferred: DeferredSources): RenderableCode {
+  const variants: Record<string, RenderableVariant> = {};
+  for (const [variantName, variant] of Object.entries(code.variants)) {
+    const deferredVariant = deferred[variantName];
+    variants[variantName] = {
+      ...variant,
+      ...(deferredVariant?.source !== undefined ? { html: deferredVariant.source } : {}),
+      ...(variant.extraFiles
+        ? {
+            extraFiles: Object.fromEntries(
+              Object.entries(variant.extraFiles).map(([fileName, file]) => [
+                fileName,
+                {
+                  ...file,
+                  ...(deferredVariant?.extraFiles?.[fileName] !== undefined
+                    ? { html: deferredVariant.extraFiles[fileName] }
+                    : {}),
+                },
+              ]),
+            ),
+          }
+        : {}),
+    };
+  }
+  return { ...code, variants };
+}
+
+/** Fetches and merges deferred highlighted markup on first use. */
+export function useDeferredSources(rawCode: CodePrecompute): {
+  code: RenderableCode;
+  deferredSources: DeferredSources | null;
+  loadDeferredSources: () => Promise<DeferredSources | null>;
+} {
+  const [deferredSources, setDeferredSources] = React.useState<DeferredSources | null>(null);
+  const deferredUrl = rawCode.deferredUrl;
+  const fetchRef = React.useRef<Promise<DeferredSources | null> | null>(null);
+
+  const loadDeferredSources = React.useCallback(async () => {
+    if (!deferredUrl) {
+      return null;
+    }
+    if (!fetchRef.current) {
+      fetchRef.current = (async () => {
+        try {
+          const response = await fetch(deferredUrl);
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          const sources = (await response.json()) as DeferredSources;
+          setDeferredSources(sources);
+          return sources;
+        } catch {
+          fetchRef.current = null;
+          return null;
+        }
+      })();
+    }
+    return fetchRef.current;
+  }, [deferredUrl]);
+
+  const code = React.useMemo(
+    () => (deferredSources ? mergeDeferredSources(rawCode, deferredSources) : rawCode),
+    [rawCode, deferredSources],
+  );
+  return { code, deferredSources, loadDeferredSources };
+}

--- a/packages/docs-infra/src/lite/runtime/useDemo.test.tsx
+++ b/packages/docs-infra/src/lite/runtime/useDemo.test.tsx
@@ -142,6 +142,40 @@ describe('useDemo', () => {
     expect(onCopied).toHaveBeenCalledOnce();
   });
 
+  it('exposes deferred source failures and retries them', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(DEFERRED_PAYLOAD) });
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = renderHook(() => useDemo(props(code())));
+    act(() => result.current.selectFileName('helper.ts'));
+
+    await waitFor(() => expect(result.current.deferredSourcesError?.message).toBe('HTTP 503'));
+    expect(result.current.loading).toBe(true);
+
+    await act(() => result.current.loadDeferredSources());
+
+    expect(result.current.deferredSourcesError).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(markup(result.current.selectedFile)).toContain('helper-full');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not copy truncated source when deferred source loading fails', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    const onCopied = vi.fn();
+    const { result } = renderHook(() => useDemo(props(code()), { copy: { onCopied } }));
+
+    await act(async () => result.current.copy());
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(onCopied).not.toHaveBeenCalled();
+    expect(result.current.deferredSourcesError?.message).toBe('HTTP 503');
+  });
+
   it('applies a matching hash to variant, file, and expansion state', async () => {
     stubFetch();
     const { result } = renderHook(() => useDemo(props(code())));

--- a/packages/docs-infra/src/lite/runtime/useDemo.test.tsx
+++ b/packages/docs-infra/src/lite/runtime/useDemo.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import { useDemo } from './useDemo';
+import type { CodePrecompute, ContentProps } from './types';
+
+const DEFERRED_URL = 'https://example.test/demo.json';
+const DEFERRED_PAYLOAD = {
+  Default: {
+    source: '<span>main-full</span>',
+    extraFiles: { 'helper.ts': '<span>helper-full</span>' },
+  },
+};
+
+function code(): CodePrecompute {
+  return {
+    deferredUrl: DEFERRED_URL,
+    variants: {
+      Default: {
+        fileName: 'MyComponent.tsx',
+        exportName: 'MyComponent',
+        html: '<span>main-paint</span>',
+        language: 'tsx',
+        totalLines: 20,
+        extraFiles: {
+          'helper.ts': { language: 'ts', totalLines: 3 },
+        },
+      },
+      Css: {
+        fileName: 'MyComponent.tsx',
+        exportName: 'default',
+        html: '<span>css</span>',
+        language: 'tsx',
+        totalLines: 8,
+      },
+    },
+  };
+}
+
+function props(precompute: CodePrecompute): ContentProps {
+  return {
+    name: 'My Component',
+    slug: 'my-component',
+    url: 'file:///project/demos/my-component/index.ts',
+    components: { Default: 'default-element', Css: 'css-element' },
+    code: precompute,
+  };
+}
+
+function markup(node: React.ReactNode): string {
+  return node == null ? '' : ReactDOMServer.renderToStaticMarkup(node);
+}
+
+function stubFetch() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(DEFERRED_PAYLOAD),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  const values = new Map<string, string>();
+  const localStorage: Storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+  Object.defineProperty(window, 'localStorage', { configurable: true, value: localStorage });
+  window.location.hash = '';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useDemo', () => {
+  it('selects variants and recovers from invalid persisted variants', () => {
+    const { result } = renderHook(() => useDemo(props(code())));
+    expect(result.current.variants).toEqual(['Default', 'Css']);
+    expect(result.current.selectedVariant).toBe('Default');
+    act(() => result.current.selectVariant('Css'));
+    expect(result.current.component).toBe('css-element');
+    act(() => result.current.selectVariant('Missing'));
+    expect(result.current.selectedVariant).toBe('Default');
+  });
+
+  it('lists files and recovers from an invalid selected extra file', () => {
+    const { result } = renderHook(() => useDemo(props(code())));
+    expect(result.current.files).toEqual([
+      { name: 'MyComponent.tsx', slug: 'my-component:my-component.tsx' },
+      { name: 'helper.ts', slug: 'my-component:helper.ts' },
+    ]);
+    act(() => result.current.selectFileName('helper.ts'));
+    expect(result.current.selectedFileName).toBe('helper.ts');
+    act(() => result.current.selectFileName('missing.ts'));
+    expect(result.current.selectedFileName).toBe('MyComponent.tsx');
+  });
+
+  it('fetches deferred source markup once and resolves loading files', async () => {
+    const fetchMock = stubFetch();
+    const { result } = renderHook(() => useDemo(props(code())));
+    act(() => result.current.selectFileName('helper.ts'));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.selectedFile).toBeNull();
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(markup(result.current.selectedFile)).toContain('helper-full');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes deferred source loading for prefetching', async () => {
+    const fetchMock = stubFetch();
+    const { result } = renderHook(() => useDemo(props(code())));
+
+    await act(() => result.current.loadDeferredSources());
+
+    expect(fetchMock).toHaveBeenCalledWith(DEFERRED_URL);
+    expect(markup(result.current.selectedFile)).toContain('main-full');
+  });
+
+  it('fetches full main markup before copying truncated HTML', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    stubFetch();
+    const onCopied = vi.fn();
+    const { result } = renderHook(() => useDemo(props(code()), { copy: { onCopied } }));
+
+    await act(async () => result.current.copy());
+
+    expect(writeText).toHaveBeenCalledWith('main-full');
+    expect(onCopied).toHaveBeenCalledOnce();
+  });
+
+  it('applies a matching hash to variant, file, and expansion state', async () => {
+    stubFetch();
+    const { result } = renderHook(() => useDemo(props(code())));
+    act(() => {
+      window.location.hash = '#my-component:helper.ts';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+    await waitFor(() => expect(result.current.expanded).toBe(true));
+    expect(result.current.selectedVariant).toBe('Default');
+    expect(result.current.selectedFileName).toBe('helper.ts');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/useDemo.ts
+++ b/packages/docs-infra/src/lite/runtime/useDemo.ts
@@ -29,6 +29,7 @@ export interface UseDemoResult {
   selectedFileName: string;
   selectedFileLines: number;
   loading: boolean;
+  deferredSourcesError: Error | null;
   selectFileName: (name: string | null) => void;
   expanded: boolean;
   expand: () => void;
@@ -44,7 +45,8 @@ export function useDemo<T extends object = {}>(
 ): UseDemoResult {
   const { code: rawCode, components, slug } = props;
   const deferredUrl = rawCode.deferredUrl;
-  const { code, deferredSources, loadDeferredSources } = useDeferredSources(rawCode);
+  const { code, deferredSources, deferredSourcesError, loadDeferredSources } =
+    useDeferredSources(rawCode);
   const variants = Object.keys(code.variants);
   if (variants.length === 0) {
     throw new Error('docs-infra: the demo loader returned no variants.');
@@ -84,16 +86,19 @@ export function useDemo<T extends object = {}>(
   const [expanded, setExpanded] = React.useState(false);
   const expand = React.useCallback(() => setExpanded(true), []);
   React.useEffect(() => {
-    if (deferredUrl && !deferredSources && (expanded || loading)) {
+    if (deferredUrl && !deferredSources && !deferredSourcesError && (expanded || loading)) {
       loadDeferredSources();
     }
-  }, [deferredUrl, deferredSources, expanded, loading, loadDeferredSources]);
+  }, [deferredSources, deferredSourcesError, deferredUrl, expanded, loading, loadDeferredSources]);
 
   const onCopied = options.copy?.onCopied;
   const copy = React.useCallback(async () => {
     let html = selectedFileData.html;
     if (deferredUrl) {
       const sources = deferredSources ?? (await loadDeferredSources());
+      if (!sources) {
+        return;
+      }
       const deferredVariant = sources?.[selectedVariant];
       html =
         (selectedFileName === mainFileName
@@ -160,6 +165,7 @@ export function useDemo<T extends object = {}>(
     selectedFile,
     selectedFileLines,
     loading,
+    deferredSourcesError,
     expanded,
     expand,
     setExpanded,

--- a/packages/docs-infra/src/lite/runtime/useDemo.ts
+++ b/packages/docs-infra/src/lite/runtime/useDemo.ts
@@ -1,0 +1,169 @@
+'use client';
+
+import * as React from 'react';
+import { generateFileSlug, toKebabCase } from './generateFileSlug';
+import { renderCodeToReact } from './renderCodeToReact';
+import type { ContentProps, DeferredSources } from './types';
+import { useDeferredSources } from './useDeferredSources';
+import { useDemoHashNavigation } from './useDemoHashNavigation';
+import { usePreference } from './usePreference';
+
+export interface UseDemoOptions {
+  copy?: { onCopied?: () => void };
+}
+
+function htmlToText(html: string): string {
+  const holder = document.createElement('div');
+  holder.innerHTML = html;
+  return holder.textContent ?? '';
+}
+
+export interface UseDemoResult {
+  component: React.ReactNode;
+  variants: string[];
+  selectedVariant: string;
+  selectVariant: (variant: string | null) => void;
+  files: Array<{ name: string; slug: string }>;
+  allFilesSlugs: Array<{ fileName: string; slug: string; variantName: string }>;
+  selectedFile: React.ReactNode;
+  selectedFileName: string;
+  selectedFileLines: number;
+  loading: boolean;
+  selectFileName: (name: string | null) => void;
+  expanded: boolean;
+  expand: () => void;
+  setExpanded: (expanded: boolean) => void;
+  loadDeferredSources: () => Promise<DeferredSources | null>;
+  copy: () => Promise<void>;
+}
+
+/** Consumes loader output into demo variant, file, copy, and export state. */
+export function useDemo<T extends object = {}>(
+  props: ContentProps<T>,
+  options: UseDemoOptions = {},
+): UseDemoResult {
+  const { code: rawCode, components, slug } = props;
+  const deferredUrl = rawCode.deferredUrl;
+  const { code, deferredSources, loadDeferredSources } = useDeferredSources(rawCode);
+  const variants = Object.keys(code.variants);
+  if (variants.length === 0) {
+    throw new Error('docs-infra: the demo loader returned no variants.');
+  }
+
+  const [preferredVariant, setPreferredVariant] = usePreference('variant', variants, variants[0]);
+  const selectedVariant =
+    preferredVariant && variants.includes(preferredVariant) ? preferredVariant : variants[0];
+  const variant = code.variants[selectedVariant];
+  const mainFileName = variant.fileName;
+  const files = React.useMemo(
+    () => [
+      {
+        name: mainFileName,
+        slug: generateFileSlug(slug, mainFileName, selectedVariant),
+      },
+      ...Object.keys(variant.extraFiles ?? {}).map((fileName) => ({
+        name: fileName,
+        slug: generateFileSlug(slug, fileName, selectedVariant),
+      })),
+    ],
+    [mainFileName, selectedVariant, slug, variant.extraFiles],
+  );
+
+  const [pickedFileName, selectFileName] = React.useState<string | null>(null);
+  const selectedFileName = files.some((file) => file.name === pickedFileName)
+    ? pickedFileName!
+    : files[0].name;
+  const selectedFileData =
+    selectedFileName === mainFileName ? variant : variant.extraFiles![selectedFileName];
+  const selectedFile = selectedFileData.html
+    ? renderCodeToReact(selectedFileData.html, selectedFileData.language)
+    : null;
+  const loading = selectedFileData.html === undefined;
+  const selectedFileLines = selectedFileData.totalLines;
+
+  const [expanded, setExpanded] = React.useState(false);
+  const expand = React.useCallback(() => setExpanded(true), []);
+  React.useEffect(() => {
+    if (deferredUrl && !deferredSources && (expanded || loading)) {
+      loadDeferredSources();
+    }
+  }, [deferredUrl, deferredSources, expanded, loading, loadDeferredSources]);
+
+  const onCopied = options.copy?.onCopied;
+  const copy = React.useCallback(async () => {
+    let html = selectedFileData.html;
+    if (deferredUrl) {
+      const sources = deferredSources ?? (await loadDeferredSources());
+      const deferredVariant = sources?.[selectedVariant];
+      html =
+        (selectedFileName === mainFileName
+          ? deferredVariant?.source
+          : deferredVariant?.extraFiles?.[selectedFileName]) ?? html;
+    }
+    if (html === undefined) {
+      return;
+    }
+    await navigator.clipboard.writeText(htmlToText(html));
+    onCopied?.();
+  }, [
+    deferredSources,
+    deferredUrl,
+    loadDeferredSources,
+    mainFileName,
+    onCopied,
+    selectedFileData.html,
+    selectedFileName,
+    selectedVariant,
+  ]);
+
+  const allFilesSlugs = React.useMemo(() => {
+    const allSlugs: Array<{ fileName: string; slug: string; variantName: string }> = [];
+    for (const [variantName, variantCode] of Object.entries(code.variants)) {
+      const fileName = variantCode.fileName;
+      if (variantName !== 'Default') {
+        allSlugs.push({ fileName, slug: `${slug}:${toKebabCase(variantName)}`, variantName });
+      }
+      allSlugs.push({
+        fileName,
+        slug: generateFileSlug(slug, fileName, variantName),
+        variantName,
+      });
+      for (const extraFileName of Object.keys(variantCode.extraFiles ?? {})) {
+        allSlugs.push({
+          fileName: extraFileName,
+          slug: generateFileSlug(slug, extraFileName, variantName),
+          variantName,
+        });
+      }
+    }
+    return allSlugs;
+  }, [code.variants, slug]);
+
+  useDemoHashNavigation({
+    mainSlug: slug,
+    allFilesSlugs,
+    expanded,
+    setPreferredVariant,
+    selectFileName,
+    setExpanded,
+  });
+
+  return {
+    component: components[selectedVariant],
+    variants,
+    selectedVariant,
+    selectVariant: setPreferredVariant,
+    files,
+    selectedFileName,
+    selectFileName,
+    allFilesSlugs,
+    selectedFile,
+    selectedFileLines,
+    loading,
+    expanded,
+    expand,
+    setExpanded,
+    loadDeferredSources,
+    copy,
+  };
+}

--- a/packages/docs-infra/src/lite/runtime/useDemo.user.spec.ts
+++ b/packages/docs-infra/src/lite/runtime/useDemo.user.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import { useDemo } from './useDemo';
+import type { CodePrecompute, ContentProps } from './types';
+
+const DEFERRED_URL = 'https://example.test/demo.json';
+const DEFERRED_PAYLOAD = {
+  Default: {
+    source: '<span>main-full</span>',
+    extraFiles: { 'helper.ts': '<span>helper-full</span>' },
+  },
+};
+
+function code(): CodePrecompute {
+  return {
+    deferredUrl: DEFERRED_URL,
+    variants: {
+      Default: {
+        fileName: 'MyComponent.tsx',
+        exportName: 'default',
+        html: '<span>main-paint</span>',
+        language: 'tsx',
+        totalLines: 20,
+        extraFiles: {
+          'helper.ts': { language: 'ts', totalLines: 3 },
+        },
+      },
+      Css: {
+        fileName: 'MyComponent.tsx',
+        exportName: 'default',
+        html: '<span>css</span>',
+        language: 'tsx',
+        totalLines: 8,
+      },
+    },
+  };
+}
+
+function props(): ContentProps {
+  return {
+    name: 'My Component',
+    slug: 'my-component',
+    url: 'file:///project/demos/my-component/index.ts',
+    components: { Default: 'default-el', Css: 'css-el' },
+    code: code(),
+  };
+}
+
+function markup(node: React.ReactNode): string {
+  return node == null ? '' : ReactDOMServer.renderToStaticMarkup(node);
+}
+
+function stubFetch() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(DEFERRED_PAYLOAD),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.location.hash = '';
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('demo user behavior', () => {
+  it('switches variants and restores the main file selection', () => {
+    const { result } = renderHook(() => useDemo(props()));
+    act(() => result.current.selectFileName('helper.ts'));
+    act(() => result.current.selectVariant('Css'));
+
+    expect(result.current.selectedVariant).toBe('Css');
+    expect(result.current.selectedFileName).toBe('MyComponent.tsx');
+    expect(result.current.component).toBe('css-el');
+  });
+
+  it('loads a deferred extra file when selected', async () => {
+    const fetchMock = stubFetch();
+    const { result } = renderHook(() => useDemo(props()));
+    act(() => result.current.selectFileName('helper.ts'));
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(markup(result.current.selectedFile)).toContain('helper-full');
+    expect(fetchMock).toHaveBeenCalledWith(DEFERRED_URL);
+  });
+
+  it('loads full sources when expanded', async () => {
+    const fetchMock = stubFetch();
+    const { result } = renderHook(() => useDemo(props()));
+    act(() => result.current.expand());
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(DEFERRED_URL));
+    await waitFor(() => expect(markup(result.current.selectedFile)).toContain('main-full'));
+  });
+
+  it('copies a deferred extra file', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    stubFetch();
+    const { result } = renderHook(() => useDemo(props()));
+    act(() => result.current.selectFileName('helper.ts'));
+
+    await act(async () => result.current.copy());
+
+    expect(writeText).toHaveBeenCalledWith('helper-full');
+  });
+
+  it('navigates to a matching file hash', async () => {
+    stubFetch();
+    const { result } = renderHook(() => useDemo(props()));
+    act(() => {
+      window.location.hash = '#my-component:helper.ts';
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    });
+
+    await waitFor(() => expect(result.current.expanded).toBe(true));
+    expect(result.current.selectedFileName).toBe('helper.ts');
+  });
+});

--- a/packages/docs-infra/src/lite/runtime/useDemoHashNavigation.ts
+++ b/packages/docs-infra/src/lite/runtime/useDemoHashNavigation.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import * as React from 'react';
+
+function subscribeToHashChange(callback: () => void) {
+  window.addEventListener('hashchange', callback);
+  return () => window.removeEventListener('hashchange', callback);
+}
+
+function getHashSnapshot(): string | null {
+  return window.location.hash ? window.location.hash.slice(1) : null;
+}
+
+function getServerHashSnapshot(): string | null {
+  return null;
+}
+
+function useUrlHash(): string | null {
+  return React.useSyncExternalStore(subscribeToHashChange, getHashSnapshot, getServerHashSnapshot);
+}
+
+interface FileSlug {
+  fileName: string;
+  slug: string;
+  variantName: string;
+}
+
+interface HashNavigationParams {
+  mainSlug: string;
+  allFilesSlugs: FileSlug[];
+  expanded: boolean;
+  setPreferredVariant: (variant: string) => void;
+  selectFileName: (name: string | null) => void;
+  setExpanded: (expanded: boolean) => void;
+}
+
+/** Applies matching demo hash anchors to variant/file state once per hash. */
+export function useDemoHashNavigation({
+  mainSlug,
+  allFilesSlugs,
+  expanded,
+  setPreferredVariant,
+  selectFileName,
+  setExpanded,
+}: HashNavigationParams): void {
+  const hash = useUrlHash();
+  const appliedHashRef = React.useRef<string | null>(null);
+  const pendingScrollHashRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (!hash || !mainSlug || !hash.startsWith(`${mainSlug}:`)) {
+      return;
+    }
+    if (appliedHashRef.current === hash) {
+      return;
+    }
+    const match = allFilesSlugs.find((entry) => entry.slug === hash);
+    if (!match) {
+      return;
+    }
+    appliedHashRef.current = hash;
+    pendingScrollHashRef.current = hash;
+    setPreferredVariant(match.variantName);
+    selectFileName(match.fileName);
+    setExpanded(true);
+  }, [hash, mainSlug, allFilesSlugs, setPreferredVariant, selectFileName, setExpanded]);
+
+  React.useEffect(() => {
+    if (pendingScrollHashRef.current == null || !expanded) {
+      return;
+    }
+    const anchor = document.getElementById(pendingScrollHashRef.current);
+    pendingScrollHashRef.current = null;
+    anchor?.scrollIntoView({ block: 'start', behavior: 'instant' });
+  });
+}

--- a/packages/docs-infra/src/lite/runtime/usePreference.ts
+++ b/packages/docs-infra/src/lite/runtime/usePreference.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import * as React from 'react';
+
+/** Remembers shared demo/code preferences while remaining SSR-safe. */
+export function usePreference(
+  type: 'variant' | 'transform',
+  name: string | string[],
+  initializer: string | null | (() => string | null) = null,
+): [string | null, (value: string | null) => void] {
+  const key = React.useMemo(() => {
+    if (Array.isArray(name)) {
+      return name.length > 1 ? [...name].sort().join(':') : null;
+    }
+    return name;
+  }, [name]);
+  const storageKey = key === null ? null : `_docs_${type}_pref:${key}`;
+  const [value, setValue] = React.useState<string | null>(() =>
+    typeof initializer === 'function' ? initializer() : initializer,
+  );
+
+  React.useEffect(() => {
+    if (storageKey === null) {
+      return;
+    }
+    const stored = window.localStorage.getItem(storageKey);
+    if (stored !== null) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- read after hydration
+      setValue(stored);
+    }
+  }, [storageKey]);
+
+  const setPreference = React.useCallback(
+    (next: string | null) => {
+      setValue(next);
+      if (storageKey !== null) {
+        try {
+          if (next === null) {
+            window.localStorage.removeItem(storageKey);
+          } else {
+            window.localStorage.setItem(storageKey, next);
+          }
+        } catch {
+          // Keep the in-memory value when storage is unavailable.
+        }
+      }
+    },
+    [storageKey],
+  );
+  return [value, setPreference];
+}

--- a/packages/docs-infra/src/lite/shared/parsers/parseDemoIndex.ts
+++ b/packages/docs-infra/src/lite/shared/parsers/parseDemoIndex.ts
@@ -1,0 +1,138 @@
+import { parser as jsParser } from '@lezer/javascript';
+
+const parser = jsParser.configure({ dialect: 'jsx ts' });
+
+export interface RelativeImport {
+  specifier: string;
+  start: number;
+  end: number;
+}
+
+/** How a variant component is imported in the demo index module. */
+export interface DemoVariantImport {
+  specifier: string;
+  /** The component's export name in its module, or `'default'` for a default import. */
+  importName: string;
+}
+
+/** The demo export and its variants (variant name to import info) found in an index module. */
+export interface ParsedDemoModule {
+  exportName: string;
+  variants: Record<string, DemoVariantImport>;
+}
+
+/** Finds relative import/export specifiers and their quote-free source offsets. */
+export function getRelativeImports(source: string): RelativeImport[] {
+  const specifiers: RelativeImport[] = [];
+  parser.parse(source).iterate({
+    enter(node) {
+      if (node.name !== 'ImportDeclaration' && node.name !== 'ExportDeclaration') {
+        return undefined;
+      }
+      const string = node.node.getChild('String');
+      if (string) {
+        const specifier = source.slice(string.from + 1, string.to - 1);
+        if (specifier.startsWith('.')) {
+          specifiers.push({ specifier, start: string.from + 1, end: string.to - 1 });
+        }
+      }
+      return false;
+    },
+  });
+  return specifiers;
+}
+
+export function parseDemoIndex(source: string): ParsedDemoModule | null {
+  const tree = parser.parse(source);
+  const top = tree.topNode;
+  const getSourceText = (node: { from: number; to: number }): string =>
+    source.slice(node.from, node.to);
+
+  // Default imports bind as a direct VariableDefinition child; named imports
+  // sit inside an ImportGroup (`{ A, B as C }` binds A and C). An aliased
+  // specifier's exported name is the VariableName preceding its binding.
+  const imports: Record<string, DemoVariantImport> = {};
+
+  for (const declaration of top.getChildren('ImportDeclaration')) {
+    const string = declaration.getChild('String');
+    if (!string) {
+      continue;
+    }
+    const specifier = getSourceText(string).slice(1, -1);
+    const binding = declaration.getChild('VariableDefinition');
+    if (binding) {
+      imports[getSourceText(binding)] = { specifier, importName: 'default' };
+    }
+    const group = declaration.getChild('ImportGroup');
+    if (group) {
+      let importedName: string | null = null;
+      for (let child = group.firstChild; child; child = child.nextSibling) {
+        if (child.name === 'VariableName') {
+          importedName = getSourceText(child);
+        } else if (child.name === 'VariableDefinition') {
+          imports[getSourceText(child)] = {
+            specifier,
+            importName: importedName ?? getSourceText(child),
+          };
+          importedName = null;
+        }
+      }
+    }
+  }
+
+  for (const exportDeclaration of top.getChildren('ExportDeclaration')) {
+    const declaration = exportDeclaration.getChild('VariableDeclaration');
+    const call = declaration?.getChild('CallExpression');
+    const callee = call?.getChild('VariableName');
+    const calleeName = callee ? getSourceText(callee) : '';
+    if (calleeName !== 'createDemo' && calleeName !== 'createDemoWithVariants') {
+      continue;
+    }
+    const exportBinding = declaration?.getChild('VariableDefinition');
+    if (!exportBinding || !call) {
+      continue;
+    }
+    const exportName = getSourceText(exportBinding);
+    const argList = call.getChild('ArgList');
+
+    const variants: Record<string, DemoVariantImport | undefined> = {};
+    if (calleeName === 'createDemoWithVariants') {
+      // createDemoWithVariants(import.meta.url, { Name } | { Name: Component }, options?)
+      const object = argList?.getChild('ObjectExpression');
+      if (!object) {
+        return null;
+      }
+      for (const property of object.getChildren('Property')) {
+        const key = property.getChild('PropertyDefinition');
+        if (key) {
+          const value = property.getChild('VariableName');
+          variants[getSourceText(key)] = imports[value ? getSourceText(value) : getSourceText(key)];
+        }
+      }
+    } else {
+      // createDemo(import.meta.url, Component, options?): the component is
+      // the first identifier argument (import.meta.url contains none).
+      const component = argList?.getChild('VariableName');
+      if (!component) {
+        return null;
+      }
+      variants.Default = imports[getSourceText(component)];
+    }
+
+    const resolvedVariants: Record<string, DemoVariantImport> = {};
+    for (const [variantName, variantImport] of Object.entries(variants)) {
+      if (!variantImport) {
+        throw new Error(
+          `docs-infra: could not find the import for demo variant "${variantName}". ` +
+            'Demo variants must be imported directly in the demo index file.',
+        );
+      }
+      resolvedVariants[variantName] = variantImport;
+    }
+    return { exportName, variants: resolvedVariants };
+  }
+  return null;
+}
+
+/** Loader-facing alias for the parsed demo index contract. */
+export const parseDemoModule = parseDemoIndex;

--- a/packages/docs-infra/src/lite/shared/syntax/emphasis.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/emphasis.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { LANGUAGES } from './highlight';
+import type { Token } from './highlight';
+import { extractEmphasis, resolveTextHighlightRanges, splitTokensAtRanges } from './emphasis';
+
+describe('extractEmphasis', () => {
+  it('strips and maps single-line and range highlights', () => {
+    const source = [
+      'const a = 1; // @highlight',
+      '// @highlight-start',
+      'const b = 2;',
+      'const c = 3;',
+      '// @highlight-end',
+      '',
+    ].join('\n');
+    const result = extractEmphasis(source, LANGUAGES.ts);
+    expect(result.source).not.toContain('@highlight');
+    expect([...result.highlightLines]).toEqual([1, 2, 3]);
+  });
+
+  it('combines focus padding with text targets', () => {
+    const source = [
+      'const a = 1;',
+      '// @highlight-start @focus @padding 1',
+      'const b = value; // @highlight-text "value"',
+      '// @highlight-end',
+      'const c = 3;',
+      '',
+    ].join('\n');
+    const result = extractEmphasis(source, LANGUAGES.ts);
+    expect(result.focusRange).toEqual({ start: 1, end: 3 });
+    expect(Object.fromEntries(result.textHighlights)).toEqual({ 2: ['value'] });
+  });
+
+  it('ignores unmatched and prefix-sharing directives', () => {
+    const source = ['// @focused on performance', '// @highlight-end', 'const a = 1;'].join('\n');
+    const result = extractEmphasis(source, LANGUAGES.ts);
+    expect(result.source).toContain('@focused');
+    expect(result.highlightLines.size).toBe(0);
+    expect(result.focusRange).toBeNull();
+  });
+});
+
+describe('resolveTextHighlightRanges', () => {
+  it('finds repeated targets without overlapping prior matches', () => {
+    expect(resolveTextHighlightRanges('value value', new Map([[1, ['value', 'value']]]))).toEqual([
+      { from: 0, to: 5 },
+      { from: 6, to: 11 },
+    ]);
+  });
+});
+
+describe('splitTokensAtRanges', () => {
+  it('preserves token classes across a range spanning tokens', () => {
+    const tokens: Token[] = [
+      { text: 'foo', classes: 'pl-a' },
+      { text: 'bar', classes: 'pl-b' },
+    ];
+    expect(splitTokensAtRanges(tokens, [{ from: 2, to: 5 }])).toEqual([
+      { text: 'fo', classes: 'pl-a' },
+      { text: 'o', classes: 'pl-a', mark: true },
+      { text: 'ba', classes: 'pl-b', mark: true },
+      { text: 'r', classes: 'pl-b' },
+    ]);
+  });
+});

--- a/packages/docs-infra/src/lite/shared/syntax/emphasis.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/emphasis.ts
@@ -1,0 +1,316 @@
+import type { Language, Token } from './highlight';
+
+const HIGHLIGHT_TEXT = '@highlight-text';
+
+const DIRECTIVE_TOKENS: Record<
+  string,
+  { kind: 'highlight' | 'focus'; type: 'single' | 'start' | 'end' }
+> = {
+  '@highlight': { kind: 'highlight', type: 'single' },
+  '@highlight-start': { kind: 'highlight', type: 'start' },
+  '@highlight-end': { kind: 'highlight', type: 'end' },
+  '@focus': { kind: 'focus', type: 'single' },
+  '@focus-start': { kind: 'focus', type: 'start' },
+  '@focus-end': { kind: 'focus', type: 'end' },
+};
+
+export interface FocusRange {
+  start: number;
+  end: number;
+}
+
+export interface Emphasis {
+  source: string;
+  highlightLines: Set<number>;
+  textHighlights: Map<number, string[]>;
+  focusRange: FocusRange | null;
+}
+
+type ParsedDirective =
+  | {
+      kind: 'highlight' | 'focus';
+      type: 'single' | 'start' | 'end';
+      padding: number;
+      focus: boolean;
+    }
+  | { kind: 'text'; texts: string[] };
+
+interface FoundDirective {
+  parsed: ParsedDirective;
+  from: number;
+  to: number;
+  originalLine: number;
+  finalOffset: number;
+}
+
+function isBlank(char: string): boolean {
+  return char === ' ' || char === '\t';
+}
+
+function commentInnerText(raw: string): string {
+  return raw.startsWith('//') ? raw.slice(2) : raw.slice(2, -2);
+}
+
+function parsePaddingModifier(rest: string[]): number {
+  const index = rest.indexOf('@padding');
+  if (index === -1) {
+    return 0;
+  }
+  const value = Number.parseInt(rest[index + 1] ?? '', 10);
+  return Number.isNaN(value) || value < 0 ? 0 : value;
+}
+
+function parseDirective(content: string): ParsedDirective | null {
+  const trimmed = content.trim();
+  if (trimmed.startsWith(HIGHLIGHT_TEXT)) {
+    const texts = [...trimmed.slice(HIGHLIGHT_TEXT.length).matchAll(/"([^"]*)"/g)].map(
+      (match) => match[1],
+    );
+    return texts.length > 0 ? { kind: 'text', texts } : null;
+  }
+  const [first, ...rest] = trimmed.split(/\s+/);
+  const directive = DIRECTIVE_TOKENS[first];
+  if (!directive) {
+    return null;
+  }
+  const focus = directive.kind === 'highlight' && rest.includes('@focus');
+  return { ...directive, padding: parsePaddingModifier(rest), focus };
+}
+
+/** Returns the untouched source with no emphasis metadata. */
+export function emptyEmphasis(source: string): Emphasis {
+  return { source, highlightLines: new Set(), textHighlights: new Map(), focusRange: null };
+}
+
+/** Extracts and strips supported emphasis directives from source comments. */
+export function extractEmphasis(source: string, lang: Language): Emphasis {
+  if (!lang.commentNodes || !/@(?:highlight|focus)/.test(source)) {
+    return emptyEmphasis(source);
+  }
+
+  const directives: FoundDirective[] = [];
+  lang.parser.parse(source).iterate({
+    enter(node) {
+      if (!lang.commentNodes?.has(node.name)) {
+        return;
+      }
+      const parsed = parseDirective(commentInnerText(source.slice(node.from, node.to)));
+      if (parsed) {
+        directives.push({ parsed, from: node.from, to: node.to, originalLine: 0, finalOffset: 0 });
+      }
+    },
+  });
+  if (directives.length === 0) {
+    return emptyEmphasis(source);
+  }
+
+  const removals: Array<{ from: number; to: number }> = [];
+  const removedOriginalLines: number[] = [];
+  for (const directive of directives) {
+    const lineStart = source.lastIndexOf('\n', directive.from - 1) + 1;
+    const nextLine = source.indexOf('\n', directive.to);
+    const lineEnd = nextLine === -1 ? source.length : nextLine;
+    const originalLine = source.slice(0, lineStart).split('\n').length;
+
+    let from = directive.from;
+    let to = directive.to;
+    if (source[from - 1] === '{') {
+      from -= 1;
+    }
+    if (source[to] === '}') {
+      to += 1;
+    }
+
+    const commentOnly = source.slice(lineStart, lineEnd).trim() === source.slice(from, to).trim();
+    if (commentOnly) {
+      removals.push({ from: lineStart, to: lineEnd < source.length ? lineEnd + 1 : lineEnd });
+      removedOriginalLines.push(originalLine);
+    } else {
+      while (from > lineStart && isBlank(source[from - 1])) {
+        from -= 1;
+      }
+      while (to < lineEnd && isBlank(source[to])) {
+        to += 1;
+      }
+      removals.push({ from, to });
+    }
+    const { parsed } = directive;
+    directive.originalLine = originalLine;
+    directive.finalOffset = commentOnly && parsed.kind !== 'text' && parsed.type === 'end' ? -1 : 0;
+  }
+  removedOriginalLines.sort((first, second) => first - second);
+
+  const toFinalLine = (originalLine: number): number => {
+    let removedBefore = 0;
+    for (const removed of removedOriginalLines) {
+      if (removed < originalLine) {
+        removedBefore += 1;
+      } else {
+        break;
+      }
+    }
+    return originalLine - removedBefore;
+  };
+
+  removals.sort((first, second) => first.from - second.from);
+  let strippedSource = '';
+  let cursor = 0;
+  for (const removal of removals) {
+    strippedSource += source.slice(cursor, removal.from);
+    cursor = removal.to;
+  }
+  strippedSource += source.slice(cursor);
+
+  const highlightLines = new Set<number>();
+  const textHighlights = new Map<number, string[]>();
+  let focusStart: number | undefined;
+  let focusEnd: number | undefined;
+  const highlightStack: Array<{ line: number; focus: boolean; padding: number }> = [];
+  const focusStack: Array<{ line: number; padding: number }> = [];
+  const addFocus = (rangeStart: number, rangeEnd: number, padding: number) => {
+    focusStart =
+      focusStart === undefined ? rangeStart - padding : Math.min(focusStart, rangeStart - padding);
+    focusEnd = focusEnd === undefined ? rangeEnd + padding : Math.max(focusEnd, rangeEnd + padding);
+  };
+
+  for (const directive of directives) {
+    const finalLine = toFinalLine(directive.originalLine) + directive.finalOffset;
+    const { parsed } = directive;
+    if (parsed.kind === 'text') {
+      const existing = textHighlights.get(finalLine) ?? [];
+      textHighlights.set(finalLine, [...existing, ...parsed.texts]);
+      continue;
+    }
+    if (parsed.kind === 'highlight') {
+      if (parsed.type === 'start') {
+        highlightStack.push({ line: finalLine, focus: parsed.focus, padding: parsed.padding });
+        continue;
+      }
+      let rangeStart = finalLine;
+      let focus = parsed.focus;
+      let padding = parsed.padding;
+      if (parsed.type === 'end') {
+        const opener = highlightStack.pop();
+        if (opener === undefined) {
+          continue;
+        }
+        rangeStart = opener.line;
+        focus = opener.focus;
+        padding = opener.padding;
+      }
+      for (let line = rangeStart; line <= finalLine; line += 1) {
+        highlightLines.add(line);
+      }
+      if (focus) {
+        addFocus(rangeStart, finalLine, padding);
+      }
+      continue;
+    }
+    if (parsed.type === 'start') {
+      focusStack.push({ line: finalLine, padding: parsed.padding });
+      continue;
+    }
+    let opener: { line: number; padding: number } | undefined;
+    if (parsed.type === 'end') {
+      opener = focusStack.pop();
+      if (opener === undefined) {
+        continue;
+      }
+    }
+    const rangeStart = opener?.line ?? finalLine;
+    addFocus(rangeStart, finalLine, Math.max(parsed.padding, opener?.padding ?? 0));
+  }
+
+  let focusRange: FocusRange | null = null;
+  if (focusStart !== undefined && focusEnd !== undefined) {
+    const totalLines = strippedSource.replace(/\n$/, '').split('\n').length;
+    focusRange = { start: Math.max(1, focusStart), end: Math.min(totalLines, focusEnd) };
+  }
+
+  return { source: strippedSource, highlightLines, textHighlights, focusRange };
+}
+
+function overlapsClaimed(
+  claimed: Array<{ from: number; to: number }>,
+  from: number,
+  to: number,
+): boolean {
+  return claimed.some((range) => from < range.to && to > range.from);
+}
+
+/** Resolves text emphasis targets to absolute source ranges. */
+export function resolveTextHighlightRanges(
+  source: string,
+  textHighlights: Map<number, string[]>,
+): Array<{ from: number; to: number }> {
+  if (textHighlights.size === 0) {
+    return [];
+  }
+  const lines = source.split('\n');
+  const ranges: Array<{ from: number; to: number }> = [];
+  let lineStart = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    const texts = textHighlights.get(index + 1);
+    if (texts) {
+      const claimed: Array<{ from: number; to: number }> = [];
+      for (const text of texts) {
+        let textIndex = lines[index].indexOf(text);
+        while (textIndex !== -1 && overlapsClaimed(claimed, textIndex, textIndex + text.length)) {
+          textIndex = lines[index].indexOf(text, textIndex + 1);
+        }
+        if (textIndex !== -1) {
+          claimed.push({ from: textIndex, to: textIndex + text.length });
+          ranges.push({ from: lineStart + textIndex, to: lineStart + textIndex + text.length });
+        }
+      }
+    }
+    lineStart += lines[index].length + 1;
+  }
+  ranges.sort((first, second) => first.from - second.from);
+  return ranges;
+}
+
+/** Splits tokens at source ranges and marks the matching token segments. */
+export function splitTokensAtRanges(
+  tokens: Token[],
+  ranges: Array<{ from: number; to: number }>,
+): Token[] {
+  if (ranges.length === 0) {
+    return tokens;
+  }
+  const result: Token[] = [];
+  let rangeIndex = 0;
+  let offset = 0;
+  for (const token of tokens) {
+    const tokenEnd = offset + token.text.length;
+    let cursor = offset;
+    while (rangeIndex < ranges.length && ranges[rangeIndex].from < tokenEnd) {
+      const range = ranges[rangeIndex];
+      const from = Math.max(range.from, cursor);
+      const to = Math.min(range.to, tokenEnd);
+      if (from > cursor) {
+        result.push({
+          text: token.text.slice(cursor - offset, from - offset),
+          classes: token.classes,
+        });
+      }
+      if (to > from) {
+        result.push({
+          text: token.text.slice(from - offset, to - offset),
+          classes: token.classes,
+          mark: true,
+        });
+      }
+      cursor = to;
+      if (range.to > tokenEnd) {
+        break;
+      }
+      rangeIndex += 1;
+    }
+    if (cursor < tokenEnd) {
+      result.push({ text: token.text.slice(cursor - offset), classes: token.classes });
+    }
+    offset = tokenEnd;
+  }
+  return result;
+}

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
@@ -10,9 +10,9 @@ const classesOf = (src: string, langKey: keyof typeof LANGUAGES | string, text: 
 describe('spread operator', () => {
   // `...` is stock-tagged the too-broad tags.punctuation and is colored via a
   // `styleTags({ Spread })` rule (not a tree fixup) - assert every context.
-  it('colors `...` as `pl-k di-pu` in calls, arrays, objects, and params', () => {
+  it('colors `...` as `pl-k pl-pu` in calls, arrays, objects, and params', () => {
     for (const src of ['f(...x)', '[...a]', '({ ...o })', '({ ...rest }) => rest']) {
-      expect(classesOf(src, 'tsx', '...')).toEqual(['pl-k di-pu']);
+      expect(classesOf(src, 'tsx', '...')).toEqual(['pl-k pl-pu']);
     }
   });
 });

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { parser as jsParser } from '@lezer/javascript';
+import { tokenize, findJsxGenericTypeArgRanges, LANGUAGES } from './highlight';
+
+const classesOf = (src: string, langKey: keyof typeof LANGUAGES | string, text: string): string[] =>
+  tokenize(src, LANGUAGES[langKey])
+    .filter((token) => token.text === text)
+    .map((token) => token.classes);
+
+describe('spread operator', () => {
+  // `...` is stock-tagged the too-broad tags.punctuation and is colored via a
+  // `styleTags({ Spread })` rule (not a tree fixup) - assert every context.
+  it('colors `...` as `pl-k di-pu` in calls, arrays, objects, and params', () => {
+    for (const src of ['f(...x)', '[...a]', '({ ...o })', '({ ...rest }) => rest']) {
+      expect(classesOf(src, 'tsx', '...')).toEqual(['pl-k di-pu']);
+    }
+  });
+});
+
+describe('JSX generic type argument grammar gap', () => {
+  const source = 'const x = <Item.Root<Payload> open />;\n';
+
+  // findJsxGenericTypeArgRanges depends on @lezer/javascript misparsing
+  // `<Component<T>>` in a specific way. Keep this pinned to detect grammar changes.
+  it('still misparses `<Component<T>>` with the detected signature', () => {
+    const parser = jsParser.configure({ dialect: 'jsx ts' });
+    let signatureSeen = false;
+    parser.parse(source).iterate({
+      enter(node) {
+        if (node.name !== 'JSXMemberExpression' && node.name !== 'JSXIdentifier') {
+          return;
+        }
+        const parent = node.node.parent;
+        if (
+          parent &&
+          parent.to === node.to &&
+          (parent.name === 'JSXSelfClosingTag' || parent.name === 'JSXOpenTag') &&
+          source[node.to] === '<'
+        ) {
+          signatureSeen = true;
+        }
+      },
+    });
+    expect(signatureSeen).toBe(true);
+  });
+
+  it('recovers the `<TypeArg>` range from the misparse', () => {
+    const ranges = findJsxGenericTypeArgRanges(source, LANGUAGES.tsx);
+    expect(ranges).toHaveLength(1);
+    expect(source.slice(ranges[0].from, ranges[0].to)).toBe('<Payload>');
+  });
+});

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
@@ -26,6 +26,16 @@ describe('CSS custom properties', () => {
   });
 });
 
+describe('HTML', () => {
+  it('colors tag names, attributes, and values', () => {
+    const source = '<button type="button" disabled>Save</button>';
+    expect(classesOf(source, 'html', 'button')).toEqual(['pl-ent pl-ht', 'pl-ent pl-ht']);
+    expect(classesOf(source, 'html', 'type')).toEqual(['pl-ak']);
+    expect(classesOf(source, 'html', 'disabled')).toEqual(['pl-ak']);
+    expect(classesOf(source, 'html', '"button"')).toEqual(['pl-s pl-av']);
+  });
+});
+
 describe('JSX generic type argument grammar gap', () => {
   const source = 'const x = <Item.Root<Payload> open />;\n';
 

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.test.ts
@@ -17,6 +17,15 @@ describe('spread operator', () => {
   });
 });
 
+describe('CSS custom properties', () => {
+  it('colors declarations and references as variables', () => {
+    expect(classesOf(':root { --size: 1px; height: var(--size); }', 'css', '--size')).toEqual([
+      'pl-v',
+      'pl-v',
+    ]);
+  });
+});
+
 describe('JSX generic type argument grammar gap', () => {
   const source = 'const x = <Item.Root<Payload> open />;\n';
 

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.ts
@@ -1,0 +1,384 @@
+import { highlightTree, tagHighlighter, styleTags, tags } from '@lezer/highlight';
+import type { Highlighter } from '@lezer/highlight';
+import type { SyntaxNode, Tree } from '@lezer/common';
+import { parser as jsParser } from '@lezer/javascript';
+import { parser as cssParser } from '@lezer/css';
+import { parser as jsonParser } from '@lezer/json';
+
+/** Grammar setup, class mapping, and tokenization for parseSource. */
+
+export interface Token {
+  text: string;
+  classes: string;
+  /** Set by `@highlight-text` splitting and rendered inside a `<mark>`. */
+  mark?: boolean;
+}
+
+interface ClassFixup {
+  from: number;
+  to: number;
+  classes: string;
+}
+
+export interface Language {
+  parser: { parse(source: string): Tree };
+  highlighter: Highlighter;
+  fixups?: (tree: Tree) => ClassFixup[];
+  commentNodes?: Set<string>;
+  jsx?: boolean;
+}
+
+export const BUILT_IN_TYPES = new Set([
+  'string',
+  'number',
+  'boolean',
+  'void',
+  'never',
+  'symbol',
+  'object',
+  'any',
+  'unknown',
+  'bigint',
+]);
+
+const TYPE_NAME = 'lz-type';
+const TAG_NAME = 'lz-tag';
+
+const jsExtraStyles = styleTags({
+  'ParamList/VariableDefinition ArrowFunction/VariableDefinition': tags.special(
+    tags.definition(tags.variableName),
+  ),
+  'ImportGroup/VariableDefinition ImportDeclaration/VariableDefinition': tags.special(
+    tags.variableName,
+  ),
+  Spread: tags.controlOperator,
+});
+const jsBase = jsParser.configure({ props: [jsExtraStyles] });
+
+export const jsHighlighter = tagHighlighter([
+  { tag: tags.comment, class: 'pl-c' },
+  { tag: tags.string, class: 'pl-s' },
+  { tag: tags.special(tags.string), class: 'pl-s' },
+  { tag: tags.regexp, class: 'pl-sr' },
+  { tag: tags.escape, class: 'pl-cce' },
+  { tag: tags.number, class: 'pl-c1 di-num' },
+  { tag: tags.bool, class: 'pl-c1 di-bool' },
+  { tag: tags.null, class: 'pl-c1 di-n' },
+  { tag: tags.atom, class: 'pl-c1' },
+  { tag: tags.keyword, class: 'pl-k' },
+  { tag: tags.self, class: 'pl-c1 di-this' },
+  { tag: tags.typeName, class: TYPE_NAME },
+  { tag: tags.className, class: 'pl-en' },
+  { tag: tags.propertyName, class: 'pl-c1' },
+  { tag: tags.variableName, class: 'pl-smi' },
+  { tag: tags.special(tags.variableName), class: 'pl-smi' },
+  { tag: tags.definition(tags.variableName), class: 'pl-c1' },
+  { tag: tags.special(tags.definition(tags.variableName)), class: 'pl-v' },
+  { tag: tags.function(tags.variableName), class: 'pl-en' },
+  { tag: tags.function(tags.definition(tags.variableName)), class: 'pl-en' },
+  { tag: tags.function(tags.propertyName), class: 'pl-en' },
+  { tag: tags.arithmeticOperator, class: 'pl-k di-pu' },
+  { tag: tags.logicOperator, class: 'pl-k di-pu' },
+  { tag: tags.bitwiseOperator, class: 'pl-k di-pu' },
+  { tag: tags.compareOperator, class: 'pl-k di-pu' },
+  { tag: tags.updateOperator, class: 'pl-k di-pu' },
+  { tag: tags.definitionOperator, class: 'pl-k di-pu' },
+  { tag: tags.typeOperator, class: 'pl-k di-pu' },
+  { tag: tags.controlOperator, class: 'pl-k di-pu' },
+  { tag: tags.function(tags.punctuation), class: 'pl-k di-pu' },
+  { tag: tags.tagName, class: TAG_NAME },
+  { tag: tags.attributeName, class: 'di-ak' },
+  { tag: tags.attributeValue, class: 'pl-s di-av' },
+  { tag: tags.angleBracket, class: 'di-jsx' },
+]);
+
+const cssExtraStyles = styleTags({ AttributeName: tags.attributeName });
+const cssBase = cssParser.configure({ props: [cssExtraStyles] });
+
+const cssHighlighter = tagHighlighter([
+  { tag: tags.comment, class: 'pl-c' },
+  { tag: tags.string, class: 'pl-s' },
+  { tag: tags.propertyName, class: 'di-cp' },
+  { tag: tags.variableName, class: 'pl-c1' },
+  { tag: tags.tagName, class: 'pl-ent' },
+  { tag: tags.className, class: 'pl-e' },
+  { tag: tags.constant(tags.className), class: 'pl-e' },
+  { tag: tags.attributeName, class: 'pl-e di-da' },
+  { tag: tags.definitionOperator, class: 'pl-ent' },
+  { tag: tags.logicOperator, class: 'pl-k' },
+  { tag: tags.compareOperator, class: 'pl-k' },
+  { tag: tags.definitionKeyword, class: 'pl-k' },
+  { tag: tags.number, class: 'pl-c1 di-num' },
+  { tag: tags.unit, class: 'pl-k' },
+  { tag: tags.atom, class: 'pl-c1 di-cv' },
+  { tag: tags.keyword, class: 'pl-c1 di-cv' },
+  { tag: tags.color, class: 'pl-c1' },
+]);
+
+const jsonHighlighter = tagHighlighter([
+  { tag: tags.propertyName, class: 'pl-ent' },
+  { tag: tags.string, class: 'pl-s' },
+  { tag: tags.number, class: 'pl-c1 di-num' },
+  { tag: tags.bool, class: 'pl-c1 di-bool' },
+  { tag: tags.null, class: 'pl-c1 di-n' },
+]);
+
+const jsCommentNodes = new Set(['LineComment', 'BlockComment']);
+const cssCommentNodes = new Set(['Comment']);
+
+export const LANGUAGES: Record<string, Language> = {
+  js: {
+    parser: jsBase,
+    highlighter: jsHighlighter,
+    fixups: jsTreeFixups,
+    commentNodes: jsCommentNodes,
+  },
+  ts: {
+    parser: jsBase.configure({ dialect: 'ts' }),
+    highlighter: jsHighlighter,
+    fixups: jsTreeFixups,
+    commentNodes: jsCommentNodes,
+  },
+  tsx: {
+    parser: jsBase.configure({ dialect: 'jsx ts' }),
+    highlighter: jsHighlighter,
+    fixups: jsTreeFixups,
+    commentNodes: jsCommentNodes,
+    jsx: true,
+  },
+  css: { parser: cssBase, highlighter: cssHighlighter, commentNodes: cssCommentNodes },
+  json: { parser: jsonParser, highlighter: jsonHighlighter },
+};
+LANGUAGES.jsx = LANGUAGES.tsx;
+LANGUAGES.javascript = LANGUAGES.js;
+LANGUAGES.typescript = LANGUAGES.ts;
+LANGUAGES.mjs = LANGUAGES.js;
+LANGUAGES.cjs = LANGUAGES.js;
+LANGUAGES.mts = LANGUAGES.ts;
+LANGUAGES.cts = LANGUAGES.ts;
+
+function specializeClasses(classes: string, text: string): string {
+  if (classes === TYPE_NAME) {
+    return BUILT_IN_TYPES.has(text) ? 'pl-c1 di-bt' : 'pl-en';
+  }
+  if (classes === TAG_NAME) {
+    return /^[a-z]/.test(text) ? 'pl-ent di-ht' : 'di-jt';
+  }
+  return classes;
+}
+
+export function languageFromFileName(fileName?: string): string | undefined {
+  const extension = /\.([a-z0-9]+)$/i.exec(fileName || '');
+  return extension ? extension[1].toLowerCase() : undefined;
+}
+
+const PATTERN_NODES = new Set(['ObjectPattern', 'ArrayPattern', 'PatternProperty']);
+
+function collectParamPatternFixups(pattern: SyntaxNode, fixups: ClassFixup[]): void {
+  for (let child = pattern.firstChild; child; child = child.nextSibling) {
+    if (child.name === 'PropertyName' || child.name === 'VariableDefinition') {
+      fixups.push({ from: child.from, to: child.to, classes: 'pl-v' });
+    } else if (PATTERN_NODES.has(child.name)) {
+      collectParamPatternFixups(child, fixups);
+    }
+  }
+}
+
+function jsTreeFixups(tree: Tree): ClassFixup[] {
+  const fixups: ClassFixup[] = [];
+  tree.iterate({
+    enter(node) {
+      if (
+        (node.name === 'ObjectPattern' || node.name === 'ArrayPattern') &&
+        node.node.parent?.name === 'ParamList'
+      ) {
+        collectParamPatternFixups(node.node, fixups);
+        return false;
+      }
+      if (node.name === 'JSXAttribute') {
+        const equals = node.node.getChild('Equals');
+        if (equals) {
+          fixups.push({ from: equals.from, to: equals.to, classes: 'pl-k di-ae' });
+        }
+      } else if (node.name === 'JSXMemberExpression') {
+        for (let child = node.node.firstChild; child; child = child.nextSibling) {
+          if (child.name === 'JSXIdentifier' || child.name === '.') {
+            fixups.push({ from: child.from, to: child.to, classes: 'di-jt' });
+          }
+        }
+      }
+      return undefined;
+    },
+  });
+  return fixups.sort((first, second) => first.from - second.from);
+}
+
+function findMatchingAngleBracket(source: string, start: number): number {
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '\n') {
+      return -1;
+    }
+    if (char === '<') {
+      depth += 1;
+    } else if (char === '>' && source[index - 1] !== '=') {
+      depth -= 1;
+      if (depth === 0) {
+        return index + 1;
+      }
+    }
+  }
+  return -1;
+}
+
+/** Recovers JSX generic type arguments that Lezer currently misparses. */
+export function findJsxGenericTypeArgRanges(
+  source: string,
+  lang: Language,
+): Array<{ from: number; to: number }> {
+  if (!lang.jsx) {
+    return [];
+  }
+  const ranges: Array<{ from: number; to: number }> = [];
+  lang.parser.parse(source).iterate({
+    enter(node) {
+      if (node.name !== 'JSXMemberExpression' && node.name !== 'JSXIdentifier') {
+        return;
+      }
+      const parent = node.node.parent;
+      if (
+        parent &&
+        parent.to === node.to &&
+        (parent.name === 'JSXSelfClosingTag' || parent.name === 'JSXOpenTag') &&
+        source[node.to] === '<'
+      ) {
+        const end = findMatchingAngleBracket(source, node.to);
+        if (end !== -1) {
+          ranges.push({ from: node.to, to: end });
+        }
+      }
+    },
+  });
+  return ranges;
+}
+
+/** Highlights source into flat tokens that cover the complete source. */
+export function tokenize(source: string, lang: Language): Token[] {
+  const tree = lang.parser.parse(source);
+  const fixups = lang.fixups ? lang.fixups(tree) : [];
+  let fixupIndex = 0;
+  const tokens: Token[] = [];
+
+  const pushPlain = (from: number, to: number) => {
+    let cursor = from;
+    while (fixupIndex < fixups.length && fixups[fixupIndex].from < to) {
+      const fixup = fixups[fixupIndex];
+      if (fixup.from < cursor) {
+        fixupIndex += 1;
+        continue;
+      }
+      if (fixup.to > to) {
+        break;
+      }
+      if (fixup.from > cursor) {
+        tokens.push({ text: source.slice(cursor, fixup.from), classes: '' });
+      }
+      tokens.push({ text: source.slice(fixup.from, fixup.to), classes: fixup.classes });
+      cursor = fixup.to;
+      fixupIndex += 1;
+    }
+    if (cursor < to) {
+      tokens.push({ text: source.slice(cursor, to), classes: '' });
+    }
+  };
+
+  let position = 0;
+  highlightTree(tree, lang.highlighter, (from, to, classes) => {
+    if (from > position) {
+      pushPlain(position, from);
+    }
+    while (fixupIndex < fixups.length && fixups[fixupIndex].from < from) {
+      fixupIndex += 1;
+    }
+    const fixup = fixups[fixupIndex];
+    const text = source.slice(from, to);
+    if (fixup && fixup.from === from && fixup.to === to) {
+      tokens.push({ text, classes: fixup.classes });
+      fixupIndex += 1;
+    } else {
+      tokens.push({ text, classes: specializeClasses(classes, text) });
+    }
+    position = to;
+  });
+  if (position < source.length) {
+    pushPlain(position, source.length);
+  }
+  return tokens;
+}
+
+/** Highlights a JSX generic span by parsing it in a supported call position. */
+export function highlightAsTypeArg(typeArgText: string, lang: Language): Token[] {
+  const synthetic = `f${typeArgText}()`;
+  const tokens = tokenize(synthetic, lang);
+  const from = 1;
+  const to = 1 + typeArgText.length;
+  const sliced: Token[] = [];
+  let offset = 0;
+  for (const token of tokens) {
+    const tokenEnd = offset + token.text.length;
+    if (tokenEnd > from && offset < to) {
+      const start = Math.max(from, offset);
+      const end = Math.min(to, tokenEnd);
+      sliced.push({ text: token.text.slice(start - offset, end - offset), classes: token.classes });
+    }
+    offset = tokenEnd;
+  }
+  return sliced;
+}
+
+export interface TokenReplacement {
+  from: number;
+  to: number;
+  tokens: Token[];
+}
+
+/** Replaces absolute token ranges while preserving all surrounding positions. */
+export function spliceTokens(tokens: Token[], replacements: TokenReplacement[]): Token[] {
+  if (replacements.length === 0) {
+    return tokens;
+  }
+  const result: Token[] = [];
+  let replacementIndex = 0;
+  let offset = 0;
+  for (const token of tokens) {
+    const tokenEnd = offset + token.text.length;
+    let cursor = offset;
+    while (
+      replacementIndex < replacements.length &&
+      replacements[replacementIndex].from < tokenEnd
+    ) {
+      const replacement = replacements[replacementIndex];
+      const from = Math.max(replacement.from, cursor);
+      if (from > cursor) {
+        result.push({
+          text: token.text.slice(cursor - offset, from - offset),
+          classes: token.classes,
+        });
+      }
+      if (from === replacement.from) {
+        result.push(...replacement.tokens);
+      }
+      cursor = Math.min(replacement.to, tokenEnd);
+      if (replacement.to > tokenEnd) {
+        break;
+      }
+      replacementIndex += 1;
+    }
+    if (cursor < tokenEnd) {
+      result.push({ text: token.text.slice(cursor - offset), classes: token.classes });
+    }
+    offset = tokenEnd;
+  }
+  return result;
+}

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.ts
@@ -3,6 +3,7 @@ import type { Highlighter } from '@lezer/highlight';
 import type { SyntaxNode, Tree } from '@lezer/common';
 import { parser as jsParser } from '@lezer/javascript';
 import { parser as cssParser } from '@lezer/css';
+import { parser as htmlParser } from '@lezer/html';
 import { parser as jsonParser } from '@lezer/json';
 
 /** Grammar setup, class mapping, and tokenization for parseSource. */
@@ -123,6 +124,16 @@ const jsonHighlighter = tagHighlighter([
   { tag: tags.null, class: 'pl-c1 pl-n' },
 ]);
 
+const htmlHighlighter = tagHighlighter([
+  { tag: tags.comment, class: 'pl-c' },
+  { tag: tags.tagName, class: 'pl-ent pl-ht' },
+  { tag: tags.attributeName, class: 'pl-ak' },
+  { tag: tags.attributeValue, class: 'pl-s pl-av' },
+  { tag: tags.string, class: 'pl-s pl-av' },
+  { tag: tags.angleBracket, class: 'pl-jsx' },
+  { tag: tags.meta, class: 'pl-k' },
+]);
+
 const jsCommentNodes = new Set(['LineComment', 'BlockComment']);
 const cssCommentNodes = new Set(['Comment']);
 
@@ -147,8 +158,10 @@ export const LANGUAGES: Record<string, Language> = {
     jsx: true,
   },
   css: { parser: cssBase, highlighter: cssHighlighter, commentNodes: cssCommentNodes },
+  html: { parser: htmlParser, highlighter: htmlHighlighter },
   json: { parser: jsonParser, highlighter: jsonHighlighter },
 };
+LANGUAGES.htm = LANGUAGES.html;
 LANGUAGES.jsx = LANGUAGES.tsx;
 LANGUAGES.javascript = LANGUAGES.js;
 LANGUAGES.typescript = LANGUAGES.ts;

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.ts
@@ -99,7 +99,7 @@ const cssHighlighter = tagHighlighter([
   { tag: tags.comment, class: 'pl-c' },
   { tag: tags.string, class: 'pl-s' },
   { tag: tags.propertyName, class: 'di-cp' },
-  { tag: tags.variableName, class: 'pl-c1' },
+  { tag: tags.variableName, class: 'pl-v' },
   { tag: tags.tagName, class: 'pl-ent' },
   { tag: tags.className, class: 'pl-e' },
   { tag: tags.constant(tags.className), class: 'pl-e' },

--- a/packages/docs-infra/src/lite/shared/syntax/highlight.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/highlight.ts
@@ -61,12 +61,12 @@ export const jsHighlighter = tagHighlighter([
   { tag: tags.special(tags.string), class: 'pl-s' },
   { tag: tags.regexp, class: 'pl-sr' },
   { tag: tags.escape, class: 'pl-cce' },
-  { tag: tags.number, class: 'pl-c1 di-num' },
-  { tag: tags.bool, class: 'pl-c1 di-bool' },
-  { tag: tags.null, class: 'pl-c1 di-n' },
+  { tag: tags.number, class: 'pl-c1 pl-num' },
+  { tag: tags.bool, class: 'pl-c1 pl-bool' },
+  { tag: tags.null, class: 'pl-c1 pl-n' },
   { tag: tags.atom, class: 'pl-c1' },
   { tag: tags.keyword, class: 'pl-k' },
-  { tag: tags.self, class: 'pl-c1 di-this' },
+  { tag: tags.self, class: 'pl-c1 pl-this' },
   { tag: tags.typeName, class: TYPE_NAME },
   { tag: tags.className, class: 'pl-en' },
   { tag: tags.propertyName, class: 'pl-c1' },
@@ -77,19 +77,19 @@ export const jsHighlighter = tagHighlighter([
   { tag: tags.function(tags.variableName), class: 'pl-en' },
   { tag: tags.function(tags.definition(tags.variableName)), class: 'pl-en' },
   { tag: tags.function(tags.propertyName), class: 'pl-en' },
-  { tag: tags.arithmeticOperator, class: 'pl-k di-pu' },
-  { tag: tags.logicOperator, class: 'pl-k di-pu' },
-  { tag: tags.bitwiseOperator, class: 'pl-k di-pu' },
-  { tag: tags.compareOperator, class: 'pl-k di-pu' },
-  { tag: tags.updateOperator, class: 'pl-k di-pu' },
-  { tag: tags.definitionOperator, class: 'pl-k di-pu' },
-  { tag: tags.typeOperator, class: 'pl-k di-pu' },
-  { tag: tags.controlOperator, class: 'pl-k di-pu' },
-  { tag: tags.function(tags.punctuation), class: 'pl-k di-pu' },
+  { tag: tags.arithmeticOperator, class: 'pl-k pl-pu' },
+  { tag: tags.logicOperator, class: 'pl-k pl-pu' },
+  { tag: tags.bitwiseOperator, class: 'pl-k pl-pu' },
+  { tag: tags.compareOperator, class: 'pl-k pl-pu' },
+  { tag: tags.updateOperator, class: 'pl-k pl-pu' },
+  { tag: tags.definitionOperator, class: 'pl-k pl-pu' },
+  { tag: tags.typeOperator, class: 'pl-k pl-pu' },
+  { tag: tags.controlOperator, class: 'pl-k pl-pu' },
+  { tag: tags.function(tags.punctuation), class: 'pl-k pl-pu' },
   { tag: tags.tagName, class: TAG_NAME },
-  { tag: tags.attributeName, class: 'di-ak' },
-  { tag: tags.attributeValue, class: 'pl-s di-av' },
-  { tag: tags.angleBracket, class: 'di-jsx' },
+  { tag: tags.attributeName, class: 'pl-ak' },
+  { tag: tags.attributeValue, class: 'pl-s pl-av' },
+  { tag: tags.angleBracket, class: 'pl-jsx' },
 ]);
 
 const cssExtraStyles = styleTags({ AttributeName: tags.attributeName });
@@ -98,29 +98,29 @@ const cssBase = cssParser.configure({ props: [cssExtraStyles] });
 const cssHighlighter = tagHighlighter([
   { tag: tags.comment, class: 'pl-c' },
   { tag: tags.string, class: 'pl-s' },
-  { tag: tags.propertyName, class: 'di-cp' },
+  { tag: tags.propertyName, class: 'pl-cp' },
   { tag: tags.variableName, class: 'pl-v' },
   { tag: tags.tagName, class: 'pl-ent' },
   { tag: tags.className, class: 'pl-e' },
   { tag: tags.constant(tags.className), class: 'pl-e' },
-  { tag: tags.attributeName, class: 'pl-e di-da' },
+  { tag: tags.attributeName, class: 'pl-e pl-da' },
   { tag: tags.definitionOperator, class: 'pl-ent' },
   { tag: tags.logicOperator, class: 'pl-k' },
   { tag: tags.compareOperator, class: 'pl-k' },
   { tag: tags.definitionKeyword, class: 'pl-k' },
-  { tag: tags.number, class: 'pl-c1 di-num' },
+  { tag: tags.number, class: 'pl-c1 pl-num' },
   { tag: tags.unit, class: 'pl-k' },
-  { tag: tags.atom, class: 'pl-c1 di-cv' },
-  { tag: tags.keyword, class: 'pl-c1 di-cv' },
+  { tag: tags.atom, class: 'pl-c1 pl-cv' },
+  { tag: tags.keyword, class: 'pl-c1 pl-cv' },
   { tag: tags.color, class: 'pl-c1' },
 ]);
 
 const jsonHighlighter = tagHighlighter([
   { tag: tags.propertyName, class: 'pl-ent' },
   { tag: tags.string, class: 'pl-s' },
-  { tag: tags.number, class: 'pl-c1 di-num' },
-  { tag: tags.bool, class: 'pl-c1 di-bool' },
-  { tag: tags.null, class: 'pl-c1 di-n' },
+  { tag: tags.number, class: 'pl-c1 pl-num' },
+  { tag: tags.bool, class: 'pl-c1 pl-bool' },
+  { tag: tags.null, class: 'pl-c1 pl-n' },
 ]);
 
 const jsCommentNodes = new Set(['LineComment', 'BlockComment']);
@@ -159,10 +159,10 @@ LANGUAGES.cts = LANGUAGES.ts;
 
 function specializeClasses(classes: string, text: string): string {
   if (classes === TYPE_NAME) {
-    return BUILT_IN_TYPES.has(text) ? 'pl-c1 di-bt' : 'pl-en';
+    return BUILT_IN_TYPES.has(text) ? 'pl-c1 pl-bt' : 'pl-en';
   }
   if (classes === TAG_NAME) {
-    return /^[a-z]/.test(text) ? 'pl-ent di-ht' : 'di-jt';
+    return /^[a-z]/.test(text) ? 'pl-ent pl-ht' : 'pl-jt';
   }
   return classes;
 }
@@ -198,12 +198,12 @@ function jsTreeFixups(tree: Tree): ClassFixup[] {
       if (node.name === 'JSXAttribute') {
         const equals = node.node.getChild('Equals');
         if (equals) {
-          fixups.push({ from: equals.from, to: equals.to, classes: 'pl-k di-ae' });
+          fixups.push({ from: equals.from, to: equals.to, classes: 'pl-k pl-ae' });
         }
       } else if (node.name === 'JSXMemberExpression') {
         for (let child = node.node.firstChild; child; child = child.nextSibling) {
           if (child.name === 'JSXIdentifier' || child.name === '.') {
-            fixups.push({ from: child.from, to: child.to, classes: 'di-jt' });
+            fixups.push({ from: child.from, to: child.to, classes: 'pl-jt' });
           }
         }
       }

--- a/packages/docs-infra/src/lite/shared/syntax/parseSource.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/parseSource.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from 'vitest';
+import type { Element, Root, RootContent } from 'hast';
+import { parseSource, splitFocusFrame, splitFocusFrameRange } from './parseSource';
+
+function textOf(node: Root | RootContent): string {
+  if (node.type === 'text') {
+    return node.value;
+  }
+  if ('children' in node) {
+    return node.children.map(textOf).join('');
+  }
+  return '';
+}
+
+function isElement(node: Root | RootContent): node is Element {
+  return node.type === 'element';
+}
+
+function linesOf(root: Root): Element[] {
+  const frame = root.children[0];
+  if (!isElement(frame)) {
+    throw new Error('expected a frame element at the tree root');
+  }
+  return frame.children.filter(isElement);
+}
+
+function marksOf(line: Element): string[] {
+  return line.children
+    .filter((child): child is Element => isElement(child) && child.tagName === 'mark')
+    .map(textOf);
+}
+
+function isHighlighted(line: Element): boolean {
+  return 'dataHl' in (line.properties ?? {});
+}
+
+describe('parseSource emphasis directives', () => {
+  it('strips directive comments and applies line highlights and text marks', () => {
+    const source = [
+      '<Tabs.Root defaultValue="overview">',
+      '  <Tabs.List>',
+      '    {/* @highlight-start */}',
+      '    {/* @highlight-text "nativeButton={false}" "render" */}',
+      '    <Tabs.Tab nativeButton={false} render={<Link href="/overview" />} value="overview">',
+      '      Overview',
+      '    </Tabs.Tab>',
+      '    {/* @highlight-end */}',
+      '  </Tabs.List>',
+      '</Tabs.Root>;',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.tsx');
+    const lines = linesOf(root);
+
+    expect(textOf(root)).not.toContain('@highlight');
+    expect(root.data?.totalLines).toBe(7);
+    expect(lines.map(isHighlighted)).toEqual([false, false, true, true, true, false, false]);
+    expect(marksOf(lines[2])).toEqual(['nativeButton={false}', 'render']);
+  });
+
+  it('marks @highlight-text targets regardless of their order on the line', () => {
+    const source = [
+      '// @highlight-text "state" "errors" "formAction"',
+      '<Form action={formAction} errors={state.errors}>',
+      '</Form>;',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.tsx');
+    expect(marksOf(linesOf(root)[0])).toEqual(['formAction', 'errors', 'state']);
+  });
+
+  it('advances repeated @highlight-text targets to successive occurrences', () => {
+    const source = [
+      '// @highlight-text "errors" "errors"',
+      'const errors = mergeErrors(errors);',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(marksOf(linesOf(root)[0])).toEqual(['errors', 'errors']);
+  });
+
+  it('folds a tight {// brace into a stripped trailing directive', () => {
+    const source = [
+      '<Form',
+      '  errors={errors} {// @highlight-text "errors"',
+      '  onSubmit={fn}',
+      '>',
+      '</Form>;',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.tsx');
+    const line = linesOf(root)[1];
+    expect(textOf(line)).toBe('  errors={errors}');
+    expect(marksOf(line)).toEqual(['errors']);
+  });
+
+  it('marks @highlight-text targets in css comments', () => {
+    const source = ['.demo {', '  /* @highlight-text "40px" */', '  width: 40px;', '}', ''].join(
+      '\n',
+    );
+    const root = parseSource(source, 'a.css');
+    expect(marksOf(linesOf(root)[1])).toEqual(['40px']);
+  });
+
+  it('reports focus ranges and post-strip totalLines without highlighting', () => {
+    const source = [
+      'const a = 1;',
+      '// @focus-start',
+      'const b = 2;',
+      'const c = 3;',
+      '// @focus-end',
+      'const d = 4;',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(root.data?.totalLines).toBe(4);
+    expect(root.data?.focusRange).toEqual({ start: 2, end: 3 });
+    expect(linesOf(root).some(isHighlighted)).toBe(false);
+  });
+
+  it('leaves sources without directives untouched', () => {
+    const source = 'const url = "mailto:a@highlight.dev";\n';
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).toBe(source);
+    expect(root.data).toEqual({ totalLines: 1, focusRange: null });
+  });
+});
+
+describe('parseSource emphasis directive modifiers', () => {
+  it('recognizes @focus-start with a @padding modifier and expands the focus range', () => {
+    const source = [
+      'const a = 1;',
+      'const b = 2;',
+      '// @focus-start @padding 1',
+      'const c = 3;',
+      '// @focus-end',
+      'const d = 4;',
+      'const e = 5;',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).not.toContain('@focus');
+    expect(root.data?.totalLines).toBe(5);
+    expect(root.data?.focusRange).toEqual({ start: 2, end: 4 });
+  });
+
+  it('applies @padding on a single-line @focus directive', () => {
+    const source = [
+      'const a = 1;',
+      'const b = 2;',
+      'const c = 3; // @focus @padding 1',
+      'const d = 4;',
+      'const e = 5;',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).toContain('const c = 3;');
+    expect(root.data?.focusRange).toEqual({ start: 2, end: 4 });
+  });
+
+  it('clamps a padded focus range at the file boundaries', () => {
+    const source = ['const a = 1; // @focus @padding 3', 'const b = 2;', ''].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(root.data?.totalLines).toBe(2);
+    expect(root.data?.focusRange).toEqual({ start: 1, end: 2 });
+  });
+
+  it('still applies a directive whose unknown modifiers are ignored', () => {
+    const source = ['const a = 1;', 'const b = 2; // @focus @min 6', ''].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).not.toContain('@min');
+    expect(root.data?.focusRange).toEqual({ start: 2, end: 2 });
+  });
+
+  it('recognizes @highlight with a trailing modifier and ignores the padding', () => {
+    const source = ['const a = 1; // @highlight @padding 2', 'const b = 2;', ''].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).not.toContain('@highlight');
+    expect(linesOf(root).map(isHighlighted)).toEqual([true, false]);
+    expect(root.data?.focusRange).toBeNull();
+  });
+
+  it('tolerates a quoted description after a directive', () => {
+    const source = [
+      '// @focus-start "primary preview area"',
+      'const a = 1;',
+      '// @focus-end',
+      '',
+    ].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).not.toContain('primary preview area');
+    expect(root.data?.focusRange).toEqual({ start: 1, end: 1 });
+  });
+
+  it('does not treat a longer word sharing a directive prefix as a directive', () => {
+    const source = ['// @focused on performance here', 'const a = 1;', ''].join('\n');
+    const root = parseSource(source, 'a.ts');
+    expect(textOf(root)).toContain('@focused on performance here');
+    expect(root.data?.focusRange).toBeNull();
+  });
+});
+
+describe('parseSource JSX generic type arguments', () => {
+  it('reconstructs the source exactly and styles the tag attributes', () => {
+    const source =
+      'const x = <AlertDialog.Root<Payload> handle={h} open>{child}</AlertDialog.Root>;\n';
+    const root = parseSource(source, 'a.tsx');
+    expect(textOf(root)).toBe(source);
+    const spans = linesOf(root)[0].children.filter(isElement);
+    const classOf = (text: string) =>
+      spans
+        .filter((span) => textOf(span) === text)
+        .map((span) => (span.properties.className as string[]).join(' '));
+    expect(classOf('Payload')).toEqual(['pl-en']);
+    expect(classOf('handle')).toEqual(['di-ak']);
+    expect(classOf('open')).toEqual(['di-ak']);
+  });
+
+  it('handles function types inside the type argument', () => {
+    const source = 'const x = <Item.Root<(v: string) => void> handle={h} open />;\n';
+    expect(textOf(parseSource(source, 'a.tsx'))).toBe(source);
+  });
+});
+
+describe('parseSource JSX member tags', () => {
+  const tokensOf = (src: string): Array<[string, string]> =>
+    linesOf(parseSource(src, 'a.tsx'))[0]
+      .children.filter(isElement)
+      .map((child) => [textOf(child), (child.properties.className as string[]).join(' ')]);
+
+  it('colors a lowercase member-tag base as a component, not an html tag', () => {
+    const tokens = tokensOf('const x = <form.Field name="a" />;\n');
+    expect(tokens).toContainEqual(['form', 'di-jt']);
+    expect(tokens).toContainEqual(['.', 'di-jt']);
+    expect(tokens).toContainEqual(['Field', 'di-jt']);
+  });
+
+  it('colors every part of a nested member tag', () => {
+    const tokens = tokensOf('const x = <a.b.c />;\n');
+    for (const part of ['a', 'b', 'c']) {
+      expect(tokens).toContainEqual([part, 'di-jt']);
+    }
+    expect(tokens.filter((token) => token[0] === '.').map((token) => token[1])).toEqual([
+      'di-jt',
+      'di-jt',
+    ]);
+  });
+
+  it('keeps plain lowercase tags html-colored', () => {
+    const tokens = tokensOf('const x = <form action="/a" />;\n');
+    expect(tokens).toContainEqual(['form', 'pl-ent di-ht']);
+  });
+});
+
+describe('parseSource parameter destructuring', () => {
+  const tokensOf = (src: string): Array<[string, string]> =>
+    linesOf(parseSource(src, 'a.tsx'))[0]
+      .children.filter(isElement)
+      .map((child) => [textOf(child), (child.properties.className as string[]).join(' ')]);
+
+  it('colors every name bound by a param pattern as a parameter', () => {
+    const tokens = tokensOf('const f = ({ payload, other: renamed, ...rest }, [x]) => payload;\n');
+    for (const name of ['payload', 'other', 'renamed', 'rest', 'x']) {
+      expect(tokens).toContainEqual([name, 'pl-v']);
+    }
+    expect(tokens.filter((token) => token[0] === 'payload').map((token) => token[1])).toEqual([
+      'pl-v',
+      'pl-smi',
+    ]);
+  });
+
+  it('keeps non-param destructuring and default values stock-colored', () => {
+    const tokens = tokensOf('const { open } = props;\n');
+    expect(tokens).toContainEqual(['open', 'pl-c1']);
+
+    const withDefault = tokensOf('const f = ({ a = other }) => a;\n');
+    expect(withDefault).toContainEqual(['a', 'pl-v']);
+    expect(withDefault).toContainEqual(['other', 'pl-smi']);
+  });
+});
+
+describe('splitFocusFrameRange', () => {
+  const parse = () => parseSource('l1\nl2\nl3\nl4\nl5\n', 'a.txt');
+  const frameTypes = (root: Root) =>
+    root.children.map((frame) =>
+      isElement(frame) ? ((frame.properties?.dataFrameType as string | undefined) ?? null) : null,
+    );
+
+  it('splits a mid-file range into lead, focus, and trail frames', () => {
+    const root = splitFocusFrameRange(parse(), 2, 3);
+    expect(frameTypes(root)).toEqual([null, 'focus', null]);
+    expect(root.children.map(textOf)).toEqual(['l1\n', 'l2\nl3\n', 'l4\nl5\n']);
+  });
+
+  it('clamps an overflowing end line', () => {
+    const root = splitFocusFrameRange(parse(), 4, 9);
+    expect(frameTypes(root)).toEqual([null, 'focus']);
+    expect(textOf(root.children[1])).toBe('l4\nl5\n');
+  });
+
+  it('returns the tree unchanged when the range covers everything', () => {
+    expect(frameTypes(splitFocusFrameRange(parse(), 1, 5))).toEqual([null]);
+  });
+
+  it('keeps splitFocusFrame as the first-N-lines case', () => {
+    const root = splitFocusFrame(parse(), 2);
+    expect(frameTypes(root)).toEqual(['focus', null]);
+    expect(textOf(root.children[0])).toBe('l1\nl2\n');
+  });
+});

--- a/packages/docs-infra/src/lite/shared/syntax/parseSource.test.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/parseSource.test.ts
@@ -212,8 +212,8 @@ describe('parseSource JSX generic type arguments', () => {
         .filter((span) => textOf(span) === text)
         .map((span) => (span.properties.className as string[]).join(' '));
     expect(classOf('Payload')).toEqual(['pl-en']);
-    expect(classOf('handle')).toEqual(['di-ak']);
-    expect(classOf('open')).toEqual(['di-ak']);
+    expect(classOf('handle')).toEqual(['pl-ak']);
+    expect(classOf('open')).toEqual(['pl-ak']);
   });
 
   it('handles function types inside the type argument', () => {
@@ -230,25 +230,25 @@ describe('parseSource JSX member tags', () => {
 
   it('colors a lowercase member-tag base as a component, not an html tag', () => {
     const tokens = tokensOf('const x = <form.Field name="a" />;\n');
-    expect(tokens).toContainEqual(['form', 'di-jt']);
-    expect(tokens).toContainEqual(['.', 'di-jt']);
-    expect(tokens).toContainEqual(['Field', 'di-jt']);
+    expect(tokens).toContainEqual(['form', 'pl-jt']);
+    expect(tokens).toContainEqual(['.', 'pl-jt']);
+    expect(tokens).toContainEqual(['Field', 'pl-jt']);
   });
 
   it('colors every part of a nested member tag', () => {
     const tokens = tokensOf('const x = <a.b.c />;\n');
     for (const part of ['a', 'b', 'c']) {
-      expect(tokens).toContainEqual([part, 'di-jt']);
+      expect(tokens).toContainEqual([part, 'pl-jt']);
     }
     expect(tokens.filter((token) => token[0] === '.').map((token) => token[1])).toEqual([
-      'di-jt',
-      'di-jt',
+      'pl-jt',
+      'pl-jt',
     ]);
   });
 
   it('keeps plain lowercase tags html-colored', () => {
     const tokens = tokensOf('const x = <form action="/a" />;\n');
-    expect(tokens).toContainEqual(['form', 'pl-ent di-ht']);
+    expect(tokens).toContainEqual(['form', 'pl-ent pl-ht']);
   });
 });
 

--- a/packages/docs-infra/src/lite/shared/syntax/parseSource.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/parseSource.ts
@@ -1,0 +1,311 @@
+import type { Element, ElementContent, Root } from 'hast';
+import {
+  BUILT_IN_TYPES,
+  LANGUAGES,
+  findJsxGenericTypeArgRanges,
+  highlightAsTypeArg,
+  jsHighlighter,
+  languageFromFileName,
+  spliceTokens,
+  tokenize,
+} from './highlight';
+import type { Token } from './highlight';
+import {
+  emptyEmphasis,
+  extractEmphasis,
+  resolveTextHighlightRanges,
+  splitTokensAtRanges,
+} from './emphasis';
+import type { FocusRange } from './emphasis';
+
+export interface ParseSourceData {
+  totalLines: number;
+  focusRange: FocusRange | null;
+}
+
+export interface ParseSourceRoot extends Root {
+  data: ParseSourceData;
+}
+
+function toLinedHast(tokens: Token[], options: { highlightedLines?: Set<number> } = {}): Root {
+  const highlightedLines = options.highlightedLines ?? new Set<number>();
+  const lines: ElementContent[] = [];
+  let currentLine: ElementContent[] = [];
+  let markGroup: ElementContent[] | null = null;
+  let lineNumber = 0;
+
+  const flushMark = () => {
+    if (!markGroup) {
+      return;
+    }
+    const properties = highlightedLines.has(lineNumber + 1) ? { dataHl: '' } : {};
+    if (
+      markGroup.length === 1 &&
+      markGroup[0].type === 'element' &&
+      markGroup[0].tagName === 'span'
+    ) {
+      const [child] = markGroup;
+      currentLine.push({
+        ...child,
+        tagName: 'mark',
+        properties: { ...child.properties, ...properties },
+      });
+    } else {
+      currentLine.push({ type: 'element', tagName: 'mark', properties, children: markGroup });
+    }
+    markGroup = null;
+  };
+
+  const pushLine = (endOfLine: boolean) => {
+    flushMark();
+    lineNumber += 1;
+    const newlineInside = endOfLine && currentLine.length === 0;
+    if (newlineInside) {
+      currentLine.push({ type: 'text', value: '\n' });
+    }
+    const properties: Element['properties'] = { className: ['line'], dataLn: lineNumber };
+    if (highlightedLines.has(lineNumber)) {
+      properties.dataHl = '';
+    }
+    lines.push({ type: 'element', tagName: 'span', properties, children: currentLine });
+    if (endOfLine && !newlineInside) {
+      lines.push({ type: 'text', value: '\n' });
+    }
+    currentLine = [];
+  };
+
+  for (const token of tokens) {
+    const parts = token.text.split('\n');
+    // eslint-disable-next-line @typescript-eslint/no-loop-func
+    parts.forEach((part, index) => {
+      if (index > 0) {
+        pushLine(true);
+      }
+      if (part === '') {
+        return;
+      }
+      const node: ElementContent =
+        token.classes === ''
+          ? { type: 'text', value: part }
+          : {
+              type: 'element',
+              tagName: 'span',
+              properties: { className: token.classes.split(' ') },
+              children: [{ type: 'text', value: part }],
+            };
+      if (token.mark) {
+        markGroup = markGroup ? [...markGroup, node] : [node];
+      } else {
+        flushMark();
+        currentLine.push(node);
+      }
+    });
+  }
+  flushMark();
+  if (currentLine.length > 0) {
+    pushLine(false);
+  }
+
+  return {
+    type: 'root',
+    children: [
+      {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['frame'], dataLined: '' },
+        children: lines,
+      },
+    ],
+  };
+}
+
+function spanNode(classes: string, text: string): Element {
+  return {
+    type: 'element',
+    tagName: 'span',
+    properties: { className: classes.split(' ') },
+    children: [{ type: 'text', value: text }],
+  };
+}
+
+function tokenToNode(token: Token): ElementContent {
+  return token.classes === ''
+    ? { type: 'text', value: token.text }
+    : spanNode(token.classes, token.text);
+}
+
+function groupInlineTags(tokens: Token[]): ElementContent[] {
+  const nodes: ElementContent[] = [];
+  let index = 0;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    const next = tokens[index + 1];
+    const opensTag =
+      token.text.endsWith('<') && next && /(?:^| )(?:di-jt|di-ht|pl-ent)(?: |$)/.test(next.classes);
+    if (!opensTag) {
+      nodes.push(tokenToNode(token));
+      index += 1;
+      continue;
+    }
+    let close = index + 1;
+    while (close < tokens.length && !tokens[close].text.includes('>')) {
+      close += 1;
+    }
+    if (close === tokens.length) {
+      nodes.push(tokenToNode(token));
+      index += 1;
+      continue;
+    }
+    const children: ElementContent[] = [];
+    const prefix = token.text.slice(0, -1);
+    if (prefix) {
+      nodes.push(tokenToNode({ classes: token.classes, text: prefix }));
+    }
+    children.push(tokenToNode({ classes: token.classes, text: '<' }));
+    for (let childIndex = index + 1; childIndex < close; childIndex += 1) {
+      children.push(tokenToNode(tokens[childIndex]));
+    }
+    const closeText = tokens[close].text;
+    const bracketEnd = closeText.indexOf('>') + 1;
+    children.push(
+      tokenToNode({ classes: tokens[close].classes, text: closeText.slice(0, bracketEnd) }),
+    );
+    nodes.push({
+      type: 'element',
+      tagName: 'span',
+      properties: { className: [next.classes.includes('di-jt') ? 'di-jt' : 'di-ht'] },
+      children,
+    });
+    const rest = closeText.slice(bracketEnd);
+    if (rest) {
+      tokens[close] = { classes: tokens[close].classes, text: rest };
+      index = close;
+    } else {
+      index = close + 1;
+    }
+  }
+  return nodes;
+}
+
+/** Highlights an inline snippet into flat hast children. */
+export function parseSourceInline(source: string, language?: string): ElementContent[] | null {
+  const lang = LANGUAGES[language ?? ''];
+  if (!lang) {
+    return null;
+  }
+  let text = source;
+  let parenWrapped = false;
+  if (lang.highlighter === jsHighlighter) {
+    const trimmed = text.trim();
+    if (BUILT_IN_TYPES.has(trimmed)) {
+      return [spanNode('pl-c1 di-bt', text)];
+    }
+    if (trimmed.length >= 2 && trimmed.startsWith('{') && trimmed.endsWith('}')) {
+      text = `(${text})`;
+      parenWrapped = true;
+    }
+  }
+  const tokens = tokenize(text, lang);
+  if (parenWrapped && tokens.length > 0) {
+    tokens[0].text = tokens[0].text.slice(1);
+    tokens[tokens.length - 1].text = tokens[tokens.length - 1].text.slice(0, -1);
+  }
+  return groupInlineTags(tokens.filter((token) => token.text !== ''));
+}
+
+export interface ParseSourceOptions {
+  /** Whether to parse and strip emphasis directive comments. */
+  emphasis?: boolean;
+}
+
+/** Highlights source into the docs lined-frame hast structure. */
+export function parseSource(
+  source: string,
+  fileName?: string,
+  language?: string,
+  options: ParseSourceOptions = {},
+): ParseSourceRoot {
+  const lang = LANGUAGES[language ?? ''] ?? LANGUAGES[languageFromFileName(fileName) ?? ''];
+  const emphasis =
+    lang && (options.emphasis ?? true) ? extractEmphasis(source, lang) : emptyEmphasis(source);
+  const jsxGenericRanges = lang ? findJsxGenericTypeArgRanges(emphasis.source, lang) : [];
+  const maskedSource = jsxGenericRanges.reduceRight(
+    (result, range) =>
+      result.slice(0, range.from) + ' '.repeat(range.to - range.from) + result.slice(range.to),
+    emphasis.source,
+  );
+
+  let tokens: Token[] = lang ? tokenize(maskedSource, lang) : [{ text: maskedSource, classes: '' }];
+  tokens = spliceTokens(
+    tokens,
+    jsxGenericRanges.map((range) => ({
+      ...range,
+      tokens: highlightAsTypeArg(emphasis.source.slice(range.from, range.to), lang),
+    })),
+  );
+  tokens = splitTokensAtRanges(
+    tokens,
+    resolveTextHighlightRanges(emphasis.source, emphasis.textHighlights),
+  );
+
+  const root = toLinedHast(tokens, { highlightedLines: emphasis.highlightLines });
+  return {
+    ...root,
+    data: {
+      totalLines: emphasis.source.replace(/\n$/, '').split('\n').length,
+      focusRange: emphasis.focusRange,
+    },
+  };
+}
+
+/** Splits a lined frame around a 1-indexed inclusive focus range. */
+export function splitFocusFrameRange(
+  root: ParseSourceRoot,
+  startLine: number,
+  endLine: number,
+): ParseSourceRoot {
+  const frame = root.children[0];
+  if (root.children.length !== 1 || frame?.type !== 'element') {
+    return root;
+  }
+  const boundaries = [0];
+  let lines = 0;
+  for (let index = 0; index < frame.children.length; index += 1) {
+    if (frame.children[index].type === 'element') {
+      lines += 1;
+      boundaries[lines] = frame.children[index + 1]?.type === 'text' ? index + 2 : index + 1;
+    }
+  }
+  if (startLine < 1 || endLine < startLine || startLine > lines) {
+    return root;
+  }
+  const leadEnd = boundaries[startLine - 1];
+  const focusEnd = boundaries[Math.min(endLine, lines)];
+  if (leadEnd === 0 && focusEnd >= frame.children.length) {
+    return root;
+  }
+
+  const children: Root['children'] = [];
+  if (leadEnd > 0) {
+    children.push({ ...frame, children: frame.children.slice(0, leadEnd) });
+  }
+  children.push({
+    ...frame,
+    properties: { ...frame.properties, dataFrameType: 'focus' },
+    children: frame.children.slice(leadEnd, focusEnd),
+  });
+  if (focusEnd < frame.children.length) {
+    children.push({ ...frame, children: frame.children.slice(focusEnd) });
+  }
+  return { ...root, children };
+}
+
+/** Splits a focus frame around the first N lines. */
+export function splitFocusFrame(root: ParseSourceRoot, focusLines: number): ParseSourceRoot {
+  return splitFocusFrameRange(root, 1, focusLines);
+}
+
+/** Returns the synchronous parser in the existing asynchronous factory shape. */
+export async function createParseSource(): Promise<typeof parseSource> {
+  return parseSource;
+}

--- a/packages/docs-infra/src/lite/shared/syntax/parseSource.ts
+++ b/packages/docs-infra/src/lite/shared/syntax/parseSource.ts
@@ -141,7 +141,7 @@ function groupInlineTags(tokens: Token[]): ElementContent[] {
     const token = tokens[index];
     const next = tokens[index + 1];
     const opensTag =
-      token.text.endsWith('<') && next && /(?:^| )(?:di-jt|di-ht|pl-ent)(?: |$)/.test(next.classes);
+      token.text.endsWith('<') && next && /(?:^| )(?:pl-jt|pl-ht|pl-ent)(?: |$)/.test(next.classes);
     if (!opensTag) {
       nodes.push(tokenToNode(token));
       index += 1;
@@ -173,7 +173,7 @@ function groupInlineTags(tokens: Token[]): ElementContent[] {
     nodes.push({
       type: 'element',
       tagName: 'span',
-      properties: { className: [next.classes.includes('di-jt') ? 'di-jt' : 'di-ht'] },
+      properties: { className: [next.classes.includes('pl-jt') ? 'pl-jt' : 'pl-ht'] },
       children,
     });
     const rest = closeText.slice(bracketEnd);
@@ -198,7 +198,7 @@ export function parseSourceInline(source: string, language?: string): ElementCon
   if (lang.highlighter === jsHighlighter) {
     const trimmed = text.trim();
     if (BUILT_IN_TYPES.has(trimmed)) {
-      return [spanNode('pl-c1 di-bt', text)];
+      return [spanNode('pl-c1 pl-bt', text)];
     }
     if (trimmed.length >= 2 && trimmed.startsWith('{') && trimmed.endsWith('}')) {
       text = `(${text})`;

--- a/packages/docs-infra/src/syntax.css
+++ b/packages/docs-infra/src/syntax.css
@@ -1,0 +1,218 @@
+.pl-c {
+  color: var(--syntax-comment);
+}
+
+.pl-c1,
+.pl-s .pl-v {
+  color: var(--syntax-constant);
+}
+
+.pl-e,
+.pl-en {
+  color: var(--syntax-entity);
+}
+
+.pl-smi,
+.pl-s .pl-s1 {
+  color: var(--syntax-storage-modifier-import);
+}
+
+.pl-ent {
+  color: var(--syntax-entity-tag);
+}
+
+.pl-k {
+  color: var(--syntax-keyword);
+}
+
+.pl-s,
+.pl-pds,
+.pl-s .pl-pse .pl-s1,
+.pl-sr,
+.pl-sr .pl-cce,
+.pl-sr .pl-sre,
+.pl-sr .pl-sra {
+  color: var(--syntax-string);
+}
+
+.pl-v,
+.pl-smw {
+  color: var(--syntax-variable);
+}
+
+.pl-bu {
+  color: var(--syntax-brackethighlighter-unmatched);
+}
+
+.pl-ii {
+  color: var(--syntax-invalid-illegal-text);
+  background-color: var(--syntax-invalid-illegal-bg);
+}
+
+.pl-c2 {
+  color: var(--syntax-carriage-return-text);
+  background-color: var(--syntax-carriage-return-bg);
+}
+
+.pl-sr .pl-cce {
+  font-weight: bold;
+  color: var(--syntax-string-regexp);
+}
+
+.pl-ml {
+  color: var(--syntax-markup-list);
+}
+
+.pl-mh,
+.pl-mh .pl-en,
+.pl-ms {
+  font-weight: bold;
+  color: var(--syntax-markup-heading);
+}
+
+.pl-mi {
+  font-style: italic;
+  color: var(--syntax-markup-italic);
+}
+
+.pl-mb {
+  font-weight: bold;
+  color: var(--syntax-markup-bold);
+}
+
+.pl-md {
+  color: var(--syntax-markup-deleted-text);
+  background-color: var(--syntax-markup-deleted-bg);
+}
+
+.pl-mi1 {
+  color: var(--syntax-markup-inserted-text);
+  background-color: var(--syntax-markup-inserted-bg);
+}
+
+.pl-mc {
+  color: var(--syntax-markup-changed-text);
+  background-color: var(--syntax-markup-changed-bg);
+}
+
+.pl-mi2 {
+  color: var(--syntax-markup-ignored-text);
+  background-color: var(--syntax-markup-ignored-bg);
+}
+
+.pl-mdr {
+  font-weight: bold;
+  color: var(--syntax-meta-diff-range);
+}
+
+.pl-ba {
+  color: var(--syntax-brackethighlighter-angle);
+}
+
+.pl-sg {
+  color: var(--syntax-sublimelinter-gutter-mark);
+}
+
+.pl-corl {
+  text-decoration: underline;
+  color: var(--syntax-constant-other-reference-link);
+}
+
+.pl-cce {
+  color: var(--syntax-string-regexp);
+}
+
+.di-num,
+.pl-num {
+  color: var(--syntax-number);
+}
+
+.di-bool,
+.pl-bool {
+  color: var(--syntax-boolean);
+}
+
+.di-n,
+.pl-n {
+  color: var(--syntax-nullish);
+}
+
+.di-ps {
+  color: var(--syntax-property-string);
+}
+
+.di-op {
+  color: var(--syntax-object-property);
+}
+
+.di-ak,
+.pl-ak {
+  color: var(--syntax-attr-key);
+}
+
+.di-av,
+.pl-av {
+  color: var(--syntax-attr-value);
+}
+
+.di-ae,
+.pl-ae {
+  color: var(--syntax-attr-equals);
+}
+
+.di-da,
+.pl-da {
+  color: var(--syntax-data-attr);
+}
+
+.di-cp,
+.pl-cp {
+  color: var(--syntax-css-property);
+}
+
+.di-cv,
+.pl-cv {
+  color: var(--syntax-css-value);
+}
+
+.di-this,
+.pl-this {
+  color: var(--syntax-this);
+}
+
+.di-bt,
+.pl-bt {
+  color: var(--syntax-builtin-type);
+}
+
+.di-pu,
+.pl-pu {
+  color: var(--syntax-punctuation);
+}
+
+.di-te {
+  color: var(--syntax-template-expression);
+}
+
+.di-td {
+  color: var(--syntax-template-delimiter);
+}
+
+.di-jsx,
+.pl-jsx {
+  color: var(--syntax-jsx);
+}
+
+.di-jv {
+  color: var(--syntax-jsx-variable);
+}
+
+.di-ht,
+.pl-ht {
+  color: var(--syntax-html-tag);
+}
+
+.di-jt,
+.pl-jt {
+  color: var(--syntax-jsx-tag);
+}

--- a/packages/docs-infra/vitest.setup.ts
+++ b/packages/docs-infra/vitest.setup.ts
@@ -11,3 +11,16 @@ import { cleanup } from '@testing-library/react/pure.js';
 // an otherwise-green run. `cleanup()` is a no-op when nothing is mounted, so it is safe in the
 // package's Node-only test files too.
 afterEach(cleanup);
+
+// Vitest's jsdom environment only copies window properties that globalThis lacks. Node >=26 defines
+// `localStorage`/`sessionStorage` itself (undefined without `--localstorage-file`), so jsdom's own are
+// never installed. Restore them from the jsdom window.
+const jsdomWindow: Window | undefined = (globalThis as { jsdom?: { window: Window } }).jsdom
+  ?.window;
+if (jsdomWindow) {
+  for (const key of ['localStorage', 'sessionStorage'] as const) {
+    if (!globalThis[key]) {
+      Object.defineProperty(globalThis, key, { get: () => jsdomWindow[key], configurable: true });
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,6 +862,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@lezer/html':
+        specifier: ^1.3.13
+        version: 1.3.13
       '@lezer/javascript':
         specifier: 1.5.4
         version: 1.5.4
@@ -3138,6 +3141,9 @@ packages:
 
   '@lezer/highlight@1.2.3':
     resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
 
   '@lezer/javascript@1.5.4':
     resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
@@ -12924,6 +12930,12 @@ snapshots:
   '@lezer/highlight@1.2.3':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
 
   '@lezer/javascript@1.5.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -853,6 +853,21 @@ importers:
       '@csstools/postcss-stepped-value-functions':
         specifier: ^5.0.4
         version: 5.0.4(postcss@8.5.23)
+      '@lezer/common':
+        specifier: ^1.5.2
+        version: 1.5.2
+      '@lezer/css':
+        specifier: ^1.3.4
+        version: 1.3.4
+      '@lezer/highlight':
+        specifier: ^1.2.3
+        version: 1.2.3
+      '@lezer/javascript':
+        specifier: 1.5.4
+        version: 1.5.4
+      '@lezer/json':
+        specifier: ^1.0.3
+        version: 1.0.3
       '@orama/orama':
         specifier: ^3.1.18
         version: 3.1.18
@@ -883,6 +898,9 @@ importers:
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
+      hast-util-to-html:
+        specifier: 9.0.5
+        version: 9.0.5
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6(supports-color@10.2.2)
@@ -1016,9 +1034,6 @@ importers:
       estree-util-to-js:
         specifier: 2.0.0
         version: 2.0.0
-      hast-util-to-html:
-        specifier: 9.0.5
-        version: 9.0.5
       next:
         specifier: ^16.2.11
         version: 16.2.11(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -3114,6 +3129,24 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.4':
+    resolution: {integrity: sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
 
   '@mdn/browser-compat-data@5.7.6':
     resolution: {integrity: sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==}
@@ -12879,6 +12912,34 @@ snapshots:
       keyv: 5.6.0
 
   '@keyv/serialize@1.1.1': {}
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
 
   '@mdn/browser-compat-data@5.7.6': {}
 


### PR DESCRIPTION
* Pre-renders all demo code as syntax highlighted html strings
* Sends only the first few lines of the first file for each variant along with other minimal metadata
* Sends a url to the client to fetch the rest of the demo data (other files of all variants) on the client side at its convenience.
* Uses lezer for syntax highlighting and no client side highlighting runtime. This means no editing support with this loader, which is fine for all except core/X.
* Cleaned up the useDemo runtime code to be minimal and no external library.