### PR TITLE
[renovate] Group `@types/react` with `react`, revive two dead rules

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -138,11 +138,6 @@
       "reviewers": ["team:infra"]
     },
     {
-      "matchDepTypes": ["action"],
-      "matchCurrentVersion": "!/^0/",
-      "matchUpdateTypes": ["minor", "patch", "digest"]
-    },
-    {
       "groupName": "@definitelytyped tools",
       "matchPackageNames": ["@definitelytyped/*"]
     },
@@ -206,13 +201,22 @@
       "matchSourceUrls": ["https://github.com/tailwindlabs/**"]
     },
     {
+      "groupName": "react",
+      "extends": ["monorepo:react"]
+    },
+    {
+      "groupName": "react",
+      "description": "@types/react is published from DefinitelyTyped, so group:definitelyTyped would otherwise split it away from the React release it describes.",
+      "matchPackageNames": ["@types/react", "@types/react-dom", "@types/react-is"]
+    },
+    {
       "groupName": "remark monorepo",
       "extends": ["group:remarkMonorepo"]
     },
     {
       "groupName": "remark monorepo",
       "description": "Catch remark plugins outside the remark monorepo (including remark-mdx) and keep them in the same group.",
-      "matchPackagePatterns": ["^remark-"]
+      "matchPackageNames": ["remark-*"]
     },
     {
       "groupName": "Vite & Vitest",
@@ -243,7 +247,7 @@
     },
     {
       "description": "Disable replacements for @tsconfig/node* packages",
-      "matchPackagePatterns": ["^@tsconfig/node"],
+      "matchPackageNames": ["@tsconfig/node*"],
       "replacementName": null,
       "replacementVersion": null
     },


### PR DESCRIPTION
`matchPackagePatterns` was removed in Renovate 40 and the runner is on v46, so the `remark-*` catch-all and the `@tsconfig/node*` replacement suppression have been inert. Converted both to `matchPackageNames` globs.

`@types/react` comes from DefinitelyTyped, so `group:definitelyTyped` split it away from the React release it describes. Grouped it with `monorepo:react`, following the `@types/node` precedent. Also dropped a packageRule that had matchers but no settings.