### PR TITLE
[renovate] Add experimental grouping preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>mui/mui-public//renovate/default"],
+  "extends": ["github>mui/mui-public//renovate/experimental"],
   "schedule": "* 5-9 * * 7",
-  "lockFileMaintenance": {
-    "schedule": "* 0-4 3 * *"
-  },
   "packageRules": [
     {
       "description": "Skip major @mui/* updates in apps/tools-public — Toolpad Studio constrains peer deps and these PRs always fail.",

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>mui/mui-public//renovate/experimental"],
   "schedule": "* 5-9 * * 7",
+  "lockFileMaintenance": {
+    "description": "Match the schedule above. Lock file maintenance defaults to its own Monday window, which would open the group PR a second time outside the weekly one.",
+    "schedule": "* 5-9 * * 7"
+  },
   "packageRules": [
     {
       "description": "Skip major @mui/* updates in apps/tools-public — Toolpad Studio constrains peer deps and these PRs always fail.",

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -70,31 +70,3 @@ This will do nothing, instead you will have to set it on each rule:
   "autoMerge": true
 }
 ```
-
-## Presets
-
-- `base.json` — catch-all groups, extended first so that every later `groupName` wins over it.
-- `default.json` — the configuration every MUI repository extends.
-- `experimental.json` — extends `default.json` and is extended by mui-public only, so a grouping
-  change can be observed for a few cycles before it reaches the other repositories. It is meant to
-  be folded into `default.json` and deleted, not to live on.
-
-Presets are resolved from GitHub rather than from disk, so a change only takes effect once it is
-on `master` and there is nothing to roll back to. To try a preset out from a pull request, point
-the consuming `renovate.json` at the branch for the duration of the review:
-
-```json
-{ "extends": ["github>mui/mui-public//renovate/experimental#my-branch"] }
-```
-
-## Grouping by update type
-
-Every family group — the ones written here, and the ones `config:recommended` brings in through
-`group:monorepos` and `group:recommended` — matches on package identity only, not on update type.
-One family therefore produces a PR for its patches, another for its minors, and another for its
-majors.
-
-Because `groupName` is a setting and the last matching rule wins, a rule placed _after_ those that
-claims every non-major update collapses all of them into one PR, and leaves each family group
-applying to majors alone. That is the whole mechanism behind `experimental.json`; no per-family
-rule is needed to group majors, because the family groups already exist.

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -70,3 +70,31 @@ This will do nothing, instead you will have to set it on each rule:
   "autoMerge": true
 }
 ```
+
+## Presets
+
+- `base.json` — catch-all groups, extended first so that every later `groupName` wins over it.
+- `default.json` — the configuration every MUI repository extends.
+- `experimental.json` — extends `default.json` and is extended by mui-public only, so a grouping
+  change can be observed for a few cycles before it reaches the other repositories. It is meant to
+  be folded into `default.json` and deleted, not to live on.
+
+Presets are resolved from GitHub rather than from disk, so a change only takes effect once it is
+on `master` and there is nothing to roll back to. To try a preset out from a pull request, point
+the consuming `renovate.json` at the branch for the duration of the review:
+
+```json
+{ "extends": ["github>mui/mui-public//renovate/experimental#my-branch"] }
+```
+
+## Grouping by update type
+
+Every family group — the ones written here, and the ones `config:recommended` brings in through
+`group:monorepos` and `group:recommended` — matches on package identity only, not on update type.
+One family therefore produces a PR for its patches, another for its minors, and another for its
+majors.
+
+Because `groupName` is a setting and the last matching rule wins, a rule placed _after_ those that
+claims every non-major update collapses all of them into one PR, and leaves each family group
+applying to majors alone. That is the whole mechanism behind `experimental.json`; no per-family
+rule is needed to group majors, because the family groups already exist.

--- a/renovate/experimental.json
+++ b/renovate/experimental.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Experimental grouping strategy. Only mui-public extends this, so the strategy can be observed for a few cycles before it is folded into renovate/default.json.",
+  "extends": ["github>mui/mui-public//renovate/default"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "groupName": "npm non-major",
+    "schedule": null
+  },
+  "vulnerabilityAlerts": {
+    "description": "Keep security fixes on their own branch so they are never blocked behind an unrelated group PR.",
+    "groupName": null
+  },
+  "packageRules": [
+    // Collapsing every non-major update into one group per package manager also turns each family
+    // group in the default preset (eslint, babel monorepo, Vite & Vitest, ...) into a majors-only
+    // group, because those rules are unscoped by update type and these ones are applied after.
+    {
+      "groupName": "npm non-major",
+      "description": "All npm patch/minor updates in a single PR, together with the lockfile refresh. The exclusions are the groups that span package managers, or that are reverted often enough to be worth reviewing on their own.",
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor", "patch", "bump"],
+      "matchPackageNames": [
+        "!@mui/*",
+        "!@types/node",
+        "!playwright",
+        "!playwright-core",
+        "!@playwright/*"
+      ]
+    },
+    {
+      "groupName": "GitHub Actions non-major",
+      "description": "Most action updates arrive as digest updates because of helpers:pinGitHubActionDigests. Matching the action depType leaves uses-with alone, so actions/setup-node's Node version stays in the node group.",
+      "matchManagers": ["github-actions"],
+      "matchDepTypes": ["action"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"],
+      "reviewers": ["team:infra"]
+    },
+    {
+      "groupName": "CI images & tooling non-major",
+      "description": "The Playwright image stays with the npm packages it has to match, and Node stays in the cross-manager node group.",
+      "matchManagers": ["circleci", "custom.regex", "dockerfile", "docker-compose", "nvm"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"],
+      "matchPackageNames": ["!mcr.microsoft.com/playwright", "!node"],
+      "reviewers": ["team:infra"]
+    }
+  ]
+}

--- a/renovate/experimental.json
+++ b/renovate/experimental.json
@@ -3,9 +3,7 @@
   "description": "Experimental grouping strategy. Only mui-public extends this, so the strategy can be observed for a few cycles before it is folded into renovate/default.json.",
   "extends": ["github>mui/mui-public//renovate/default"],
   "lockFileMaintenance": {
-    "enabled": true,
-    "groupName": "npm non-major",
-    "schedule": null
+    "enabled": true
   },
   "vulnerabilityAlerts": {
     "description": "Keep security fixes on their own branch so they are never blocked behind an unrelated group PR.",
@@ -32,10 +30,14 @@
     },
     {
       "groupName": "CI images & tooling non-major",
-      "description": "The Playwright image stays with the npm packages it has to match, and Node stays in the cross-manager node group.",
+      "description": "The Playwright image stays with the npm packages it has to match, Node stays in the cross-manager node group, and the code-infra orb stays with the MUI infra packages it is released alongside.",
       "matchManagers": ["circleci", "custom.regex", "dockerfile", "docker-compose", "nvm"],
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"],
-      "matchPackageNames": ["!mcr.microsoft.com/playwright", "!node"],
+      "matchPackageNames": [
+        "!mcr.microsoft.com/playwright",
+        "!node",
+        "!https://github.com/mui/mui-public"
+      ],
       "reviewers": ["team:infra"]
     },
     {
@@ -43,6 +45,11 @@
       "description": "The Playwright Docker image has to match the npm package exactly or the browser tests break, and the npm package is in the group above. Pull the image in after it rather than leaving it with the other CI images, so the two can never land in separate PRs. Majors are left alone and stay in the playwright monorepo group.",
       "matchPackageNames": ["mcr.microsoft.com/playwright"],
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"]
+    },
+    {
+      "groupName": "npm non-major",
+      "description": "Refresh the lockfile inside the group PR rather than on a branch of its own. This has to be a package rule: the lockFileMaintenance config block resets groupName to null, and package rules are the only thing applied after it. It deliberately leaves the schedule alone, which the consuming repository lines up with its own window.",
+      "matchUpdateTypes": ["lockFileMaintenance"]
     }
   ]
 }

--- a/renovate/experimental.json
+++ b/renovate/experimental.json
@@ -17,16 +17,10 @@
     // group, because those rules are unscoped by update type and these ones are applied after.
     {
       "groupName": "npm non-major",
-      "description": "All npm patch/minor updates in a single PR, together with the lockfile refresh. The exclusions are the groups that span package managers, or that are reverted often enough to be worth reviewing on their own.",
+      "description": "All npm patch/minor updates in a single PR, together with the lockfile refresh. @mui/* is excluded because it is unscheduled and exempt from the minimum release age, which a weekly group would take away from it; @types/node because it has to move with the Node version pinned across CI and Netlify.",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch", "bump"],
-      "matchPackageNames": [
-        "!@mui/*",
-        "!@types/node",
-        "!playwright",
-        "!playwright-core",
-        "!@playwright/*"
-      ]
+      "matchPackageNames": ["!@mui/*", "!@types/node"]
     },
     {
       "groupName": "GitHub Actions non-major",
@@ -43,6 +37,12 @@
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"],
       "matchPackageNames": ["!mcr.microsoft.com/playwright", "!node"],
       "reviewers": ["team:infra"]
+    },
+    {
+      "groupName": "npm non-major",
+      "description": "The Playwright Docker image has to match the npm package exactly or the browser tests break, and the npm package is in the group above. Pull the image in after it rather than leaving it with the other CI images, so the two can never land in separate PRs. Majors are left alone and stay in the playwright monorepo group.",
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"]
     }
   ]
 }

--- a/renovate/experimental.json
+++ b/renovate/experimental.json
@@ -50,6 +50,37 @@
       "groupName": "npm non-major",
       "description": "Refresh the lockfile inside the group PR rather than on a branch of its own. This has to be a package rule: the lockFileMaintenance config block resets groupName to null, and package rules are the only thing applied after it. It deliberately leaves the schedule alone, which the consuming repository lines up with its own window.",
       "matchUpdateTypes": ["lockFileMaintenance"]
+    },
+    // Linters and formatters keep their own PR at every update type, because their releases tend to
+    // come with new rules that need code changes, and the Prettier group reformats the whole
+    // repository from a postUpgradeTask. Neither is reviewable buried in a group of forty bumps.
+    // These repeat the matchers from the default preset because a group cannot be matched on, only
+    // assigned; folding this preset in replaces the repetition with ordering.
+    {
+      "groupName": "eslint",
+      "extends": ["monorepo:eslint", "monorepo:typescript-eslint"]
+    },
+    {
+      "groupName": "eslint",
+      "matchPackageNames": [
+        "eslint-plugin-*",
+        "*/eslint-plugin-*",
+        "@vitest/eslint-plugin",
+        "!@next/eslint-plugin-next"
+      ]
+    },
+    {
+      "groupName": "eslint",
+      "matchSourceUrls": ["https://github.com/eslint/*"]
+    },
+    {
+      "groupName": "eslint",
+      "matchSourceUrls": ["https://github.com/import-js/eslint-plugin-import"]
+    },
+    {
+      "groupName": "Prettier",
+      "description": "Last, so that eslint-config-prettier lands here rather than in the eslint group, matching the order in the default preset.",
+      "matchPackageNames": ["prettier", "pretty-quick", "eslint-config-prettier"]
     }
   ]
 }


### PR DESCRIPTION
Collapses every non-major update into one group per package manager, with the lockfile refresh folded into the npm one. mui-public extends this alone until it has run for a few cycles.

No per-family rule was needed for the majors: every family group matches on package identity, not update type, so a rule applied after them that claims all non-majors leaves them applying to majors alone.

The lockfile refresh joins the group through a package rule matching the `lockFileMaintenance` update type, because the `lockFileMaintenance` config block resets `groupName` to null and package rules are the only thing applied after it. That leaves its schedule alone, which `renovate.json` lines up with the weekly window so everything lands in one PR.

Carved out of the catch-alls: eslint and Prettier, whose releases bring rules that need code changes and which reformat the repository from a postUpgradeTask; Playwright's npm package together with its Docker image, which live in different managers and would otherwise split across two PRs and break the browser tests; and `@mui/*`, `@types/node` and the code-infra orb, which keep the cadence and cross-manager groups the default preset gives them.
