### PR TITLE
[code-infra] Restore publish-dir workaround for pkg.pr.new#389

### DIFF
--- a/.github/actions/ci-publish/action.yml
+++ b/.github/actions/ci-publish/action.yml
@@ -24,7 +24,7 @@ runs:
         for i in 1 2 3; do
           echo "Attempt $i to publish packages..."
 
-          pnpm exec pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=path) --pnpm --packageManager=pnpm --peerDeps --template './examples/*' --comment=${{ inputs.pr-comment == 'true' && 'update' || 'off' }} --compact false
+          pnpm exec pkg-pr-new publish $(pnpm code-infra list-workspaces --public-only --output=publish-dir) --pnpm --packageManager=pnpm --peerDeps --template './examples/*' --comment=${{ inputs.pr-comment == 'true' && 'update' || 'off' }} --compact false
 
           exit_code=$?
           if [ $exit_code -eq 0 ]; then

--- a/packages/code-infra/src/cli/cmdListWorkspaces.mjs
+++ b/packages/code-infra/src/cli/cmdListWorkspaces.mjs
@@ -6,12 +6,14 @@
  * @typedef {import('../utils/pnpm.mjs').PublicPackage} PublicPackage
  */
 
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { getWorkspacePackages } from '../utils/pnpm.mjs';
 
 /**
  * @typedef {Object} Args
  * @property {boolean} [publicOnly] - Whether to filter to only public packages
- * @property {'json'|'path'|'name'} [output] - Output format (name, path, or json)
+ * @property {'json'|'path'|'name'|'publish-dir'} [output] - Output format (name, path, or json)
  * @property {string} [sinceRef] - Git reference to filter changes since
  * @property {string[]} [filter] - Same as filtering packages with --filter in pnpm. Only include packages matching the filter. See https://pnpm.io/filtering.
  */
@@ -28,10 +30,10 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       })
       .option('output', {
         type: 'string',
-        choices: ['json', 'path', 'name'],
+        choices: ['json', 'path', 'name', 'publish-dir'],
         default: 'path',
         description:
-          'Output format: name (package names), path (package paths), or json (full JSON)',
+          'Output format: name (package names), path (package paths), publish-dir (publish directories), or json (full JSON)',
       })
       .option('since-ref', {
         type: 'string',
@@ -57,6 +59,32 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
       // Print package paths
       packages.forEach((pkg) => {
         console.log(pkg.path);
+      });
+    } else if (output === 'publish-dir') {
+      // Works around https://github.com/stackblitz-labs/pkg.pr.new/issues/389: pkg-pr-new rewrites
+      // workspace:* deps to its URLs in the source package.json, but `pnpm pack` honors
+      // publishConfig.directory and packs the build package.json, whose workspace:* deps are left to
+      // resolve to plain versions. Pointing pkg-pr-new at the build dir makes both act on the same file.
+      // Note: #389 was closed by pkg-pr-new#499, but that only fixed the tarball location, not the dep
+      // resolution — verified still broken on 0.0.78. Do not remove until the packed deps are URLs
+      // without this. Removing it prematurely regressed publishing once (see mui-public#1354).
+      // Print publish directories (package.json publishConfig.directory or package path)
+      const publishDirs = await Promise.all(
+        packages.map(async (pkg) => {
+          const packageJsonPath = path.join(pkg.path, 'package.json');
+          const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
+          const packageJson = JSON.parse(packageJsonContent);
+
+          if (packageJson.publishConfig?.directory) {
+            return path.join(pkg.path, packageJson.publishConfig.directory);
+          }
+
+          return pkg.path;
+        }),
+      );
+
+      publishDirs.forEach((dir) => {
+        console.log(dir);
       });
     } else if (output === 'name') {
       // Print package names (default)


### PR DESCRIPTION
Reverts #1354, which removed the `--output=publish-dir` workaround assuming pkg.pr.new#389 was fixed upstream. It wasn't — pkg-pr-new rewrites `workspace:*` deps to its URLs in the *source* `package.json`, but `pnpm pack` honors `publishConfig.directory` and packs the *build* `package.json`, whose `workspace:*` deps `pnpm pack` then resolves to plain versions. https://github.com/stackblitz-labs/pkg.pr.new/issues/389 was closed by https://github.com/stackblitz-labs/pkg.pr.new/pull/499, but that only fixed the tarball location, not the dep resolution; verified still broken on `0.0.78` (what mui-x pins). Symptom: cross-package pkg.pr.new links regressed on consumer PRs, e.g. mui/mui-x#23209 shipped a version for `@mui/x-internals` instead of its pkg.pr.new URL.

Pointing pkg-pr-new at the build dir makes the rewrite and the pack act on the same file. The restored comment now records why removing it regressed publishing, so it isn't dropped a third time.