### PR TITLE
[renovate] Do not pin the next devDependency in this repo

### DIFF
--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -171,7 +171,7 @@
     "@typescript-eslint/utils": "8.64.0",
     "estree-util-to-js": "2.0.0",
     "hast-util-to-html": "9.0.5",
-    "next": "16.2.10",
+    "next": "^16.2.10",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "rehype-parse": "9.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1014,7 +1014,7 @@ importers:
         specifier: 9.0.5
         version: 9.0.5
       next:
-        specifier: 16.2.10
+        specifier: ^16.2.10
         version: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: 19.2.7

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "enabled": false
     },
     {
-      "description": "Do not pin the next devDependency in this repo; let it float with a caret range.",
+      "description": "Do not pin packages that are used as both a dev and non-dev dependency.",
       "matchDepNames": ["next"],
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "bump"

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "enabled": false
     },
     {
-      "description": "Do not pin packages that are used as both a dev and non-dev dependency.",
+      "description": "Override :pinDevDependencies for packages that are used as both a dev and non-dev dependency, so they are not pinned.",
       "matchDepNames": ["next"],
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "bump"

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,12 @@
       "matchPackageNames": ["@mui/*"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Do not pin the next devDependency in this repo; let it float with a caret range.",
+      "matchDepNames": ["next"],
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
`next` is used both as a non-dev `dependency` and a `devDependency`, so `:pinDevDependencies` pins the devDependency copy to an exact version, diverging from the ranged non-dev copies. This repo-local rule overrides that so it keeps a caret range.
