### PR TITLE
Request approving reviewers on cherry-pick PRs

### DIFF
--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -64,10 +64,10 @@ module.exports = async ({ core, context, github }) => {
     });
 
     // extract the reviewers who approved the PR from the reviews
-    const approvingReviewers = reviews
-      .filter((review) => review.state === 'APPROVED')
-      // `user` is null when the reviewer's account no longer exists
-      .flatMap((review) => (review.user ? [review.user.login] : []));
+    // `user` is null when the reviewer's account no longer exists
+    const approvingReviewers = reviews.flatMap((review) =>
+      review.state === 'APPROVED' && review.user ? [review.user.login] : [],
+    );
     core.info(`>>> Approving reviewers: ${approvingReviewers.join(', ')}`);
 
     // merge the 2 arrays into a single array of unique reviewers

--- a/.github/workflows/scripts/prs/detectTargetBranch.js
+++ b/.github/workflows/scripts/prs/detectTargetBranch.js
@@ -57,16 +57,17 @@ module.exports = async ({ core, context, github }) => {
     core.info(`>>> Requested reviewers: ${requestedReviewers.join(', ')}`);
 
     // get a list of the reviews done for the PR
-    const { data: reviews } = github.rest.pulls.listReviews({
+    const { data: reviews } = await github.rest.pulls.listReviews({
       owner,
       repo,
       pull_number: pullNumber,
     });
 
     // extract the reviewers who approved the PR from the reviews
-    const approvingReviewers =
-      reviews?.filter((review) => review.state === 'APPROVED').map((review) => review.user.login) ||
-      [];
+    const approvingReviewers = reviews
+      .filter((review) => review.state === 'APPROVED')
+      // `user` is null when the reviewer's account no longer exists
+      .flatMap((review) => (review.user ? [review.user.login] : []));
     core.info(`>>> Approving reviewers: ${approvingReviewers.join(', ')}`);
 
     // merge the 2 arrays into a single array of unique reviewers


### PR DESCRIPTION
Follow-up to https://github.com/mui/mui-public/pull/1705 (independent -- the two touch different parts of the file and can merge in either order).

## Problem

`detectTargetBranch.js` collects the reviewers to carry over to the cherry-pick PR, but the `listReviews` call is missing an `await`:

```js
const { data: reviews } = github.rest.pulls.listReviews({ ... });
```

Destructuring `data` off a pending promise yields `undefined`, so `reviews?.filter(...)` short-circuits and `approvingReviewers` falls back to `[]` on every run. Anyone who approved the original PR has never been requested on its cherry-pick -- only the PR author and reviewers who were still pending at merge time were carried over.

The `?.` and `|| []` were papering over exactly this, which is why it stayed silent.

## Fix

Await the call, and drop the now-redundant defensive operators.

Since that code has never actually executed, it also runs against real data for the first time -- so it now skips reviews whose `user` is `null` (returned when the reviewer's account no longer exists) rather than throwing `Cannot read properties of null` and failing the whole detect job.

The extraction is a single `flatMap` rather than `filter` + `map`, which is worth a note: `.filter` does not narrow `user` here (the predicate returns `false | {login} | null` rather than a boolean, so TypeScript cannot infer a type predicate from it), and a plain `.map` afterwards trips `strictNullChecks` with `TS18047: 'review.user' is possibly 'null'`.

## Verified

With a representative payload (an approval, a comment, a duplicate approval from the same person, a changes-requested, and an approval from a deleted account):

```
old: []
new: ["flaviendelangle","flaviendelangle"]
REVIEWERS output = LukasTy,michelengelen,flaviendelangle
```

Duplicate approvals are collapsed by the existing `new Set(...)`, and the null-user review is skipped. `node --check` and Prettier both pass.
