### PR TITLE
[docs-infra] Allow documenting props from library

### DIFF
--- a/docs/app/docs-infra/pipeline/load-precomputed-types/types.md
+++ b/docs/app/docs-infra/pipeline/load-precomputed-types/types.md
@@ -71,6 +71,11 @@ type LoaderOptions = {
    * Each entry has a `pattern` (regex string) and `replacement` string.
    */
   descriptionReplacements?: DescriptionReplacement[];
+  /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name.
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
   /** Options for code blocks highlighted inside generated type metadata */
   codeBlockEmphasisOptions?: TransformHtmlCodeBlockOptions;
   /**

--- a/docs/app/docs-infra/pipeline/load-server-types-meta/types.md
+++ b/docs/app/docs-infra/pipeline/load-server-types-meta/types.md
@@ -279,6 +279,13 @@ type LoadServerTypesMetaOptions = {
    * Each entry has a `pattern` (regex string) and `replacement` string.
    */
   descriptionReplacements?: DescriptionReplacement[];
+  /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name. The parser normally drops props that are
+   * only declared inside `node_modules`; this re-adds the configured ones.
+   * @example { BaseUIComponentProps: ['className', 'render', 'style'] }
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
 };
 ```
 

--- a/docs/app/docs-infra/pipeline/load-server-types/types.md
+++ b/docs/app/docs-infra/pipeline/load-server-types/types.md
@@ -393,6 +393,11 @@ type LoadServerTypesOptions = {
    */
   descriptionReplacements?: DescriptionReplacement[];
   /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name.
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
+  /**
    * Directory for the sha256-validated JSON cache of the types pipeline. When set, after
    * writing types.md syncTypes pre-populates `{cacheDir}/types-text/{route}.json` with the
    * parsed `TypesSourceData`, leaving it warm for the next cold `loadServerTypesText` read.

--- a/docs/app/docs-infra/pipeline/sync-types/types.md
+++ b/docs/app/docs-infra/pipeline/sync-types/types.md
@@ -93,6 +93,11 @@ type SyncTypesOptions = {
    */
   descriptionReplacements?: DescriptionReplacement[];
   /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name.
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
+  /**
    * Directory for the sha256-validated JSON cache of the types pipeline. When set, after
    * writing types.md syncTypes pre-populates `{cacheDir}/types-text/{route}.json` with the
    * parsed `TypesSourceData`, leaving it warm for the next cold `loadServerTypesText` read.

--- a/docs/app/docs-infra/pipeline/with-docs-infra/types.md
+++ b/docs/app/docs-infra/pipeline/with-docs-infra/types.md
@@ -260,6 +260,26 @@ type WithDocsInfraOptions = {
    */
   descriptionReplacements?: DescriptionReplacement[];
   /**
+   * Props to re-include in component docs when they are inherited from these
+   * externally declared types, keyed by the declaring type's name. Type
+   * extraction normally drops props that are only declared inside
+   * `node_modules` (which keeps native DOM attributes out of the docs); this
+   * option re-adds the configured props when a component's props type extends
+   * one of the listed types from an installed package.
+   *
+   * Entries can also pin the package the type must come from, to disambiguate
+   * same-named types from different packages.
+   * @example
+   * ```js
+   * { BaseUIComponentProps: ['className', 'render', 'style'] }
+   * ```
+   * @example
+   * ```js
+   * { BaseUIComponentProps: { from: '@base-ui/react', props: ['className', 'render', 'style'] } }
+   * ```
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
+  /**
    * Directory rooting docs-infra's build caches and coordination state — relocate it (or point it
    * at a persistent cache) and everything under it moves together: the sha256-validated JSON caches
    * (`pages-index`, `types-text`, `types-enhanced`) and the index marker directories

--- a/packages/docs-infra/src/cli/loadNextConfig.ts
+++ b/packages/docs-infra/src/cli/loadNextConfig.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { createJiti } from 'jiti';
 import type { DescriptionReplacement } from '../pipeline/loadServerTypesMeta/format';
+import type { InheritedExternalPropsConfig } from '../pipeline/loadServerTypesMeta/inheritedExternalProps';
 import type { OrderingConfig } from '../pipeline/loadServerTypesText/order';
 
 const TYPES_LOADER = '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes';
@@ -34,6 +35,8 @@ export interface DemoPageRequirement {
 export type ExtractedNextConfigOptions = {
   ordering?: OrderingConfig;
   descriptionReplacements?: DescriptionReplacement[];
+  /** Props to re-include when inherited from these externally declared types. */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
   useVisibleDescription?: boolean;
   socketDir?: string;
   /** Page-index cache directory configured on the sitemap loader. */
@@ -103,6 +106,14 @@ function extractOptionsFromLoaderEntries(
         .descriptionReplacements as DescriptionReplacement[];
     }
     if (
+      !result.inheritedExternalProps &&
+      loader.loader === TYPES_LOADER &&
+      loader.options?.inheritedExternalProps
+    ) {
+      result.inheritedExternalProps = loader.options
+        .inheritedExternalProps as InheritedExternalPropsConfig;
+    }
+    if (
       !result.socketDir &&
       loader.loader === TYPES_LOADER &&
       typeof loader.options?.socketDir === 'string'
@@ -146,6 +157,7 @@ export function extractOptionsFromTurbopack(config: any): ExtractedNextConfigOpt
     const extracted = extractOptionsFromLoaderEntries(loaders);
     merged.ordering ??= extracted.ordering;
     merged.descriptionReplacements ??= extracted.descriptionReplacements;
+    merged.inheritedExternalProps ??= extracted.inheritedExternalProps;
     merged.useVisibleDescription ??= extracted.useVisibleDescription;
     merged.socketDir ??= extracted.socketDir;
     merged.cacheDir ??= extracted.cacheDir;
@@ -236,6 +248,7 @@ function extractOptionsFromWebpackResult(result: any): ExtractedNextConfigOption
     const extracted = extractOptionsFromLoaderEntries(useEntries);
     merged.ordering ??= extracted.ordering;
     merged.descriptionReplacements ??= extracted.descriptionReplacements;
+    merged.inheritedExternalProps ??= extracted.inheritedExternalProps;
     merged.useVisibleDescription ??= extracted.useVisibleDescription;
     merged.socketDir ??= extracted.socketDir;
     merged.cacheDir ??= extracted.cacheDir;
@@ -414,6 +427,7 @@ export async function extractDocsInfraOptionsFromNextConfig(
   return {
     ordering: turbopack.ordering ?? webpack.ordering,
     descriptionReplacements: turbopack.descriptionReplacements ?? webpack.descriptionReplacements,
+    inheritedExternalProps: turbopack.inheritedExternalProps ?? webpack.inheritedExternalProps,
     useVisibleDescription: turbopack.useVisibleDescription ?? webpack.useVisibleDescription,
     socketDir: turbopack.socketDir ?? webpack.socketDir,
     cacheDir: turbopack.cacheDir ?? webpack.cacheDir,

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -118,6 +118,7 @@ const runValidate: CommandModule<{}, Args> = {
     const {
       ordering,
       descriptionReplacements,
+      inheritedExternalProps,
       useVisibleDescription = false,
       socketDir: configSocketDir,
       cacheDir: configCacheDir,
@@ -358,6 +359,7 @@ const runValidate: CommandModule<{}, Args> = {
                 },
                 ordering,
                 descriptionReplacements,
+                inheritedExternalProps,
                 socketDir,
                 cacheDir,
               },

--- a/packages/docs-infra/src/cli/validateWorker.ts
+++ b/packages/docs-infra/src/cli/validateWorker.ts
@@ -136,6 +136,7 @@ if (parentPort) {
               : task.syncTypesOptions.updateParentIndex,
             ordering: task.syncTypesOptions.ordering,
             descriptionReplacements: task.syncTypesOptions.descriptionReplacements,
+            inheritedExternalProps: task.syncTypesOptions.inheritedExternalProps,
             socketDir: task.syncTypesOptions.socketDir,
             cacheDir: task.syncTypesOptions.cacheDir,
           });

--- a/packages/docs-infra/src/pipeline/loadPrecomputedTypes/loadPrecomputedTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadPrecomputedTypes/loadPrecomputedTypes.ts
@@ -20,6 +20,7 @@ import { loadServerTypes } from '../loadServerTypes';
 import type { SyncPageIndexBaseOptions } from '../transformMarkdownMetadata/types';
 import { rewriteImportsToNull } from '../loaderUtils/rewriteImports';
 import type { OrderingConfig } from '../loadServerTypesText/order';
+import type { InheritedExternalPropsConfig } from '../loadServerTypesMeta/inheritedExternalProps';
 import type { TransformHtmlCodeBlockOptions } from '../transformHtmlCodeBlock/transformHtmlCodeBlock';
 
 export type LoaderOptions = {
@@ -73,6 +74,11 @@ export type LoaderOptions = {
    * Each entry has a `pattern` (regex string) and `replacement` string.
    */
   descriptionReplacements?: DescriptionReplacement[];
+  /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name.
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
   /** Options for code blocks highlighted inside generated type metadata */
   codeBlockEmphasisOptions?: TransformHtmlCodeBlockOptions;
   /**
@@ -184,6 +190,7 @@ export async function loadPrecomputedTypes(
       externalTypesPattern: options.externalTypesPattern,
       ordering: options.ordering,
       descriptionReplacements: options.descriptionReplacements,
+      inheritedExternalProps: options.inheritedExternalProps,
       codeBlockEmphasisOptions: options.codeBlockEmphasisOptions,
       cacheDir: options.cacheDir,
       sync: true,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/inheritedExternalProps.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/inheritedExternalProps.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import ts from 'typescript';
+import { parseFromProgram } from 'typescript-api-extractor';
+import type { ComponentNode, ExportNode, ObjectNode } from 'typescript-api-extractor';
+import { augmentComponentsWithInheritedProps } from './inheritedExternalProps';
+import type { InheritedExternalPropsConfig } from './inheritedExternalProps';
+import { formatType } from './formatType';
+
+/**
+ * Fake design-system package placed under a real `node_modules` directory, so
+ * the parser treats the shared props as external (as it does when a downstream
+ * library inherits props from an installed package).
+ */
+const DESIGN_SYSTEM_TYPES = `
+import type { ReactElement } from 'react';
+
+export type HTMLProps = Record<string, unknown>;
+
+export type ComponentRenderFn<Props, State> = (props: Props, state: State) => ReactElement;
+
+export type StyledComponentProps<ElementType extends string, State, RenderFunctionProps = HTMLProps> = {
+  /**
+   * CSS class applied to the element, or a function that
+   * returns a class based on the component's state.
+   */
+  className?: string | ((state: State) => string | undefined) | undefined;
+  /**
+   * Allows you to replace the component's HTML element
+   * with a different tag, or compose it with another component.
+   */
+  render?: ReactElement | ComponentRenderFn<RenderFunctionProps, State> | undefined;
+  id?: string | undefined;
+};
+`;
+
+/**
+ * A different package declaring a type with the same name as the design
+ * system's, used to verify the `from` package guard.
+ */
+const DECOY_TYPES = `
+import type { ReactElement } from 'react';
+
+export type StyledComponentProps<State> = {
+  /** Class name from the decoy package. */
+  className?: string | ((state: State) => string | undefined) | undefined;
+};
+`;
+
+const REACT_TYPES = `
+export type ReactElement = { type: unknown; props: unknown };
+export interface SVGAttributes {
+  className?: string | undefined;
+  fill?: string | undefined;
+}
+`;
+
+const LIBRARY_ENTRY = `
+import type { ReactElement, SVGAttributes } from 'react';
+import type { StyledComponentProps } from '@acme/ui';
+import type { StyledComponentProps as DecoyProps } from '@evil/ui';
+
+export interface RootState {
+  disabled: boolean;
+}
+
+export interface RootProps extends StyledComponentProps<'div', RootState> {
+  /**
+   * The dataset for the chart.
+   */
+  data?: string[] | undefined;
+}
+
+/**
+ * Groups all chart parts.
+ */
+export declare function Root(props: RootProps): ReactElement;
+
+export declare namespace Root {
+  export type Props = RootProps;
+  export type State = RootState;
+}
+
+export interface CustomState {}
+
+/** Props overriding an inherited prop with a local declaration. */
+export interface CustomProps extends StyledComponentProps<'span', CustomState> {
+  /**
+   * Locally overridden class name.
+   */
+  className?: string | undefined;
+}
+
+export declare function Custom(props: CustomProps): ReactElement;
+
+export declare namespace Custom {
+  export type Props = CustomProps;
+  export type State = CustomState;
+}
+
+export interface DecoyState {}
+
+/** Props inheriting className from a same-named type in a different package. */
+export interface DecoyComponentProps extends DecoyProps<DecoyState> {
+  label?: string | undefined;
+}
+
+export declare function Decoy(props: DecoyComponentProps): ReactElement;
+
+export interface PlainState {}
+
+/** Props inheriting className from React's SVG attributes, not from the configured type. */
+export interface PlainProps extends SVGAttributes {
+  points?: number[] | undefined;
+}
+
+export declare function Plain(props: PlainProps): ReactElement;
+`;
+
+const PARSER_OPTIONS = {
+  includeExternalTypes: false,
+  shouldInclude: ({ depth }: { depth: number }) => depth <= 15,
+  shouldResolveObject: ({ propertyCount, depth }: { propertyCount: number; depth: number }) =>
+    propertyCount <= 50 && depth <= 15,
+};
+
+const CONFIG: InheritedExternalPropsConfig = {
+  StyledComponentProps: ['className', 'render'],
+};
+
+let projectDir: string;
+let program: ts.Program;
+let entry: string;
+let exports: ExportNode[];
+
+function parseAndAugment(config: InheritedExternalPropsConfig | undefined): ExportNode[] {
+  const result = parseFromProgram(entry, program, PARSER_OPTIONS);
+  augmentComponentsWithInheritedProps(
+    result.exports,
+    program,
+    program.getSourceFile(entry)!,
+    config,
+  );
+  return result.exports;
+}
+
+function findExport(name: string): ExportNode {
+  const exportNode = exports.find((node) => node.name === name);
+  if (!exportNode) {
+    throw new Error(`Export ${name} not found`);
+  }
+  return exportNode;
+}
+
+function formatProp(component: ComponentNode, propName: string): string {
+  const prop = component.props.find((p) => p.name === propName);
+  if (!prop) {
+    throw new Error(`Prop ${propName} not found`);
+  }
+  return formatType(prop.type, {
+    removeUndefined: prop.optional,
+    exportNames: exports.map((node) => node.name),
+    typeNameMap: { RootState: 'Root.State' },
+  });
+}
+
+beforeAll(() => {
+  projectDir = mkdtempSync(path.join(tmpdir(), 'inherited-external-props-'));
+
+  const reactDir = path.join(projectDir, 'node_modules', 'react');
+  const designSystemDir = path.join(projectDir, 'node_modules', '@acme', 'ui');
+  mkdirSync(reactDir, { recursive: true });
+  mkdirSync(designSystemDir, { recursive: true });
+
+  writeFileSync(path.join(reactDir, 'package.json'), '{ "name": "react", "types": "index.d.ts" }');
+  writeFileSync(path.join(reactDir, 'index.d.ts'), REACT_TYPES);
+  writeFileSync(
+    path.join(designSystemDir, 'package.json'),
+    '{ "name": "@acme/ui", "types": "index.d.ts" }',
+  );
+  writeFileSync(path.join(designSystemDir, 'index.d.ts'), DESIGN_SYSTEM_TYPES);
+
+  const decoyDir = path.join(projectDir, 'node_modules', '@evil', 'ui');
+  mkdirSync(decoyDir, { recursive: true });
+  writeFileSync(
+    path.join(decoyDir, 'package.json'),
+    '{ "name": "@evil/ui", "types": "index.d.ts" }',
+  );
+  writeFileSync(path.join(decoyDir, 'index.d.ts'), DECOY_TYPES);
+
+  writeFileSync(path.join(projectDir, 'index.ts'), LIBRARY_ENTRY);
+
+  entry = path.join(projectDir, 'index.ts');
+  program = ts.createProgram([entry], {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    strict: true,
+    skipLibCheck: true,
+    rootDir: projectDir,
+  });
+
+  exports = parseAndAugment(CONFIG);
+});
+
+afterAll(() => {
+  rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe('augmentComponentsWithInheritedProps', () => {
+  it('adds the configured props to components inheriting them from an external type', () => {
+    const component = findExport('Root').type as ComponentNode;
+    const propNames = component.props.map((prop) => prop.name);
+    expect(propNames).toContain('data');
+    expect(propNames).toContain('className');
+    expect(propNames).toContain('render');
+  });
+
+  it('formats a synthesized union prop like a locally declared one', () => {
+    const component = findExport('Root').type as ComponentNode;
+    expect(formatProp(component, 'className')).toBe(
+      'string | ((state: Root.State) => string | undefined)',
+    );
+  });
+
+  it('formats a synthesized render prop with the resolved type arguments', () => {
+    const component = findExport('Root').type as ComponentNode;
+    expect(formatProp(component, 'render')).toBe(
+      'ReactElement | ((props: HTMLProps, state: Root.State) => ReactElement)',
+    );
+  });
+
+  it('takes prop descriptions from the external declaration JSDoc', () => {
+    const component = findExport('Root').type as ComponentNode;
+    const className = component.props.find((prop) => prop.name === 'className');
+    expect(className?.documentation?.description).toContain('CSS class applied to the element');
+    expect(className?.optional).toBe(true);
+  });
+
+  it('does not add props of the external type that are not configured', () => {
+    const component = findExport('Root').type as ComponentNode;
+    expect(component.props.map((prop) => prop.name)).not.toContain('id');
+  });
+
+  it('mirrors the synthesized props onto the exported props types', () => {
+    const namespaced = findExport('Root.Props').type as ObjectNode;
+    expect(namespaced.properties.map((prop) => prop.name)).toContain('className');
+
+    const flat = findExport('RootProps').type as ObjectNode;
+    expect(flat.properties.map((prop) => prop.name)).toContain('render');
+  });
+
+  it('keeps a local override of an inherited prop instead of the external declaration', () => {
+    const component = findExport('Custom').type as ComponentNode;
+    const classNameProps = component.props.filter((prop) => prop.name === 'className');
+    expect(classNameProps).toHaveLength(1);
+    expect(formatProp(component, 'className')).toBe('string');
+    expect(classNameProps[0].documentation?.description).toContain('Locally overridden class name');
+
+    // Props without a local override are still synthesized from the external type.
+    expect(formatProp(component, 'render')).toContain('ReactElement');
+  });
+
+  it('keeps the local override in the mirrored props type exports', () => {
+    const namespaced = findExport('Custom.Props').type as ObjectNode;
+    const classNameProps = namespaced.properties.filter((prop) => prop.name === 'className');
+    expect(classNameProps).toHaveLength(1);
+    expect(classNameProps[0].documentation?.description).toContain('Locally overridden class name');
+    expect(namespaced.properties.map((prop) => prop.name)).toContain('render');
+  });
+
+  it('ignores props inherited from types that are not configured', () => {
+    const component = findExport('Plain').type as ComponentNode;
+    expect(component.props.map((prop) => prop.name)).toEqual(['points']);
+  });
+
+  it('matches by type name alone when no package is configured', () => {
+    const component = findExport('Decoy').type as ComponentNode;
+    expect(component.props.map((prop) => prop.name)).toContain('className');
+  });
+
+  it('only augments props declared in the configured package when `from` is set', () => {
+    const pinned = parseAndAugment({
+      StyledComponentProps: { from: '@acme/ui', props: ['className', 'render'] },
+    });
+
+    const root = pinned.find((node) => node.name === 'Root')!.type as ComponentNode;
+    expect(root.props.map((prop) => prop.name)).toContain('className');
+    expect(root.props.map((prop) => prop.name)).toContain('render');
+
+    const decoy = pinned.find((node) => node.name === 'Decoy')!.type as ComponentNode;
+    expect(decoy.props.map((prop) => prop.name)).toEqual(['label']);
+  });
+
+  it('does nothing without configuration', () => {
+    const unconfigured = parseAndAugment(undefined);
+    const component = unconfigured.find((node) => node.name === 'Root')!.type as ComponentNode;
+    expect(component.props.map((prop) => prop.name)).toEqual(['data']);
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/inheritedExternalProps.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/inheritedExternalProps.ts
@@ -1,0 +1,431 @@
+import ts from 'typescript';
+import {
+  CallSignature,
+  Documentation,
+  ExternalTypeNode,
+  FunctionNode,
+  IntrinsicNode,
+  LiteralNode,
+  Parameter,
+  PropertyNode,
+  TypeName,
+  UnionNode,
+} from 'typescript-api-extractor';
+import type { AnyType, ComponentNode, ExportNode } from 'typescript-api-extractor';
+import { isComponentType, isObjectType } from './typeGuards';
+
+/**
+ * Props to re-include for a single externally declared type. Either a list of
+ * prop names, or an object that additionally pins the package the type must be
+ * declared in — use the object form when another installed package could
+ * declare a type with the same name.
+ */
+export type InheritedExternalPropsEntry =
+  | string[]
+  | {
+      /** Name of the package the type must be declared in (e.g. `@base-ui/react`). */
+      from: string;
+      props: string[];
+    };
+
+/**
+ * Props to re-include when they are inherited from externally declared types,
+ * keyed by the name of the type (interface or type alias) that declares them.
+ *
+ * @example { BaseUIComponentProps: ['className', 'render', 'style'] }
+ * @example { BaseUIComponentProps: { from: '@base-ui/react', props: ['className'] } }
+ */
+export interface InheritedExternalPropsConfig {
+  [typeName: string]: InheritedExternalPropsEntry;
+}
+
+interface ResolvedConfigEntry {
+  from?: string;
+  props: string[];
+}
+
+function resolveConfig(config: InheritedExternalPropsConfig): Map<string, ResolvedConfigEntry> {
+  return new Map(
+    Object.entries(config).map(([typeName, entry]) => [
+      typeName,
+      Array.isArray(entry) ? { props: entry } : entry,
+    ]),
+  );
+}
+
+/** Bail out of type conversion once nesting gets deeper than any expected prop shape. */
+const MAX_CONVERSION_DEPTH = 8;
+
+/**
+ * Re-adds configured props to parsed component exports when they are inherited
+ * from a type declared in an installed package. typescript-api-extractor skips
+ * properties that are only declared inside `node_modules` (which is what keeps
+ * native DOM attributes out of the docs), so shared props that a library
+ * inherits from another package's base props type silently disappear from its
+ * prop tables. The synthesized nodes are built from the checker's resolved
+ * types, so the output matches what the extractor produces when the same props
+ * are declared locally.
+ */
+export function augmentComponentsWithInheritedProps(
+  exports: ExportNode[],
+  program: ts.Program,
+  sourceFile: ts.SourceFile,
+  config: InheritedExternalPropsConfig | undefined,
+): void {
+  if (!config || Object.keys(config).length === 0) {
+    return;
+  }
+
+  const checker = program.getTypeChecker();
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (!moduleSymbol) {
+    return;
+  }
+
+  const symbolsByExportName = new Map<string, ts.Symbol>();
+  collectExportSymbols(checker, moduleSymbol, [], symbolsByExportName, new Set());
+
+  const exportNames = exports.map((exportNode) => exportNode.name);
+  const resolvedConfig = resolveConfig(config);
+  const propNames = new Set(Array.from(resolvedConfig.values()).flatMap((entry) => entry.props));
+
+  for (const exportNode of exports) {
+    if (!isComponentType(exportNode.type)) {
+      continue;
+    }
+
+    const symbol = symbolsByExportName.get(exportNode.name);
+    if (!symbol) {
+      continue;
+    }
+
+    const propsType = getComponentPropsType(checker, symbol);
+    if (!propsType) {
+      continue;
+    }
+
+    const component = exportNode.type as ComponentNode;
+    const existingNames = new Set(component.props.map((prop) => prop.name));
+    const addedProps: PropertyNode[] = [];
+
+    for (const propName of propNames) {
+      if (existingNames.has(propName)) {
+        continue;
+      }
+
+      const propSymbol = propsType.getProperty(propName);
+      if (!propSymbol || !isInheritedExternalProp(propSymbol, propName, resolvedConfig)) {
+        continue;
+      }
+
+      const propNode = createPropNode(propSymbol, checker, exportNames);
+      if (propNode) {
+        addedProps.push(propNode);
+      }
+    }
+
+    if (addedProps.length === 0) {
+      continue;
+    }
+
+    component.props.push(...addedProps);
+    augmentPropsTypeExports(exports, exportNode, addedProps);
+  }
+}
+
+/**
+ * Mirrors the synthesized props onto the exported props type of the component
+ * (both the namespaced `Component.Props` alias and the flat interface export),
+ * so their rendered type definitions match the component's prop table.
+ */
+function augmentPropsTypeExports(
+  exports: ExportNode[],
+  componentExport: ExportNode,
+  addedProps: PropertyNode[],
+): void {
+  const componentName = componentExport.name;
+  const propsExportNames = new Set([
+    `${componentName}.Props`,
+    `${componentName.replaceAll('.', '')}Props`,
+  ]);
+  if (componentExport.reexportedFrom) {
+    propsExportNames.add(`${componentExport.reexportedFrom}Props`);
+  }
+
+  for (const exportNode of exports) {
+    if (!propsExportNames.has(exportNode.name) || !isObjectType(exportNode.type)) {
+      continue;
+    }
+    const existingNames = new Set(exportNode.type.properties.map((prop) => prop.name));
+    exportNode.type.properties.push(...addedProps.filter((prop) => !existingNames.has(prop.name)));
+  }
+}
+
+/**
+ * Maps parsed export names to their TypeScript symbols, using the same naming
+ * scheme as typescript-api-extractor (namespace members become dotted names,
+ * e.g. `Menu.Root`).
+ */
+function collectExportSymbols(
+  checker: ts.TypeChecker,
+  moduleSymbol: ts.Symbol,
+  namespaces: string[],
+  result: Map<string, ts.Symbol>,
+  visited: Set<ts.Symbol>,
+): void {
+  if (namespaces.length > 2 || visited.has(moduleSymbol)) {
+    return;
+  }
+  visited.add(moduleSymbol);
+
+  for (const exportSymbol of checker.getExportsOfModule(moduleSymbol)) {
+    const name = [...namespaces, exportSymbol.name].join('.');
+    result.set(name, exportSymbol);
+
+    // Recurse into `export * as Namespace from '...'` re-exports.
+    const declaration = exportSymbol.declarations?.[0];
+    if (declaration && ts.isNamespaceExport(declaration)) {
+      const aliased = checker.getAliasedSymbol(exportSymbol);
+      if (aliased) {
+        collectExportSymbols(checker, aliased, [...namespaces, exportSymbol.name], result, visited);
+      }
+    }
+  }
+}
+
+/**
+ * Resolves the props type of a component export from its first call signature.
+ */
+function getComponentPropsType(checker: ts.TypeChecker, symbol: ts.Symbol): ts.Type | undefined {
+  // eslint-disable-next-line no-bitwise
+  const isAlias = (symbol.flags & ts.SymbolFlags.Alias) !== 0;
+  const resolvedSymbol = isAlias ? checker.getAliasedSymbol(symbol) : symbol;
+  const componentType = checker.getTypeOfSymbol(resolvedSymbol);
+
+  for (const signature of componentType.getCallSignatures()) {
+    const propsParameter = signature.parameters[0];
+    const declaration = propsParameter?.valueDeclaration ?? propsParameter?.declarations?.[0];
+    if (declaration) {
+      return checker.getTypeOfSymbolAtLocation(propsParameter, declaration);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Checks that a prop is declared in an installed package on one of the
+ * configured types (and, when configured, in the expected package). Locally
+ * declared props are already handled by the extractor, and external props of
+ * any other origin (e.g. native DOM attributes) must stay excluded from the
+ * docs.
+ */
+function isInheritedExternalProp(
+  propSymbol: ts.Symbol,
+  propName: string,
+  config: Map<string, ResolvedConfigEntry>,
+): boolean {
+  const declarations = propSymbol.declarations ?? [];
+  if (declarations.length === 0) {
+    return false;
+  }
+
+  return declarations.every((declaration) => {
+    const fileName = declaration.getSourceFile().fileName;
+    if (!fileName.includes('node_modules')) {
+      return false;
+    }
+    const owner = ts.findAncestor(
+      declaration,
+      (node): node is ts.TypeAliasDeclaration | ts.InterfaceDeclaration =>
+        ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node),
+    );
+    const entry = owner && config.get(owner.name.text);
+    if (!entry || !entry.props.includes(propName)) {
+      return false;
+    }
+    return !entry.from || getPackageName(fileName) === entry.from;
+  });
+}
+
+/**
+ * Extracts the package name from a file path inside `node_modules`,
+ * e.g. `.../node_modules/@base-ui/react/types.d.ts` → `@base-ui/react`.
+ * Uses the last `node_modules` segment to handle nested installations.
+ */
+function getPackageName(fileName: string): string | undefined {
+  const segments = fileName.split(/[\\/]/);
+  const index = segments.lastIndexOf('node_modules');
+  if (index === -1) {
+    return undefined;
+  }
+  const first = segments[index + 1];
+  if (!first) {
+    return undefined;
+  }
+  if (first.startsWith('@')) {
+    const second = segments[index + 2];
+    return second ? `${first}/${second}` : undefined;
+  }
+  return first;
+}
+
+function createPropNode(
+  propSymbol: ts.Symbol,
+  checker: ts.TypeChecker,
+  exportNames: readonly string[],
+): PropertyNode | undefined {
+  const declaration = propSymbol.valueDeclaration ?? propSymbol.declarations?.[0];
+  if (!declaration) {
+    return undefined;
+  }
+
+  const propType = checker.getTypeOfSymbolAtLocation(propSymbol, declaration);
+  const description = ts.displayPartsToString(propSymbol.getDocumentationComment(checker));
+  // eslint-disable-next-line no-bitwise
+  const optional = (propSymbol.flags & ts.SymbolFlags.Optional) !== 0;
+
+  return new PropertyNode(
+    propSymbol.name,
+    convertType(propType, checker, exportNames, 0),
+    description ? new Documentation(description) : undefined,
+    optional,
+  );
+}
+
+/**
+ * Converts a checker-resolved type into the extractor's type model, mirroring
+ * how typescript-api-extractor represents locally declared props: intrinsics
+ * and unions are expanded, anonymous function types are expanded into call
+ * signatures, and named types become references.
+ */
+function convertType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  exportNames: readonly string[],
+  depth: number,
+): AnyType {
+  if (depth > MAX_CONVERSION_DEPTH) {
+    return new ExternalTypeNode(new TypeName(checker.typeToString(type)));
+  }
+
+  const intrinsic = getIntrinsicName(type);
+  if (intrinsic) {
+    return new IntrinsicNode(intrinsic);
+  }
+
+  // eslint-disable-next-line no-bitwise
+  if ((type.flags & ts.TypeFlags.Literal) !== 0) {
+    return new LiteralNode(checker.typeToString(type));
+  }
+
+  if (type.isUnion()) {
+    return new UnionNode(
+      undefined,
+      type.types.map((member) => convertType(member, checker, exportNames, depth + 1)),
+    );
+  }
+
+  const typeName = getNamedTypeReference(type, exportNames);
+  const callSignatures = type.getCallSignatures();
+  if (callSignatures.length > 0) {
+    return new FunctionNode(
+      typeName,
+      callSignatures.map((signature) => convertSignature(signature, checker, exportNames, depth)),
+    );
+  }
+
+  if (typeName) {
+    return new ExternalTypeNode(typeName);
+  }
+
+  return new ExternalTypeNode(new TypeName(checker.typeToString(type)));
+}
+
+function convertSignature(
+  signature: ts.Signature,
+  checker: ts.TypeChecker,
+  exportNames: readonly string[],
+  depth: number,
+): CallSignature {
+  const parameters = signature.parameters.map((parameter) => {
+    const declaration = parameter.valueDeclaration ?? parameter.declarations?.[0];
+    const parameterType = declaration
+      ? checker.getTypeOfSymbolAtLocation(parameter, declaration)
+      : checker.getTypeOfSymbol(parameter);
+    const optional = Boolean(
+      declaration &&
+      ts.isParameter(declaration) &&
+      (declaration.questionToken || declaration.initializer),
+    );
+    return new Parameter(
+      convertType(parameterType, checker, exportNames, depth + 1),
+      parameter.name,
+      undefined,
+      optional,
+      undefined,
+    );
+  });
+
+  return new CallSignature(
+    parameters,
+    convertType(signature.getReturnType(), checker, exportNames, depth + 1),
+  );
+}
+
+type IntrinsicName = ConstructorParameters<typeof IntrinsicNode>[0];
+
+const INTRINSIC_FLAGS: Array<[ts.TypeFlags, IntrinsicName]> = [
+  [ts.TypeFlags.String, 'string'],
+  [ts.TypeFlags.Number, 'number'],
+  [ts.TypeFlags.Boolean, 'boolean'],
+  [ts.TypeFlags.BigInt, 'bigint'],
+  [ts.TypeFlags.Undefined, 'undefined'],
+  [ts.TypeFlags.Null, 'null'],
+  [ts.TypeFlags.Void, 'void'],
+  [ts.TypeFlags.Any, 'any'],
+  [ts.TypeFlags.Unknown, 'unknown'],
+  [ts.TypeFlags.Never, 'never'],
+];
+
+function getIntrinsicName(type: ts.Type): IntrinsicName | undefined {
+  // `boolean` is represented as a union of literals, so check it before unions.
+  // eslint-disable-next-line no-bitwise
+  const match = INTRINSIC_FLAGS.find(([flag]) => (type.flags & flag) !== 0);
+  return match?.[1];
+}
+
+/**
+ * Builds a reference for a named type, preferring the module's dotted export
+ * name (e.g. `Menu.Root.State`) when one exists for the flat name.
+ */
+function getNamedTypeReference(
+  type: ts.Type,
+  exportNames: readonly string[],
+): TypeName | undefined {
+  const symbol = type.aliasSymbol ?? type.getSymbol();
+  const name = symbol?.name;
+  if (!symbol || !name || name.startsWith('__')) {
+    return undefined;
+  }
+
+  // Collect enclosing namespaces (e.g. `React` for `React.CSSProperties`),
+  // stopping at module/source-file symbols whose names are quoted paths.
+  const namespaces: string[] = [];
+  let parent = (symbol as { parent?: ts.Symbol }).parent;
+  while (parent && /^[A-Za-z_$][\w$]*$/.test(parent.name)) {
+    namespaces.unshift(parent.name);
+    parent = (parent as { parent?: ts.Symbol }).parent;
+  }
+
+  const flatName = [...namespaces, name].join('');
+  const dottedName = exportNames.find(
+    (exportName) => exportName.includes('.') && exportName.replaceAll('.', '') === flatName,
+  );
+  if (dottedName) {
+    const parts = dottedName.split('.');
+    return new TypeName(parts[parts.length - 1], parts.slice(0, -1));
+  }
+
+  return new TypeName(name, namespaces.length > 0 ? namespaces : undefined);
+}

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadServerTypesMeta.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/loadServerTypesMeta.ts
@@ -25,6 +25,7 @@ import type {
   FormatInlineTypeOptions,
   DescriptionReplacement,
 } from './format';
+import type { InheritedExternalPropsConfig } from './inheritedExternalProps';
 import { buildTypeCompatibilityMap } from './rewriteTypes';
 import type { TypeRewriteContext } from './rewriteTypes';
 import type { ExternalTypeMeta, ExternalTypesCollector } from './externalTypes';
@@ -139,6 +140,14 @@ export interface LoadServerTypesMetaOptions {
    * Each entry has a `pattern` (regex string) and `replacement` string.
    */
   descriptionReplacements?: DescriptionReplacement[];
+  /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name. The parser normally drops props that are
+   * only declared inside `node_modules`; this re-adds the configured ones.
+   *
+   * @example { BaseUIComponentProps: ['className', 'render', 'style'] }
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
 }
 
 export interface LoadServerTypesMetaResult extends OrganizeTypesResult<TypesMeta> {
@@ -337,6 +346,7 @@ export async function loadServerTypesMeta(
     dependencies: config.dependencies,
     rootContextDir,
     relativePath,
+    inheritedExternalProps: options.inheritedExternalProps,
   });
 
   if (!workerResult.success) {

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/processTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/processTypes.ts
@@ -5,6 +5,8 @@ import { parseFromProgram } from 'typescript-api-extractor';
 import type { ExportNode, ParserOptions, TypeName, AnyType } from 'typescript-api-extractor';
 import ts from 'typescript';
 import { createOptimizedProgram } from './createOptimizedProgram';
+import { augmentComponentsWithInheritedProps } from './inheritedExternalProps';
+import type { InheritedExternalPropsConfig } from './inheritedExternalProps';
 import { extractJSDocText, isJSDocNodeArray } from './extractJSDocText';
 import { PerformanceTracker } from './performanceTracking';
 import type { PerformanceLog } from './performanceTracking';
@@ -298,6 +300,11 @@ export interface WorkerRequest {
   /** Root context directory path (must end with /) */
   rootContextDir: string;
   relativePath: string;
+  /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name.
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
 }
 
 export interface WorkerResponse {
@@ -381,6 +388,15 @@ export async function processTypes(request: WorkerRequest): Promise<WorkerRespon
           // Use parseFromProgram directly - it now handles namespace exports,
           // type aliases, and re-exports properly
           const { exports } = parseFromProgram(entrypoint, program, parserOptions);
+
+          // Re-add configured props that the parser dropped because they are
+          // inherited from an externally declared type in node_modules
+          augmentComponentsWithInheritedProps(
+            exports,
+            program,
+            sourceFile,
+            request.inheritedExternalProps,
+          );
 
           // Extract namespaces from the exports (e.g., "Menu" from "Menu.Root")
           const namespaces = extractNamespaces(exports);

--- a/packages/docs-infra/src/pipeline/syncTypes/syncTypes.ts
+++ b/packages/docs-infra/src/pipeline/syncTypes/syncTypes.ts
@@ -6,6 +6,7 @@ import { extractNameAndSlugFromUrl } from '../loaderUtils';
 import { nameMark, performanceMeasure } from '../loadPrecomputedCodeHighlighter/performanceLogger';
 import { loadServerTypesMeta } from '../loadServerTypesMeta';
 import type { TypesMeta } from '../loadServerTypesMeta';
+import type { InheritedExternalPropsConfig } from '../loadServerTypesMeta/inheritedExternalProps';
 import type {
   FormatInlineTypeOptions,
   DescriptionReplacement,
@@ -87,6 +88,11 @@ export interface SyncTypesOptions {
    * Each entry has a `pattern` (regex string) and `replacement` string.
    */
   descriptionReplacements?: DescriptionReplacement[];
+  /**
+   * Props to re-include when inherited from these externally declared types,
+   * keyed by the declaring type's name.
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
   /**
    * Directory for the sha256-validated JSON cache of the types pipeline. When set, after
    * writing types.md syncTypes pre-populates `{cacheDir}/types-text/{route}.json` with the
@@ -286,6 +292,7 @@ export async function syncTypes(options: SyncTypesOptions): Promise<TypesSourceD
     externalTypesPattern: options.externalTypesPattern,
     ordering: options.ordering,
     descriptionReplacements: options.descriptionReplacements,
+    inheritedExternalProps: options.inheritedExternalProps,
   });
 
   const {

--- a/packages/docs-infra/src/withDocsInfra/withDocsInfra.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDocsInfra.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 import type { Configuration as WebpackConfig, RuleSetRule } from 'webpack';
 import type { OrderingConfig } from '../pipeline/loadServerTypesText/order';
 import type { DescriptionReplacement } from '../pipeline/loadServerTypesMeta/format';
+import type { InheritedExternalPropsConfig } from '../pipeline/loadServerTypesMeta/inheritedExternalProps';
 import type { EnhanceCodeEmphasisOptions } from '../pipeline/parseSource/calculateFrameRanges';
 import type { TransformHtmlCodeBlockOptions } from '../pipeline/transformHtmlCodeBlock/transformHtmlCodeBlock';
 import { DEFAULT_CACHE_DIR } from '../pipeline/cacheUtils';
@@ -172,6 +173,27 @@ export interface WithDocsInfraOptions {
    * ```
    */
   descriptionReplacements?: DescriptionReplacement[];
+  /**
+   * Props to re-include in component docs when they are inherited from these
+   * externally declared types, keyed by the declaring type's name. Type
+   * extraction normally drops props that are only declared inside
+   * `node_modules` (which keeps native DOM attributes out of the docs); this
+   * option re-adds the configured props when a component's props type extends
+   * one of the listed types from an installed package.
+   *
+   * Entries can also pin the package the type must come from, to disambiguate
+   * same-named types from different packages.
+   *
+   * @example
+   * ```js
+   * { BaseUIComponentProps: ['className', 'render', 'style'] }
+   * ```
+   * @example
+   * ```js
+   * { BaseUIComponentProps: { from: '@base-ui/react', props: ['className', 'render', 'style'] } }
+   * ```
+   */
+  inheritedExternalProps?: InheritedExternalPropsConfig;
   /**
    * Directory rooting docs-infra's build caches and coordination state — relocate it (or point it
    * at a persistent cache) and everything under it moves together: the sha256-validated JSON caches
@@ -368,6 +390,7 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
   // Only include ordering in loader options if explicitly provided
   const ordering = options.ordering;
   const descriptionReplacements = options.descriptionReplacements;
+  const inheritedExternalProps = options.inheritedExternalProps;
   const demoEmphasisOptions = options.demoEmphasisOptions;
   const codeBlockEmphasisOptions = options.codeBlockEmphasisOptions;
 
@@ -454,6 +477,9 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
               ...(ordering ? { ordering: ordering as unknown as JSONValue } : {}),
               ...(descriptionReplacements
                 ? { descriptionReplacements: descriptionReplacements as unknown as JSONValue }
+                : {}),
+              ...(inheritedExternalProps
+                ? { inheritedExternalProps: inheritedExternalProps as unknown as JSONValue }
                 : {}),
             },
           },
@@ -589,6 +615,7 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
                 ...(codeBlockEmphasisOptions ? { codeBlockEmphasisOptions } : {}),
                 ...(ordering ? { ordering } : {}),
                 ...(descriptionReplacements ? { descriptionReplacements } : {}),
+                ...(inheritedExternalProps ? { inheritedExternalProps } : {}),
               },
             },
           ],


### PR DESCRIPTION
See [discussion](https://mui-org.slack.com/archives/C042VP80PT5/p1784021445839279).

The requirement is that a user of Base UI might be extending some existing component from base ui. It might want to document the incoming props from base-ui components as well to maintain the context for the user.
So added a config that takes in the typename/path and props that get whitelisted and become part of the generated output.
It is an opt-in feature since it increases the types generation time. So only the repos that need it can opt-in. Other repos remain unaffected.