### PR TITLE
[code-infra] Fix breakages from bumped dev deps

### DIFF
--- a/docs/app/docs-infra/pipeline/hast-utils/types.md
+++ b/docs/app/docs-infra/pipeline/hast-utils/types.md
@@ -434,7 +434,7 @@ embedded in both the server build and the client bundle, so it must stay
 small — currently \~3 KB uncompressed.
 
 ```typescript
-type HAST_DICTIONARY = Uint8Array;
+type HAST_DICTIONARY = Uint8Array<ArrayBuffer>;
 ```
 
 ### MAX_DICTIONARY_SIZE

--- a/packages/babel-plugin-resolve-imports/index.js
+++ b/packages/babel-plugin-resolve-imports/index.js
@@ -6,7 +6,7 @@ const nodePath = require('node:path');
 const resolve = require('resolve/sync');
 
 /**
- * @typedef {import('@babel/core')} babel
+ * @typedef {typeof import('@babel/core')} babel
  */
 
 /**

--- a/packages/code-infra/package.json
+++ b/packages/code-infra/package.json
@@ -115,7 +115,7 @@
     "minimatch": "^10.2.5",
     "node-html-parser": "^9.0.0",
     "open": "^11.0.0",
-    "postcss-styled-syntax": "^0.7.1",
+    "postcss-styled-syntax": "^0.7.2",
     "regexp.escape": "^2.0.1",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",

--- a/packages/code-infra/src/stylelint/index.mjs
+++ b/packages/code-infra/src/stylelint/index.mjs
@@ -1,4 +1,4 @@
-import postcssStylesSyntax from 'postcss-styled-syntax';
+import * as postcssStyledSyntax from 'postcss-styled-syntax';
 
 /** @type {import('stylelint').Config} */
 export default {
@@ -39,7 +39,7 @@ export default {
   overrides: [
     {
       files: ['**/*.?(c|m)[jt]s?(x)'],
-      customSyntax: /** @type {any} */ (postcssStylesSyntax),
+      customSyntax: postcssStyledSyntax,
     },
   ],
 };

--- a/packages/code-infra/src/untyped-plugins.d.ts
+++ b/packages/code-infra/src/untyped-plugins.d.ts
@@ -169,8 +169,8 @@ declare module 'stylelint-config-standard' {
   export default configExtends;
 }
 declare module 'postcss-styled-syntax' {
-  import type { Syntax } from 'postcss';
+  import type { Parser, Stringifier } from 'postcss';
 
-  declare const syntax: Syntax;
-  export default syntax;
+  export const parse: Parser;
+  export const stringify: Stringifier;
 }

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -125,7 +125,7 @@
     "chalk": "^5.6.2",
     "clipboard-copy": "^4.0.1",
     "es-toolkit": "^1.49.0",
-    "fflate": "^0.8.2",
+    "fflate": "^0.8.3",
     "hast-util-to-jsx-runtime": "^2.3.6",
     "hast-util-to-text": "^4.0.2",
     "icss-utils": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,8 +688,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0
       postcss-styled-syntax:
-        specifier: ^0.7.1
-        version: 0.7.1(postcss@8.5.20)
+        specifier: ^0.7.2
+        version: 0.7.2(postcss@8.5.20)
       regexp.escape:
         specifier: ^2.0.1
         version: 2.0.1
@@ -875,8 +875,8 @@ importers:
         specifier: ^1.49.0
         version: 1.49.0
       fflate:
-        specifier: ^0.8.2
-        version: 0.8.2
+        specifier: ^0.8.3
+        version: 0.8.3
       hast-util-to-jsx-runtime:
         specifier: ^2.3.6
         version: 2.3.6(supports-color@10.2.2)
@@ -6873,8 +6873,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -8947,8 +8947,8 @@ packages:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
 
-  postcss-styled-syntax@0.7.1:
-    resolution: {integrity: sha512-V5Iy8JztqXOKnTojdytF8IJ3zDXyVR927XftBPinJa3TnKdChGvGzUNEYlNuDtR+iqpuFkwJMgZdaJarYfGFCg==}
+  postcss-styled-syntax@0.7.2:
+    resolution: {integrity: sha512-PrxG8BC6yh6pmrHx7NrseYt5TiSN57LbGYZxmreg7co7g+zXe6BwUfsZ6r/gghxbtabde3Z0hinelXj4jlJF4Q==}
     engines: {node: '>=14.17'}
     peerDependencies:
       postcss: ^8.5.1
@@ -10170,11 +10170,6 @@ packages:
 
   typescript@5.5.4:
     resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -17303,7 +17298,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.5
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -19665,10 +19660,10 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-styled-syntax@0.7.1(postcss@8.5.20):
+  postcss-styled-syntax@0.7.2(postcss@8.5.20):
     dependencies:
       postcss: 8.5.20
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   postcss-value-parser@4.2.0: {}
 
@@ -21236,8 +21231,6 @@ snapshots:
       - supports-color
 
   typescript@5.5.4: {}
-
-  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
Unblocks #1600. These same fixes were applied on the Renovate branch itself back in July and were lost when Renovate force-pushed a rebase, so they land on master this time.

`postcss-styled-syntax@0.7.2` is ESM-only and dropped its default export for named `parse`/`stringify` (breaks stylelint), and `fflate@0.8.3` types `strToU8` as `Uint8Array<ArrayBuffer>`, which propagates to `HAST_DICTIONARY` and makes the generated hast-utils `types.md` stale. Both are bumped here alongside their fixes since neither fix is backwards-compatible.

The `typeof import('@babel/core')` typedef change works under both the current and the newer tsgo, so it goes in without bumping `@typescript/native-preview`. `typescript-api-extractor` turned out not to be involved — beta.3 generates the same output once fflate is bumped.