### PR TITLE
Make the manual cherry-pick trigger work

### DIFF
--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -32,6 +32,10 @@ jobs:
       targetBranches: ${{ steps.detect.outputs.TARGET_BRANCHES }}
       reviewers: ${{ steps.detect.outputs.REVIEWERS }}
       labels: ${{ steps.detect.outputs.LABELS }}
+      prNumber: ${{ steps.detect.outputs.PR_NUMBER }}
+      mergeCommitSha: ${{ steps.detect.outputs.MERGE_COMMIT_SHA }}
+      prTitle: ${{ steps.detect.outputs.PR_TITLE }}
+      prAuthor: ${{ steps.detect.outputs.PR_AUTHOR }}
     steps:
       - name: Check out mui-public repo
         id: checkout
@@ -65,22 +69,70 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Full history so the commit being cherry-picked is available locally.
           fetch-depth: 0
-          # Check out the base branch explicitly. On `pull_request_target` the default
-          # resolves to the PR's merge commit SHA, which `actions/checkout` v7 refuses for
-          # fork PRs. We only ever need base branch history to replay the merged commit.
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Cherry pick and create the new PR
-        uses: carloscastrojumo/github-cherry-pick-action@503773289f4a459069c832dc628826685b75b4b3 # v1.0.10
-        with:
-          # the action will run for each value in matrix.branch
-          branch: ${{ matrix.branch }}
+          # Check out the target branch by name. It is the branch we cherry-pick onto, and
+          # naming it explicitly also keeps `actions/checkout` v7 from resolving to the PR's
+          # merge commit, which it refuses for fork PRs on `pull_request_target`.
+          ref: ${{ matrix.branch }}
+          # Same token as `gh` below, so the push and the API calls use one identity.
           token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
-          body: 'Cherry-pick of #{old_pull_request_id}'
-          cherry-pick-branch: ${{ format('cherry-pick-{0}-to-{1}', github.event.number, matrix.branch) }}
-          title: '{old_title} (@${{ github.event.pull_request.user.login }})'
-          # assigning the original reviewers to the new PR
-          reviewers: ${{ needs.detect_cherry_pick_targets.outputs.reviewers }}
-          # instead of inheriting labels (including target branch label, etc.), we filter and set the labels explicitly
-          inherit_labels: false
-          labels: ${{ needs.detect_cherry_pick_targets.outputs.labels }}
+      - name: Cherry pick and create the new PR
+        env:
+          GH_TOKEN: ${{ secrets.token || secrets.GITHUB_TOKEN }}
+          # Everything comes from the detect job, so this step behaves identically whether it
+          # was triggered by `pull_request_target` or manually via `workflow_dispatch`.
+          TARGET_BRANCH: ${{ matrix.branch }}
+          PR_NUMBER: ${{ needs.detect_cherry_pick_targets.outputs.prNumber }}
+          MERGE_COMMIT_SHA: ${{ needs.detect_cherry_pick_targets.outputs.mergeCommitSha }}
+          PR_TITLE: ${{ needs.detect_cherry_pick_targets.outputs.prTitle }}
+          PR_AUTHOR: ${{ needs.detect_cherry_pick_targets.outputs.prAuthor }}
+          REVIEWERS: ${{ needs.detect_cherry_pick_targets.outputs.reviewers }}
+          LABELS: ${{ needs.detect_cherry_pick_targets.outputs.labels }}
+        run: |
+          set -euo pipefail
+
+          CHERRY_PICK_BRANCH="cherry-pick-${PR_NUMBER}-to-${TARGET_BRANCH}"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b "$CHERRY_PICK_BRANCH"
+
+          # `--strategy-option=theirs` resolves conflicts in favour of the cherry-picked
+          # commit instead of failing, matching the behaviour of the action this replaced.
+          if ! output=$(git cherry-pick -m 1 --strategy=recursive --strategy-option=theirs "$MERGE_COMMIT_SHA" 2>&1); then
+            if [[ "$output" == *"The previous cherry-pick is now empty"* ]]; then
+              git cherry-pick --quit
+              echo "::notice::${MERGE_COMMIT_SHA} is already present on ${TARGET_BRANCH}, nothing to cherry-pick."
+              exit 0
+            fi
+            echo "$output"
+            echo "::error::Failed to cherry-pick ${MERGE_COMMIT_SHA} onto ${TARGET_BRANCH}."
+            exit 1
+          fi
+
+          git push -u origin "$CHERRY_PICK_BRANCH"
+
+          pr_url=$(gh pr create \
+            --base "$TARGET_BRANCH" \
+            --head "$CHERRY_PICK_BRANCH" \
+            --title "${PR_TITLE} (@${PR_AUTHOR})" \
+            --body "Cherry-pick of #${PR_NUMBER}")
+          echo "::notice::Opened ${pr_url}"
+
+          # Labels and reviewers are applied over REST because `gh pr edit` goes through
+          # GraphQL, which errors on repositories that still have Projects (classic) enabled.
+          new_pr_number="${pr_url##*/}"
+
+          if [ -n "$LABELS" ]; then
+            jq -nc --arg labels "$LABELS" '{labels: ($labels | split(","))}' \
+              | gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${new_pr_number}/labels" --input - >/dev/null
+          fi
+
+          if [ -n "$REVIEWERS" ]; then
+            # Not fatal: GitHub rejects the whole request if it includes the PR author or a
+            # user without repository access, and the PR itself is more important.
+            jq -nc --arg reviewers "$REVIEWERS" '{reviewers: ($reviewers | split(","))}' \
+              | gh api -X POST "repos/${GITHUB_REPOSITORY}/pulls/${new_pr_number}/requested_reviewers" --input - >/dev/null \
+              || echo "::warning::Could not request reviews from: ${REVIEWERS}"
+          fi

--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -65,6 +65,12 @@ jobs:
       pull-requests: write
       contents: write
     needs: detect_cherry_pick_targets
+    # Serialize runs for the same cherry-pick. The open-PR check below is otherwise a
+    # time-of-check/time-of-use race: an auto run and a manual retry can both find no PR
+    # and then collide on the branch. Queue rather than cancel, so a retry is never dropped.
+    concurrency:
+      group: cherry-pick-${{ github.repository }}-${{ needs.detect_cherry_pick_targets.outputs.prNumber }}-${{ matrix.branch }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -94,6 +94,15 @@ jobs:
 
           CHERRY_PICK_BRANCH="cherry-pick-${PR_NUMBER}-to-${TARGET_BRANCH}"
 
+          # A manual run is usually a retry of a cherry-pick that already half-happened, so
+          # bail out instead of colliding with the branch an earlier run pushed.
+          existing_pr=$(gh pr list --head "$CHERRY_PICK_BRANCH" --base "$TARGET_BRANCH" \
+            --state open --json url --jq '.[0].url // empty')
+          if [ -n "$existing_pr" ]; then
+            echo "::notice::A cherry-pick of #${PR_NUMBER} onto ${TARGET_BRANCH} is already open: ${existing_pr}"
+            exit 0
+          fi
+
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git checkout -b "$CHERRY_PICK_BRANCH"
@@ -111,28 +120,14 @@ jobs:
             exit 1
           fi
 
-          git push -u origin "$CHERRY_PICK_BRANCH"
+          # Force: reaching here means no PR is open for this branch, so anything left behind
+          # by a previous run is stale and safe to replace.
+          git push --force -u origin "$CHERRY_PICK_BRANCH"
 
-          pr_url=$(gh pr create \
+          gh pr create \
             --base "$TARGET_BRANCH" \
             --head "$CHERRY_PICK_BRANCH" \
             --title "${PR_TITLE} (@${PR_AUTHOR})" \
-            --body "Cherry-pick of #${PR_NUMBER}")
-          echo "::notice::Opened ${pr_url}"
-
-          # Labels and reviewers are applied over REST because `gh pr edit` goes through
-          # GraphQL, which errors on repositories that still have Projects (classic) enabled.
-          new_pr_number="${pr_url##*/}"
-
-          if [ -n "$LABELS" ]; then
-            jq -nc --arg labels "$LABELS" '{labels: ($labels | split(","))}' \
-              | gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${new_pr_number}/labels" --input - >/dev/null
-          fi
-
-          if [ -n "$REVIEWERS" ]; then
-            # Not fatal: GitHub rejects the whole request if it includes the PR author or a
-            # user without repository access, and the PR itself is more important.
-            jq -nc --arg reviewers "$REVIEWERS" '{reviewers: ($reviewers | split(","))}' \
-              | gh api -X POST "repos/${GITHUB_REPOSITORY}/pulls/${new_pr_number}/requested_reviewers" --input - >/dev/null \
-              || echo "::warning::Could not request reviews from: ${REVIEWERS}"
-          fi
+            --body "Cherry-pick of #${PR_NUMBER}" \
+            --label "$LABELS" \
+            --reviewer "$REVIEWERS"

--- a/.github/workflows/prs_create-cherry-pick-pr.yml
+++ b/.github/workflows/prs_create-cherry-pick-pr.yml
@@ -103,8 +103,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$CHERRY_PICK_BRANCH"
 
           # `--strategy-option=theirs` resolves conflicts in favour of the cherry-picked

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -31,6 +31,10 @@ module.exports = async ({ core, context, github }) => {
     );
 
     if (wasTriggeredManually) {
+      // A manual run cherry-picks exactly the branch it was given. The PR's own `vN.x` labels
+      // must be discarded, otherwise the requested branch is duplicated when it is also a label
+      // and the matrix runs two jobs racing on the same cherry-pick branch.
+      targetLabels.length = 0;
       targetLabels.push(process.env.TARGET_BRANCH);
     } else {
       core.info(`>>> PR head: ${pr.head.label}`);
@@ -85,6 +89,13 @@ module.exports = async ({ core, context, github }) => {
     core.setOutput('TARGET_BRANCHES', targetLabels);
     core.setOutput('LABELS', ['cherry-pick', ...otherLabels].join(','));
     core.setOutput('REVIEWERS', reviewers.join(','));
+
+    // The PR details the cherry-pick step needs. They are resolved here so that the next
+    // job never has to read the event payload, which is absent on a manual `workflow_dispatch`.
+    core.setOutput('PR_NUMBER', pr.number);
+    core.setOutput('MERGE_COMMIT_SHA', pr.merge_commit_sha);
+    core.setOutput('PR_TITLE', pr.title);
+    core.setOutput('PR_AUTHOR', pr.user.login);
   } catch (error) {
     core.error(`>>> Workflow failed with: ${error.message}`);
     core.setFailed(error.message);

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -22,6 +22,14 @@ module.exports = async ({ core, context, github }) => {
 
     core.info(`>>> PR fetched: ${pr.number}`);
 
+    // A manual run takes an arbitrary PR number, so it can name a PR that was never merged.
+    // `merge_commit_sha` is then either null or an unfetchable test-merge commit, and the
+    // cherry-pick would fail later with a bare `bad revision`/`bad object`.
+    if (!pr.merged) {
+      core.setFailed(`>>> PR #${pr.number} is not merged, there is nothing to cherry-pick.`);
+      return;
+    }
+
     const prLabels = pr.labels.map((label) => label.name);
 
     // filter the target labels from the original PR

--- a/.github/workflows/scripts/prs/detectTargetBranch.test.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.test.js
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import detectTargetBranch from './detectTargetBranch';
+
+/**
+ * Builds a fake `@actions/core` that records `setOutput` calls and the `setFailed` reason.
+ */
+function createCore() {
+  const outputs = {};
+  return {
+    outputs,
+    info: vi.fn(),
+    error: vi.fn(),
+    setOutput: vi.fn((name, value) => {
+      outputs[name] = value;
+    }),
+    setFailed: vi.fn(),
+  };
+}
+
+const context = { repo: { owner: 'mui', repo: 'mui-x' }, issue: { number: 42 } };
+
+/**
+ * A merged PR carrying the usual labels, overridable per test.
+ */
+function createPr(overrides = {}) {
+  return {
+    number: 6,
+    merged: true,
+    merge_commit_sha: 'd29fc6b54a33d35ff6f090d1db54366b29d2595e',
+    title: 'Fix something',
+    user: { login: 'alice' },
+    head: { ref: 'feature/x', label: 'alice:feature/x' },
+    labels: [{ name: 'needs cherry-pick' }, { name: 'v8.x' }, { name: 'scope: pickers' }],
+    requested_reviewers: [],
+    ...overrides,
+  };
+}
+
+function createGithub(pr, reviews = []) {
+  return {
+    rest: {
+      pulls: {
+        get: vi.fn(async () => ({ data: pr })),
+        listReviews: vi.fn(async () => ({ data: reviews })),
+      },
+      issues: { createComment: vi.fn(async () => ({})) },
+    },
+  };
+}
+
+/** Simulates the env the workflow passes: inputs are empty strings when not dispatched manually. */
+function stubDispatch({ prNumber = '', targetBranch = '' } = {}) {
+  vi.stubEnv('PR_NUMBER', prNumber);
+  vi.stubEnv('TARGET_BRANCH', targetBranch);
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('detectTargetBranch', () => {
+  describe('manual dispatch', () => {
+    it('cherry-picks only the dispatched branch, even when it is also a PR label', async () => {
+      const core = createCore();
+      // The PR is labelled `v8.x` and `v7.x`; a manual run for `v8.x` must not duplicate it
+      // nor pull in `v7.x`, otherwise the matrix races two jobs on the same branch.
+      const pr = createPr({
+        labels: [{ name: 'needs cherry-pick' }, { name: 'v8.x' }, { name: 'v7.x' }],
+      });
+      stubDispatch({ prNumber: '6', targetBranch: 'v8.x' });
+
+      await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+      expect(core.outputs.TARGET_BRANCHES).toEqual(['v8.x']);
+      expect(core.setFailed).not.toHaveBeenCalled();
+    });
+
+    it('fails fast when the named PR is not merged', async () => {
+      const core = createCore();
+      const pr = createPr({ merged: false, merge_commit_sha: null });
+      stubDispatch({ prNumber: '6', targetBranch: 'v8.x' });
+
+      await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+      expect(core.setFailed).toHaveBeenCalledWith(expect.stringContaining('not merged'));
+      expect(core.outputs.TARGET_BRANCHES).toBeUndefined();
+    });
+
+    it('exposes the PR details the cherry-pick job needs', async () => {
+      const core = createCore();
+      const pr = createPr({
+        number: 6,
+        merge_commit_sha: 'abc1234',
+        title: 'Fix the thing',
+        user: { login: 'octocat' },
+      });
+      stubDispatch({ prNumber: '6', targetBranch: 'v8.x' });
+
+      await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+      expect(core.outputs.PR_NUMBER).toBe(6);
+      expect(core.outputs.MERGE_COMMIT_SHA).toBe('abc1234');
+      expect(core.outputs.PR_TITLE).toBe('Fix the thing');
+      expect(core.outputs.PR_AUTHOR).toBe('octocat');
+    });
+  });
+
+  describe('automatic trigger', () => {
+    it('targets every `vN.x` label on the PR', async () => {
+      const core = createCore();
+      const pr = createPr({
+        labels: [{ name: 'needs cherry-pick' }, { name: 'v8.x' }, { name: 'v7.x' }],
+      });
+      stubDispatch(); // no inputs -> automatic
+
+      await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+      expect(core.outputs.TARGET_BRANCHES).toEqual(['v8.x', 'v7.x']);
+    });
+
+    it('adds `master` when the PR comes from a version branch', async () => {
+      const core = createCore();
+      const pr = createPr({
+        labels: [{ name: 'needs cherry-pick' }],
+        head: { ref: 'v8.x', label: 'mui:v8.x' },
+      });
+      stubDispatch();
+
+      await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+      expect(core.outputs.TARGET_BRANCHES).toEqual(['master']);
+    });
+
+    it('produces no targets when the PR has no version branch to cherry-pick to', async () => {
+      const core = createCore();
+      const pr = createPr({ labels: [{ name: 'needs cherry-pick' }, { name: 'scope: pickers' }] });
+      stubDispatch();
+
+      await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+      expect(core.outputs.TARGET_BRANCHES).toBe('');
+    });
+  });
+
+  it('sets the cherry-pick label plus the PR labels, minus the routing labels', async () => {
+    const core = createCore();
+    const pr = createPr({
+      labels: [
+        { name: 'needs cherry-pick' },
+        { name: 'v8.x' },
+        { name: 'scope: pickers' },
+        { name: 'bug' },
+      ],
+    });
+    stubDispatch({ prNumber: '6', targetBranch: 'v8.x' });
+
+    await detectTargetBranch({ core, context, github: createGithub(pr) });
+
+    // `needs cherry-pick` and the `vN.x` routing labels are dropped; `cherry-pick` is added.
+    expect(core.outputs.LABELS).toBe('cherry-pick,scope: pickers,bug');
+  });
+
+  it('collects the author, requested reviewers and approvers, de-duplicated', async () => {
+    const core = createCore();
+    const pr = createPr({
+      user: { login: 'alice' },
+      requested_reviewers: [{ login: 'bob' }],
+    });
+    const reviews = [
+      { state: 'APPROVED', user: { login: 'carol' } },
+      { state: 'APPROVED', user: { login: 'carol' } }, // duplicate approval
+      { state: 'COMMENTED', user: { login: 'dave' } }, // not an approval
+      { state: 'APPROVED', user: null }, // deleted account
+    ];
+    stubDispatch({ prNumber: '6', targetBranch: 'v8.x' });
+
+    await detectTargetBranch({ core, context, github: createGithub(pr, reviews) });
+
+    expect(core.outputs.REVIEWERS).toBe('alice,bob,carol');
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -2,6 +2,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['packages/*', 'apps/*'],
+    projects: ['packages/*', 'apps/*', '.github/workflows/scripts'],
   },
 });


### PR DESCRIPTION
## Problem

The reusable cherry-pick workflow advertises `target_branch` / `pr_number` `workflow_dispatch` inputs, but the manual path has never been able to actually cherry-pick. Every manual run in mui-x has failed -- 9 of them since 2026-02-18, 0 successes:

```
##[error]TypeError: Cannot read properties of undefined (reading 'merge_commit_sha')
```

`carloscastrojumo/github-cherry-pick-action` resolves the commit from `github.context.payload.pull_request.merge_commit_sha`. On `workflow_dispatch` there is no `pull_request` payload, so it throws before doing any git work.

This cannot be fixed by passing different inputs. The action's full input list, even on its unreleased `main`, is `token, committer, author, branch, title, body, labels, assignees, reviewers, team-reviewers, cherry-pick-branch, force` -- there is no commit input, so it can only ever learn which commit to pick from a PR event. Nor is there a version to bump to: `v1.0.10` (2024-03-27) is both the latest release and what we already pin.

https://github.com/mui/mui-public/pull/265 and https://github.com/mui/mui-public/pull/266 added and fixed the manual inputs, but only in `detectTargetBranch.js`. The cherry-pick job was never adapted, so detect succeeds and the run dies in the next job -- which makes the feature look like it works.

## Fix

Drop the action and do the cherry-pick inline, fed entirely by outputs from the detect job, which already resolves the PR over the REST API for **both** triggers. The cherry-pick job no longer reads `github.event.*` at all, so `pull_request_target` and `workflow_dispatch` run identical code.

`detectTargetBranch.js` gains four outputs it already had in hand: `PR_NUMBER`, `MERGE_COMMIT_SHA`, `PR_TITLE`, `PR_AUTHOR`.

Conventions are preserved: branch `cherry-pick-<pr>-to-<target>`, `git cherry-pick -m 1 --strategy=recursive --strategy-option=theirs`, title `<old title> (@<author>)`, body `Cherry-pick of #<pr>`, explicit labels, original reviewers.

## Also fixed

**Duplicate targets on manual runs.** The manual path only *appended* the dispatched branch to the PR's existing `vN.x` labels. Dispatching `v8.x` for a PR labelled `v8.x` produced `["v8.x","v8.x"]`; the matrix does not dedupe, so two jobs raced on the same branch. Dead code while dispatch always crashed, live once it works.

**Unmerged PRs fail clearly.** A manual run takes an arbitrary PR number and, unlike the automatic path, has no `merged` guard. For an unmerged PR `merge_commit_sha` is either null or a test-merge commit that is never fetched, so the cherry-pick died later with a bare `bad revision ''` or `bad object <sha>`. The detect job now checks `pr.merged` and fails immediately with the actual reason, before the matrix job starts.

**Re-runs are now idempotent.** A manual run is nearly always a retry of a cherry-pick that already half-happened, so the very first thing it hits is the branch a previous run pushed -- which failed with a bare `non-fast-forward` error. It now exits early with a notice if a cherry-pick PR is already open, and otherwise replaces a stale leftover branch. That check alone is a time-of-check/time-of-use race, so the job also carries a `concurrency` group keyed by repository, PR number and target branch (`cancel-in-progress: false`), which serializes an auto run against a manual retry instead of letting both push the same branch.

## Tests

`detectTargetBranch.js` had no coverage, which is why the manual path stayed broken for months (detect passed, the run then died in the next job). Added a vitest project for `.github/workflows/scripts` and a `detectTargetBranch.test.js` that injects fake `{core, context, github}` and covers: a manual run whose branch is also a PR label (single target, no matrix race), an unmerged PR (`setFailed`, no outputs), the four PR-detail outputs, per-`vN.x`-label targets on the automatic path, the version-branch `master` target, the "no target" case, `LABELS` filtering and reviewer de-duplication. 8 tests; each was mutation-checked to confirm it fails when its behaviour is broken. `pnpm test` (what CI runs) picks the project up automatically.

## Verified end to end

Run against a fork (`LukasTy/mui-x` calling `LukasTy/mui-public`), using a squash-merged PR so the commit shape matches how MUI merges:

- **Creation path** -- cherry-picked onto `v8.x` and opened the PR, with `labels: ["scope: pickers","cherry-pick"]` and `requested_reviewers: ["LukasTy"]`, title `... (@LukasTy)`, body `Cherry-pick of #6`, original commit author preserved and `github-actions[bot]` as committer.
- **Idempotent path** -- re-dispatching while that PR was open exited green with `::notice::A cherry-pick of #6 onto v8.x is already open: <url>`.
- **Auto path** -- the same fixture PR triggered `pull_request_target` and produced its cherry-pick PR normally.

That run also showed `gh pr create --label/--reviewer` works fine, so an earlier revision's REST calls (a workaround for `gh pr edit` hitting a Projects (classic) GraphQL error) were dropped as unnecessary.

## Deliberate behaviour changes

- **Empty cherry-pick exits green.** The action swallowed the "previous cherry-pick is now empty" error and pushed anyway, so `gh pr create` then failed with "No commits between". This runs `git cherry-pick --quit`, logs a notice and exits 0.
- **Checkout ref** is now `matrix.branch` rather than the PR base. This is the branch being cherry-picked onto, and it also keeps `actions/checkout` v7 from resolving to the PR merge commit, which it refuses for fork PRs -- superseding the workaround from https://github.com/mui/mui-public/pull/1694, which is removed here.
- **Checkout uses the same token as `gh`**, so the push and the API calls share one identity.

`master` is merged in, so this carries #1706's reviewer fix.


Note this workflow is consumed by every MUI repo, so merging it is effectively a deploy for all of them. The `pull_request_target` path is the one that must not regress; it was verified working immediately before this change and again in the fork test above.




