### PR TITLE
[docs-infra] Fix types worker election on Windows

### DIFF
--- a/packages/docs-infra/src/cli/runValidate.test.ts
+++ b/packages/docs-infra/src/cli/runValidate.test.ts
@@ -1,0 +1,21 @@
+import { once } from 'node:events';
+import { Worker } from 'node:worker_threads';
+import { describe, expect, it } from 'vitest';
+import { shutdownWorker } from './runValidate';
+
+describe('shutdownWorker', () => {
+  it('returns when the worker already exited', async () => {
+    const worker = new Worker('', { eval: true });
+    await once(worker, 'exit');
+
+    await expect(shutdownWorker(worker, 50)).resolves.toBeUndefined();
+  });
+
+  it('terminates a worker that does not acknowledge shutdown', async () => {
+    const worker = new Worker('setInterval(() => {}, 1000)', { eval: true });
+
+    await shutdownWorker(worker, 50);
+
+    expect(worker.threadId).toBe(-1);
+  });
+});

--- a/packages/docs-infra/src/cli/runValidate.test.ts
+++ b/packages/docs-infra/src/cli/runValidate.test.ts
@@ -1,7 +1,7 @@
 import { once } from 'node:events';
 import { Worker } from 'node:worker_threads';
 import { describe, expect, it } from 'vitest';
-import { shutdownWorker } from './runValidate';
+import { shutdownWorker, shutdownWorkers } from './runValidate';
 
 describe('shutdownWorker', () => {
   it('returns when the worker already exited', async () => {
@@ -17,5 +17,28 @@ describe('shutdownWorker', () => {
     await shutdownWorker(worker, 50);
 
     expect(worker.threadId).toBe(-1);
+  });
+
+  it('lets workers acknowledge shutdown before terminating them', async () => {
+    const worker = new Worker(
+      `
+        const { parentPort } = require('node:worker_threads');
+        parentPort.on('message', () => {
+          setTimeout(() => {
+            parentPort.postMessage({ type: 'shutdown' });
+          }, 50);
+        });
+      `,
+      { eval: true },
+    );
+    let acknowledged = false;
+    worker.on('message', () => {
+      acknowledged = true;
+    });
+    await once(worker, 'online');
+
+    await shutdownWorkers([worker]);
+
+    expect(acknowledged).toBe(true);
   });
 });

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -20,7 +20,7 @@ import { DEFAULT_CACHE_DIR } from '../pipeline/cacheUtils';
 import { extractDocsInfraOptionsFromNextConfig } from './loadNextConfig';
 import { ensureDemoClients } from './ensureDemoClients';
 import { ensureDemoPages } from './ensureDemoPages';
-import type { ValidateTask, ValidateResult } from './validateWorker';
+import type { ShutdownResult, ShutdownTask, ValidateTask, ValidateResult } from './validateWorker';
 
 type Args = {
   paths?: string[];
@@ -176,7 +176,10 @@ const runValidate: CommandModule<{}, Args> = {
     let taskIdCounter = 0;
 
     for (const worker of workers) {
-      worker.on('message', (result: ValidateResult) => {
+      worker.on('message', (result: ValidateResult | ShutdownResult) => {
+        if (result.type === 'shutdown') {
+          return;
+        }
         const resolve = pendingResults.get(result.taskId);
         if (resolve) {
           pendingResults.delete(result.taskId);
@@ -209,6 +212,29 @@ const runValidate: CommandModule<{}, Args> = {
         workers[nextWorkerIndex].postMessage(task);
         nextWorkerIndex = (nextWorkerIndex + 1) % workers.length;
       });
+    }
+
+    async function shutdownWorker(worker: Worker): Promise<void> {
+      await new Promise<void>((resolve) => {
+        let handleMessage: (result: ValidateResult | ShutdownResult) => void;
+        const finish = () => {
+          worker.off('message', handleMessage);
+          worker.off('error', finish);
+          worker.off('exit', finish);
+          resolve();
+        };
+        handleMessage = (result: ValidateResult | ShutdownResult) => {
+          if (result.type === 'shutdown') {
+            finish();
+          }
+        };
+
+        worker.on('message', handleMessage);
+        worker.once('error', finish);
+        worker.once('exit', finish);
+        worker.postMessage({ type: 'shutdown' } satisfies ShutdownTask);
+      });
+      await worker.terminate();
     }
 
     function logWorkerPerfEntries(result: ValidateResult): void {
@@ -493,11 +519,11 @@ const runValidate: CommandModule<{}, Args> = {
         currentMark = pagesMark;
       }
     } finally {
-      // Terminate worker pool
-      await Promise.all(workers.map((w) => w.terminate()));
+      // Let each validation worker release its types-server election lock before exit.
+      await Promise.all(workers.map(shutdownWorker));
 
       // Terminate the types meta worker manager to allow the process to exit
-      terminateWorkerManager();
+      await terminateWorkerManager();
     }
 
     if (observer) {

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -35,6 +35,53 @@ const completeMessage = (message: string) => `✓ ${chalk.green(message)}`;
 
 const functionName = 'Run Validate';
 
+export async function shutdownWorker(worker: Worker, timeoutMs: number = 5000): Promise<void> {
+  if (worker.threadId === -1) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let handleMessage: (result: ValidateResult | ShutdownResult) => void;
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      worker.off('message', handleMessage);
+      worker.off('error', finish);
+      worker.off('exit', finish);
+      resolve();
+    };
+
+    handleMessage = (result: ValidateResult | ShutdownResult) => {
+      if (result.type === 'shutdown') {
+        finish();
+      }
+    };
+
+    timeout = setTimeout(finish, timeoutMs);
+    worker.on('message', handleMessage);
+    worker.once('error', finish);
+    worker.once('exit', finish);
+
+    // The worker may have exited between the initial check and listener setup.
+    if (worker.threadId === -1) {
+      finish();
+      return;
+    }
+
+    worker.postMessage({ type: 'shutdown' } satisfies ShutdownTask);
+  });
+
+  await worker.terminate();
+}
+
 /**
  * Recursively find all files matching a specific name in a directory
  */
@@ -212,29 +259,6 @@ const runValidate: CommandModule<{}, Args> = {
         workers[nextWorkerIndex].postMessage(task);
         nextWorkerIndex = (nextWorkerIndex + 1) % workers.length;
       });
-    }
-
-    async function shutdownWorker(worker: Worker): Promise<void> {
-      await new Promise<void>((resolve) => {
-        let handleMessage: (result: ValidateResult | ShutdownResult) => void;
-        const finish = () => {
-          worker.off('message', handleMessage);
-          worker.off('error', finish);
-          worker.off('exit', finish);
-          resolve();
-        };
-        handleMessage = (result: ValidateResult | ShutdownResult) => {
-          if (result.type === 'shutdown') {
-            finish();
-          }
-        };
-
-        worker.on('message', handleMessage);
-        worker.once('error', finish);
-        worker.once('exit', finish);
-        worker.postMessage({ type: 'shutdown' } satisfies ShutdownTask);
-      });
-      await worker.terminate();
     }
 
     function logWorkerPerfEntries(result: ValidateResult): void {

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -20,7 +20,7 @@ import { DEFAULT_CACHE_DIR } from '../pipeline/cacheUtils';
 import { extractDocsInfraOptionsFromNextConfig } from './loadNextConfig';
 import { ensureDemoClients } from './ensureDemoClients';
 import { ensureDemoPages } from './ensureDemoPages';
-import type { ValidateTask, ValidateResult } from './validateWorker';
+import type { ShutdownResult, ShutdownTask, ValidateTask, ValidateResult } from './validateWorker';
 
 type Args = {
   paths?: string[];
@@ -174,7 +174,10 @@ const runValidate: CommandModule<{}, Args> = {
     let taskIdCounter = 0;
 
     for (const worker of workers) {
-      worker.on('message', (result: ValidateResult) => {
+      worker.on('message', (result: ValidateResult | ShutdownResult) => {
+        if (result.type === 'shutdown') {
+          return;
+        }
         const resolve = pendingResults.get(result.taskId);
         if (resolve) {
           pendingResults.delete(result.taskId);
@@ -207,6 +210,29 @@ const runValidate: CommandModule<{}, Args> = {
         workers[nextWorkerIndex].postMessage(task);
         nextWorkerIndex = (nextWorkerIndex + 1) % workers.length;
       });
+    }
+
+    async function shutdownWorker(worker: Worker): Promise<void> {
+      await new Promise<void>((resolve) => {
+        let handleMessage: (result: ValidateResult | ShutdownResult) => void;
+        const finish = () => {
+          worker.off('message', handleMessage);
+          worker.off('error', finish);
+          worker.off('exit', finish);
+          resolve();
+        };
+        handleMessage = (result: ValidateResult | ShutdownResult) => {
+          if (result.type === 'shutdown') {
+            finish();
+          }
+        };
+
+        worker.on('message', handleMessage);
+        worker.once('error', finish);
+        worker.once('exit', finish);
+        worker.postMessage({ type: 'shutdown' } satisfies ShutdownTask);
+      });
+      await worker.terminate();
     }
 
     function logWorkerPerfEntries(result: ValidateResult): void {
@@ -490,11 +516,11 @@ const runValidate: CommandModule<{}, Args> = {
         currentMark = pagesMark;
       }
     } finally {
-      // Terminate worker pool
-      await Promise.all(workers.map((w) => w.terminate()));
+      // Let each validation worker release its types-server election lock before exit.
+      await Promise.all(workers.map(shutdownWorker));
 
       // Terminate the types meta worker manager to allow the process to exit
-      terminateWorkerManager();
+      await terminateWorkerManager();
     }
 
     if (observer) {

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -82,6 +82,10 @@ export async function shutdownWorker(worker: Worker, timeoutMs: number = 5000): 
   await worker.terminate();
 }
 
+export async function shutdownWorkers(workers: Worker[]): Promise<void> {
+  await Promise.all(workers.map((worker) => shutdownWorker(worker)));
+}
+
 /**
  * Recursively find all files matching a specific name in a directory
  */
@@ -541,7 +545,7 @@ const runValidate: CommandModule<{}, Args> = {
       }
     } finally {
       // Let each validation worker release its types-server election lock before exit.
-      await Promise.all(workers.map(shutdownWorker));
+      await shutdownWorkers(workers);
 
       // Terminate the types meta worker manager to allow the process to exit
       await terminateWorkerManager();

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -35,6 +35,53 @@ const completeMessage = (message: string) => `✓ ${chalk.green(message)}`;
 
 const functionName = 'Run Validate';
 
+export async function shutdownWorker(worker: Worker, timeoutMs: number = 5000): Promise<void> {
+  if (worker.threadId === -1) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    let handleMessage: (result: ValidateResult | ShutdownResult) => void;
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      worker.off('message', handleMessage);
+      worker.off('error', finish);
+      worker.off('exit', finish);
+      resolve();
+    };
+
+    handleMessage = (result: ValidateResult | ShutdownResult) => {
+      if (result.type === 'shutdown') {
+        finish();
+      }
+    };
+
+    timeout = setTimeout(finish, timeoutMs);
+    worker.on('message', handleMessage);
+    worker.once('error', finish);
+    worker.once('exit', finish);
+
+    // The worker may have exited between the initial check and listener setup.
+    if (worker.threadId === -1) {
+      finish();
+      return;
+    }
+
+    worker.postMessage({ type: 'shutdown' } satisfies ShutdownTask);
+  });
+
+  await worker.terminate();
+}
+
 /**
  * Recursively find all files matching a specific name in a directory
  */
@@ -210,29 +257,6 @@ const runValidate: CommandModule<{}, Args> = {
         workers[nextWorkerIndex].postMessage(task);
         nextWorkerIndex = (nextWorkerIndex + 1) % workers.length;
       });
-    }
-
-    async function shutdownWorker(worker: Worker): Promise<void> {
-      await new Promise<void>((resolve) => {
-        let handleMessage: (result: ValidateResult | ShutdownResult) => void;
-        const finish = () => {
-          worker.off('message', handleMessage);
-          worker.off('error', finish);
-          worker.off('exit', finish);
-          resolve();
-        };
-        handleMessage = (result: ValidateResult | ShutdownResult) => {
-          if (result.type === 'shutdown') {
-            finish();
-          }
-        };
-
-        worker.on('message', handleMessage);
-        worker.once('error', finish);
-        worker.once('exit', finish);
-        worker.postMessage({ type: 'shutdown' } satisfies ShutdownTask);
-      });
-      await worker.terminate();
     }
 
     function logWorkerPerfEntries(result: ValidateResult): void {

--- a/packages/docs-infra/src/cli/runValidate.ts
+++ b/packages/docs-infra/src/cli/runValidate.ts
@@ -82,6 +82,10 @@ export async function shutdownWorker(worker: Worker, timeoutMs: number = 5000): 
   await worker.terminate();
 }
 
+export async function shutdownWorkers(workers: Worker[]): Promise<void> {
+  await Promise.all(workers.map((worker) => shutdownWorker(worker)));
+}
+
 /**
  * Recursively find all files matching a specific name in a directory
  */
@@ -544,7 +548,7 @@ const runValidate: CommandModule<{}, Args> = {
       }
     } finally {
       // Let each validation worker release its types-server election lock before exit.
-      await Promise.all(workers.map(shutdownWorker));
+      await shutdownWorkers(workers);
 
       // Terminate the types meta worker manager to allow the process to exit
       await terminateWorkerManager();

--- a/packages/docs-infra/src/cli/validateWorker.ts
+++ b/packages/docs-infra/src/cli/validateWorker.ts
@@ -9,6 +9,7 @@ import { transformMarkdownMetadata } from '../pipeline/transformMarkdownMetadata
 import { parseCreateFactoryCall } from '../pipeline/parseCreateFactoryCall/parseCreateFactoryCall';
 import { syncTypes } from '../pipeline/syncTypes/syncTypes';
 import type { SyncTypesOptions } from '../pipeline/syncTypes/syncTypes';
+import { terminateWorkerManager } from '../pipeline/loadServerTypesMeta/workerManager';
 
 interface IndexTask {
   type: 'index';
@@ -35,6 +36,10 @@ interface TypesTask {
   rootContext: string;
 }
 
+export interface ShutdownTask {
+  type: 'shutdown';
+}
+
 interface SerializedPerfEntry {
   name: string;
   duration: number;
@@ -58,6 +63,10 @@ interface TypesResult {
   error?: string;
 }
 
+export interface ShutdownResult {
+  type: 'shutdown';
+}
+
 export type ValidateTask = IndexTask | TypesTask;
 export type ValidateResult = IndexResult | TypesResult;
 
@@ -75,9 +84,12 @@ if (parentPort) {
   // cannot clear measures belonging to a concurrent in-flight task.
   let taskQueue: Promise<void> = Promise.resolve();
 
-  parentPort.on('message', (task: ValidateTask) => {
+  parentPort.on('message', (task: ValidateTask | ShutdownTask) => {
     taskQueue = taskQueue.then(async () => {
-      if (task.type === 'index') {
+      if (task.type === 'shutdown') {
+        await terminateWorkerManager();
+        parentPort!.postMessage({ type: 'shutdown' } satisfies ShutdownResult);
+      } else if (task.type === 'index') {
         try {
           const processor = unified()
             .use(remarkParse)

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
@@ -1,0 +1,144 @@
+import { createServer } from 'node:net';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  ensureSocketDir,
+  getSocketPath,
+  hasExistingWorker,
+  releaseServerLock,
+  SocketClient,
+  tryAcquireServerLock,
+} from './socketClient';
+
+describe('hasExistingWorker', () => {
+  it('detects a listening types worker', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    const socketPath = getSocketPath(socketDir);
+    const server = createServer();
+
+    await ensureSocketDir(socketDir);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      expect(await hasExistingWorker(socketDir)).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not elect another server while a types worker is listening', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    const socketPath = getSocketPath(socketDir);
+    const server = createServer();
+
+    await ensureSocketDir(socketDir);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      expect(await tryAcquireServerLock(socketDir)).toBe(false);
+    } finally {
+      await releaseServerLock();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+    }
+  });
+
+  it('reuses a types worker that starts while checking the endpoint', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    const socketPath = getSocketPath(socketDir);
+    const server = createServer();
+
+    await ensureSocketDir(socketDir);
+    const serverStarted = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        server.once('error', reject);
+        server.listen(socketPath, resolve);
+      }, 50);
+    });
+
+    try {
+      expect(await tryAcquireServerLock(socketDir)).toBe(false);
+    } finally {
+      await releaseServerLock();
+      await serverStarted;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('SocketClient', () => {
+  it('retries the persistent connection while the server starts', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    const socketPath = getSocketPath(socketDir);
+    const server = createServer();
+    const client = new SocketClient(socketDir);
+    let connectionCount = 0;
+
+    await ensureSocketDir(socketDir);
+    const connectionAccepted = new Promise<void>((resolve) => {
+      server.once('connection', () => {
+        connectionCount += 1;
+        resolve();
+      });
+    });
+    const serverStarted = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        server.once('error', reject);
+        server.listen(socketPath, resolve);
+      }, 50);
+    });
+
+    try {
+      await client.connect(500);
+      await connectionAccepted;
+      expect(connectionCount).toBe(1);
+    } finally {
+      client.close();
+      await serverStarted;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
@@ -12,6 +12,31 @@ import {
   tryAcquireServerLock,
 } from './socketClient';
 
+describe('tryAcquireServerLock', () => {
+  it('elects a server when no types worker is listening', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+
+    try {
+      expect(await tryAcquireServerLock(socketDir)).toBe(true);
+    } finally {
+      await releaseServerLock();
+      await rm(socketDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not elect another server while the lock is held', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+
+    try {
+      expect(await tryAcquireServerLock(socketDir)).toBe(true);
+      expect(await tryAcquireServerLock(socketDir)).toBe(false);
+    } finally {
+      await releaseServerLock();
+      await rm(socketDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe('hasExistingWorker', () => {
   it('detects a listening types worker', async () => {
     const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
@@ -12,6 +12,35 @@ import {
   tryAcquireServerLock,
 } from './socketClient';
 
+describe('tryAcquireServerLock', () => {
+  it('elects a server when no types worker is listening', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    vi.stubEnv('MUI_DOCS_INFRA_SOCKET_DIR', socketDir);
+
+    try {
+      expect(await tryAcquireServerLock()).toBe(true);
+    } finally {
+      await releaseServerLock();
+      await rm(socketDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('does not elect another server while the lock is held', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    vi.stubEnv('MUI_DOCS_INFRA_SOCKET_DIR', socketDir);
+
+    try {
+      expect(await tryAcquireServerLock()).toBe(true);
+      expect(await tryAcquireServerLock()).toBe(false);
+    } finally {
+      await releaseServerLock();
+      await rm(socketDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+});
+
 describe('hasExistingWorker', () => {
   it('detects a listening types worker', async () => {
     const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.test.ts
@@ -1,0 +1,152 @@
+import { createServer } from 'node:net';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ensureSocketDir,
+  getSocketPath,
+  hasExistingWorker,
+  releaseServerLock,
+  SocketClient,
+  tryAcquireServerLock,
+} from './socketClient';
+
+describe('hasExistingWorker', () => {
+  it('detects a listening types worker', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    vi.stubEnv('MUI_DOCS_INFRA_SOCKET_DIR', socketDir);
+    const socketPath = getSocketPath();
+    const server = createServer();
+
+    await ensureSocketDir();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      expect(await hasExistingWorker()).toBe(true);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('does not elect another server while a types worker is listening', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    vi.stubEnv('MUI_DOCS_INFRA_SOCKET_DIR', socketDir);
+    const socketPath = getSocketPath();
+    const server = createServer();
+
+    await ensureSocketDir();
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+
+    try {
+      expect(await tryAcquireServerLock()).toBe(false);
+    } finally {
+      await releaseServerLock();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('reuses a types worker that starts while checking the endpoint', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    vi.stubEnv('MUI_DOCS_INFRA_SOCKET_DIR', socketDir);
+    const socketPath = getSocketPath();
+    const server = createServer();
+
+    await ensureSocketDir();
+    const serverStarted = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        server.once('error', reject);
+        server.listen(socketPath, resolve);
+      }, 50);
+    });
+
+    try {
+      expect(await tryAcquireServerLock()).toBe(false);
+    } finally {
+      await releaseServerLock();
+      await serverStarted;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+});
+
+describe('SocketClient', () => {
+  it('retries the persistent connection while the server starts', async () => {
+    const socketDir = await mkdtemp(join(tmpdir(), 'docs-infra-types-'));
+    vi.stubEnv('MUI_DOCS_INFRA_SOCKET_DIR', socketDir);
+    const socketPath = getSocketPath();
+    const server = createServer();
+    const client = new SocketClient();
+    let connectionCount = 0;
+
+    await ensureSocketDir();
+    const connectionAccepted = new Promise<void>((resolve) => {
+      server.once('connection', () => {
+        connectionCount += 1;
+        resolve();
+      });
+    });
+    const serverStarted = new Promise<void>((resolve, reject) => {
+      setTimeout(() => {
+        server.once('error', reject);
+        server.listen(socketPath, resolve);
+      }, 50);
+    });
+
+    try {
+      await client.connect(500);
+      await connectionAccepted;
+      expect(connectionCount).toBe(1);
+    } finally {
+      client.close();
+      await serverStarted;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
+      });
+      await rm(socketDir, { recursive: true, force: true });
+      vi.unstubAllEnvs();
+    }
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
@@ -10,7 +10,7 @@
 
 import { connect } from 'node:net';
 import type { Socket } from 'node:net';
-import { mkdir, stat } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -89,18 +89,6 @@ export async function ensureSocketDir(socketDir?: string): Promise<void> {
 }
 
 /**
- * Check if a file exists
- */
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Try to connect to an IPC endpoint.
  * @returns true if connection succeeded, false otherwise
  */
@@ -151,45 +139,6 @@ async function waitForSocketConnection(socketPath: string, timeoutMs: number): P
   return false;
 }
 
-/**
- * Wait for the IPC endpoint to become available.
- * On Unix: Polls the filesystem for the socket file to appear. We avoid
- * `fs.watch` here because on macOS it does not reliably fire events when a
- * unix domain socket file is created.
- * On Windows: Polls by attempting to connect to the named pipe.
- * @param socketDir - Optional custom directory for socket files (Unix only)
- * @param timeoutMs - Timeout in milliseconds (default: 5000)
- */
-export async function waitForSocketFile(
-  socketDir?: string,
-  timeoutMs: number = 5000,
-): Promise<void> {
-  const socketPath = getSocketPath(socketDir);
-  const pollInterval = 50;
-  const startTime = Date.now();
-
-  if (isWindows) {
-    if (await waitForSocketConnection(socketPath, timeoutMs)) {
-      return;
-    }
-    throw new Error(`Named pipe did not become available within ${timeoutMs}ms`);
-  }
-
-  // Ensure the directory exists so the first stat doesn't fail spuriously
-  await mkdir(getEffectiveSocketDir(socketDir), { recursive: true });
-
-  while (Date.now() - startTime < timeoutMs) {
-    // eslint-disable-next-line no-await-in-loop
-    if (await fileExists(socketPath)) {
-      return;
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await sleep(pollInterval);
-  }
-
-  throw new Error(`Socket file did not appear within ${timeoutMs}ms`);
-}
-
 // Store the release function globally so we can call it when needed
 let lockReleaseFunction: (() => Promise<void>) | null = null;
 
@@ -212,6 +161,10 @@ export async function tryAcquireServerLock(socketDir?: string): Promise<boolean>
       retries: 0, // Don't retry, just check once
       stale: 30_000,
       realpath: false, // Don't resolve symlinks (file doesn't need to exist)
+      onCompromised: (error) => {
+        console.error('[SocketClient] Server lock compromised:', error);
+        lockReleaseFunction = null;
+      },
     });
 
     // A worker that initialized earlier may have released the election lock after
@@ -237,10 +190,12 @@ export async function tryAcquireServerLock(socketDir?: string): Promise<boolean>
  * Release the server lock
  */
 export async function releaseServerLock(): Promise<void> {
-  if (lockReleaseFunction) {
+  const release = lockReleaseFunction;
+  lockReleaseFunction = null;
+
+  if (release) {
     try {
-      await lockReleaseFunction();
-      lockReleaseFunction = null;
+      await release();
     } catch (error) {
       // Ignore errors during cleanup
     }
@@ -248,8 +203,7 @@ export async function releaseServerLock(): Promise<void> {
 }
 
 /**
- * Check if there's an existing worker socket file
- * Note: The socket server will clean up stale sockets on startup
+ * Check whether a types server is accepting connections, retrying for up to 500ms.
  * @param socketDir - Optional custom directory for socket files
  */
 export async function hasExistingWorker(socketDir?: string): Promise<boolean> {

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
@@ -114,10 +114,10 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 /**
- * Try to connect to a named pipe (Windows)
+ * Try to connect to an IPC endpoint.
  * @returns true if connection succeeded, false otherwise
  */
-function tryConnectToPipe(socketPath: string): Promise<boolean> {
+function tryConnectToSocket(socketPath: string): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const socket = connect(socketPath);
     socket.on('connect', () => {
@@ -140,6 +140,31 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Poll an IPC endpoint until it accepts a connection or the timeout expires.
+ */
+async function waitForSocketConnection(socketPath: string, timeoutMs: number): Promise<boolean> {
+  const pollInterval = 50;
+  const startTime = Date.now();
+
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    if (await tryConnectToSocket(socketPath)) {
+      return true;
+    }
+
+    const remainingTime = timeoutMs - (Date.now() - startTime);
+    if (remainingTime <= 0) {
+      return false;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(Math.min(pollInterval, remainingTime));
+  } while (Date.now() - startTime < timeoutMs);
+
+  return false;
+}
+
+/**
  * Wait for the IPC endpoint to become available.
  * On Unix: Polls the filesystem for the socket file to appear. We avoid
  * `fs.watch` here because on macOS it does not reliably fire events when a
@@ -153,13 +178,8 @@ export async function waitForSocketFile(timeoutMs: number = 5000): Promise<void>
   const startTime = Date.now();
 
   if (isWindows) {
-    while (Date.now() - startTime < timeoutMs) {
-      // eslint-disable-next-line no-await-in-loop
-      if (await tryConnectToPipe(socketPath)) {
-        return;
-      }
-      // eslint-disable-next-line no-await-in-loop
-      await sleep(pollInterval);
+    if (await waitForSocketConnection(socketPath, timeoutMs)) {
+      return;
     }
     throw new Error(`Named pipe did not become available within ${timeoutMs}ms`);
   }
@@ -194,12 +214,21 @@ export async function tryAcquireServerLock(): Promise<boolean> {
 
   try {
     // Try to acquire the lock with no retries (immediate check)
-    // Stale locks will be detected after 3 seconds (server should start quickly)
+    // Allow enough time for a server worker to start even when validation workers
+    // saturate the CPU and delay the lock heartbeat.
     lockReleaseFunction = await lockfile.lock(lockPath, {
       retries: 0, // Don't retry, just check once
-      stale: 3000, // Consider lock stale after 3 seconds
+      stale: 30_000,
       realpath: false, // Don't resolve symlinks (file doesn't need to exist)
     });
+
+    // A worker that initialized earlier may have released the election lock after
+    // starting the server. Check the endpoint while holding the lock so late
+    // workers reuse that server instead of trying to listen on the same address.
+    if (await hasExistingWorker()) {
+      await releaseServerLock();
+      return false;
+    }
 
     return true;
   } catch (error: any) {
@@ -231,7 +260,9 @@ export async function releaseServerLock(): Promise<void> {
  * Note: The socket server will clean up stale sockets on startup
  */
 export async function hasExistingWorker(): Promise<boolean> {
-  return fileExists(getSocketPath());
+  // The election lock may have been released immediately before the server
+  // becomes connectable. Retry briefly before deciding to start another server.
+  return waitForSocketConnection(getSocketPath(), 500);
 }
 
 /**
@@ -253,26 +284,26 @@ export class SocketClient {
   private buffer = '';
 
   /**
-   * Connect to the worker socket with retry logic
+   * Connect to the worker socket, retrying while the server starts or named-pipe
+   * instances are temporarily busy.
    */
-  async connect(retryCount = 0, maxRetries = 10, retryDelay = 50): Promise<void> {
+  async connect(timeoutMs: number = 30_000, retryDelay: number = 50): Promise<void> {
     const socketPath = getSocketPath();
+    const startTime = Date.now();
 
-    try {
-      await this.attemptConnect(socketPath);
-    } catch (error) {
-      // If we've exhausted retries, throw the error
-      if (retryCount >= maxRetries - 1) {
-        throw error;
+    while (true) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await this.attemptConnect(socketPath);
+        return;
+      } catch (error) {
+        if (Date.now() - startTime >= timeoutMs) {
+          throw error;
+        }
       }
 
-      // Wait before retrying
-      await new Promise((resolve) => {
-        setTimeout(resolve, retryDelay);
-      });
-
-      // Recursive retry
-      await this.connect(retryCount + 1, maxRetries, retryDelay);
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(retryDelay);
     }
   }
 

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
@@ -101,10 +101,10 @@ async function fileExists(path: string): Promise<boolean> {
 }
 
 /**
- * Try to connect to a named pipe (Windows)
+ * Try to connect to an IPC endpoint.
  * @returns true if connection succeeded, false otherwise
  */
-function tryConnectToPipe(socketPath: string): Promise<boolean> {
+function tryConnectToSocket(socketPath: string): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     const socket = connect(socketPath);
     socket.on('connect', () => {
@@ -127,6 +127,31 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
+ * Poll an IPC endpoint until it accepts a connection or the timeout expires.
+ */
+async function waitForSocketConnection(socketPath: string, timeoutMs: number): Promise<boolean> {
+  const pollInterval = 50;
+  const startTime = Date.now();
+
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    if (await tryConnectToSocket(socketPath)) {
+      return true;
+    }
+
+    const remainingTime = timeoutMs - (Date.now() - startTime);
+    if (remainingTime <= 0) {
+      return false;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(Math.min(pollInterval, remainingTime));
+  } while (Date.now() - startTime < timeoutMs);
+
+  return false;
+}
+
+/**
  * Wait for the IPC endpoint to become available.
  * On Unix: Polls the filesystem for the socket file to appear. We avoid
  * `fs.watch` here because on macOS it does not reliably fire events when a
@@ -144,13 +169,8 @@ export async function waitForSocketFile(
   const startTime = Date.now();
 
   if (isWindows) {
-    while (Date.now() - startTime < timeoutMs) {
-      // eslint-disable-next-line no-await-in-loop
-      if (await tryConnectToPipe(socketPath)) {
-        return;
-      }
-      // eslint-disable-next-line no-await-in-loop
-      await sleep(pollInterval);
+    if (await waitForSocketConnection(socketPath, timeoutMs)) {
+      return;
     }
     throw new Error(`Named pipe did not become available within ${timeoutMs}ms`);
   }
@@ -186,12 +206,21 @@ export async function tryAcquireServerLock(socketDir?: string): Promise<boolean>
 
   try {
     // Try to acquire the lock with no retries (immediate check)
-    // Stale locks will be detected after 3 seconds (server should start quickly)
+    // Allow enough time for a server worker to start even when validation workers
+    // saturate the CPU and delay the lock heartbeat.
     lockReleaseFunction = await lockfile.lock(lockPath, {
       retries: 0, // Don't retry, just check once
-      stale: 3000, // Consider lock stale after 3 seconds
+      stale: 30_000,
       realpath: false, // Don't resolve symlinks (file doesn't need to exist)
     });
+
+    // A worker that initialized earlier may have released the election lock after
+    // starting the server. Check the endpoint while holding the lock so late
+    // workers reuse that server instead of trying to listen on the same address.
+    if (await hasExistingWorker(socketDir)) {
+      await releaseServerLock();
+      return false;
+    }
 
     return true;
   } catch (error: any) {
@@ -224,7 +253,9 @@ export async function releaseServerLock(): Promise<void> {
  * @param socketDir - Optional custom directory for socket files
  */
 export async function hasExistingWorker(socketDir?: string): Promise<boolean> {
-  return fileExists(getSocketPath(socketDir));
+  // The election lock may have been released immediately before the server
+  // becomes connectable. Retry briefly before deciding to start another server.
+  return waitForSocketConnection(getSocketPath(socketDir), 500);
 }
 
 /**
@@ -252,26 +283,26 @@ export class SocketClient {
   }
 
   /**
-   * Connect to the worker socket with retry logic
+   * Connect to the worker socket, retrying while the server starts or named-pipe
+   * instances are temporarily busy.
    */
-  async connect(retryCount = 0, maxRetries = 10, retryDelay = 50): Promise<void> {
+  async connect(timeoutMs: number = 30_000, retryDelay: number = 50): Promise<void> {
     const socketPath = getSocketPath(this.socketDir);
+    const startTime = Date.now();
 
-    try {
-      await this.attemptConnect(socketPath);
-    } catch (error) {
-      // If we've exhausted retries, throw the error
-      if (retryCount >= maxRetries - 1) {
-        throw error;
+    while (true) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await this.attemptConnect(socketPath);
+        return;
+      } catch (error) {
+        if (Date.now() - startTime >= timeoutMs) {
+          throw error;
+        }
       }
 
-      // Wait before retrying
-      await new Promise((resolve) => {
-        setTimeout(resolve, retryDelay);
-      });
-
-      // Recursive retry
-      await this.connect(retryCount + 1, maxRetries, retryDelay);
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(retryDelay);
     }
   }
 

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/socketClient.ts
@@ -10,7 +10,7 @@
 
 import { connect } from 'node:net';
 import type { Socket } from 'node:net';
-import { mkdir, stat } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -102,18 +102,6 @@ export async function ensureSocketDir(): Promise<void> {
 }
 
 /**
- * Check if a file exists
- */
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await stat(path);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Try to connect to an IPC endpoint.
  * @returns true if connection succeeded, false otherwise
  */
@@ -164,41 +152,6 @@ async function waitForSocketConnection(socketPath: string, timeoutMs: number): P
   return false;
 }
 
-/**
- * Wait for the IPC endpoint to become available.
- * On Unix: Polls the filesystem for the socket file to appear. We avoid
- * `fs.watch` here because on macOS it does not reliably fire events when a
- * unix domain socket file is created.
- * On Windows: Polls by attempting to connect to the named pipe.
- * @param timeoutMs - Timeout in milliseconds (default: 5000)
- */
-export async function waitForSocketFile(timeoutMs: number = 5000): Promise<void> {
-  const socketPath = getSocketPath();
-  const pollInterval = 50;
-  const startTime = Date.now();
-
-  if (isWindows) {
-    if (await waitForSocketConnection(socketPath, timeoutMs)) {
-      return;
-    }
-    throw new Error(`Named pipe did not become available within ${timeoutMs}ms`);
-  }
-
-  // Ensure the directory exists so the first stat doesn't fail spuriously
-  await mkdir(getEffectiveSocketDir(), { recursive: true });
-
-  while (Date.now() - startTime < timeoutMs) {
-    // eslint-disable-next-line no-await-in-loop
-    if (await fileExists(socketPath)) {
-      return;
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await sleep(pollInterval);
-  }
-
-  throw new Error(`Socket file did not appear within ${timeoutMs}ms`);
-}
-
 // Store the release function globally so we can call it when needed
 let lockReleaseFunction: (() => Promise<void>) | null = null;
 
@@ -220,6 +173,10 @@ export async function tryAcquireServerLock(): Promise<boolean> {
       retries: 0, // Don't retry, just check once
       stale: 30_000,
       realpath: false, // Don't resolve symlinks (file doesn't need to exist)
+      onCompromised: (error) => {
+        console.error('[SocketClient] Server lock compromised:', error);
+        lockReleaseFunction = null;
+      },
     });
 
     // A worker that initialized earlier may have released the election lock after
@@ -245,10 +202,12 @@ export async function tryAcquireServerLock(): Promise<boolean> {
  * Release the server lock
  */
 export async function releaseServerLock(): Promise<void> {
-  if (lockReleaseFunction) {
+  const release = lockReleaseFunction;
+  lockReleaseFunction = null;
+
+  if (release) {
     try {
-      await lockReleaseFunction();
-      lockReleaseFunction = null;
+      await release();
     } catch (error) {
       // Ignore errors during cleanup
     }
@@ -256,8 +215,7 @@ export async function releaseServerLock(): Promise<void> {
 }
 
 /**
- * Check if there's an existing worker socket file
- * Note: The socket server will clean up stale sockets on startup
+ * Check whether a types server is accepting connections, retrying for up to 500ms.
  */
 export async function hasExistingWorker(): Promise<boolean> {
   // The election lock may have been released immediately before the server

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
@@ -149,8 +149,18 @@ class WorkerThreadTypesProcessor implements TypesProcessor {
       // connection fail under high concurrency.
       await this.socketClient.connect();
     } catch (error) {
-      if (isServer) {
-        await releaseServerLock();
+      this.socketClient?.close();
+      this.socketClient = null;
+
+      try {
+        if (this.serverWorker) {
+          await this.serverWorker.terminate();
+        }
+      } finally {
+        this.serverWorker = null;
+        if (isServer) {
+          await releaseServerLock();
+        }
       }
       throw error;
     }

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
@@ -5,12 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 // eslint-disable-next-line n/prefer-node-protocol
 import { isMainThread, Worker } from 'worker_threads';
-import {
-  SocketClient,
-  tryAcquireServerLock,
-  releaseServerLock,
-  waitForSocketFile,
-} from './socketClient';
+import { SocketClient, tryAcquireServerLock, releaseServerLock } from './socketClient';
 import type { WorkerRequest, WorkerResponse } from './worker';
 
 /**
@@ -18,7 +13,7 @@ import type { WorkerRequest, WorkerResponse } from './worker';
  */
 export interface TypesProcessor {
   processTypes(request: WorkerRequest): Promise<WorkerResponse>;
-  terminate(): void;
+  terminate(): Promise<void>;
 }
 
 /**
@@ -94,9 +89,9 @@ class TypesMetaWorkerManager implements TypesProcessor {
     });
   }
 
-  terminate(): void {
+  async terminate(): Promise<void> {
     if (this.worker) {
-      this.worker.terminate();
+      await this.worker.terminate();
       this.worker = null;
     }
     this.pendingRequests.clear();
@@ -106,8 +101,7 @@ class TypesMetaWorkerManager implements TypesProcessor {
 /**
  * Types processor for validate worker threads.
  * On first processTypes() call, races to acquire the server lock:
- * - Winner: releases the lock, spawns a bare worker (which acquires the lock
- *   naturally and becomes the socket server via existing worker.ts logic)
+ * - Winner: holds the lock and spawns a bare worker that becomes the socket server
  * - Losers: skip spawning
  *
  * All workers then connect to the socket server as clients.
@@ -146,24 +140,20 @@ class WorkerThreadTypesProcessor implements TypesProcessor {
       this.serverWorker.on('error', (error) => {
         console.error('[WorkerThreadTypesProcessor] Server worker error:', error);
       });
-
-      try {
-        // Wait for the socket file to appear, then release the lock.
-        await waitForSocketFile(30_000);
-      } catch (error) {
-        // Server worker crashed before creating the socket — release the lock
-        // so another worker can become the server on a subsequent attempt.
-        await releaseServerLock();
-        throw error;
-      }
-      await releaseServerLock();
-    } else {
-      // Another worker is the server — wait for the socket file.
-      await waitForSocketFile(30_000);
     }
 
     this.socketClient = new SocketClient();
-    await this.socketClient.connect();
+    try {
+      // Establish the persistent client connection directly. A separate probe
+      // can consume an available Windows named-pipe instance and make the real
+      // connection fail under high concurrency.
+      await this.socketClient.connect();
+    } catch (error) {
+      if (isServer) {
+        await releaseServerLock();
+      }
+      throw error;
+    }
   }
 
   async processTypes(request: WorkerRequest): Promise<WorkerResponse> {
@@ -171,15 +161,16 @@ class WorkerThreadTypesProcessor implements TypesProcessor {
     return this.socketClient!.sendRequest(request);
   }
 
-  terminate(): void {
+  async terminate(): Promise<void> {
     if (this.socketClient) {
       this.socketClient.close();
       this.socketClient = null;
     }
     if (this.serverWorker) {
-      this.serverWorker.terminate();
+      await this.serverWorker.terminate();
       this.serverWorker = null;
     }
+    await releaseServerLock();
   }
 }
 
@@ -208,10 +199,10 @@ export function getWorkerManager(): TypesProcessor {
   return processObj[WORKER_MANAGER_KEY];
 }
 
-export function terminateWorkerManager(): void {
+export async function terminateWorkerManager(): Promise<void> {
   const processObj = process as ProcessWithWorkerManager;
   if (processObj[WORKER_MANAGER_KEY]) {
-    processObj[WORKER_MANAGER_KEY].terminate();
+    await processObj[WORKER_MANAGER_KEY].terminate();
     processObj[WORKER_MANAGER_KEY] = undefined;
   }
 }

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
@@ -160,8 +160,18 @@ class WorkerThreadTypesProcessor implements TypesProcessor {
       // connection fail under high concurrency.
       await this.socketClient.connect();
     } catch (error) {
-      if (isServer) {
-        await releaseServerLock();
+      this.socketClient?.close();
+      this.socketClient = null;
+
+      try {
+        if (this.serverWorker) {
+          await this.serverWorker.terminate();
+        }
+      } finally {
+        this.serverWorker = null;
+        if (isServer) {
+          await releaseServerLock();
+        }
       }
       throw error;
     }

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/workerManager.ts
@@ -5,12 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 // eslint-disable-next-line n/prefer-node-protocol
 import { isMainThread, Worker } from 'worker_threads';
-import {
-  SocketClient,
-  tryAcquireServerLock,
-  releaseServerLock,
-  waitForSocketFile,
-} from './socketClient';
+import { SocketClient, tryAcquireServerLock, releaseServerLock } from './socketClient';
 import type { WorkerRequest, WorkerResponse } from './worker';
 
 /**
@@ -18,7 +13,7 @@ import type { WorkerRequest, WorkerResponse } from './worker';
  */
 export interface TypesProcessor {
   processTypes(request: WorkerRequest): Promise<WorkerResponse>;
-  terminate(): void;
+  terminate(): Promise<void>;
 }
 
 /**
@@ -99,9 +94,9 @@ class TypesMetaWorkerManager implements TypesProcessor {
     });
   }
 
-  terminate(): void {
+  async terminate(): Promise<void> {
     if (this.worker) {
-      this.worker.terminate();
+      await this.worker.terminate();
       this.worker = null;
     }
     this.pendingRequests.clear();
@@ -111,8 +106,7 @@ class TypesMetaWorkerManager implements TypesProcessor {
 /**
  * Types processor for validate worker threads.
  * On first processTypes() call, races to acquire the server lock:
- * - Winner: releases the lock, spawns a bare worker (which acquires the lock
- *   naturally and becomes the socket server via existing worker.ts logic)
+ * - Winner: holds the lock and spawns a bare worker that becomes the socket server
  * - Losers: skip spawning
  *
  * All workers then connect to the socket server as clients.
@@ -157,24 +151,20 @@ class WorkerThreadTypesProcessor implements TypesProcessor {
       this.serverWorker.on('error', (error) => {
         console.error('[WorkerThreadTypesProcessor] Server worker error:', error);
       });
-
-      try {
-        // Wait for the socket file to appear, then release the lock.
-        await waitForSocketFile(this.socketDir, 30_000);
-      } catch (error) {
-        // Server worker crashed before creating the socket — release the lock
-        // so another worker can become the server on a subsequent attempt.
-        await releaseServerLock();
-        throw error;
-      }
-      await releaseServerLock();
-    } else {
-      // Another worker is the server — wait for the socket file.
-      await waitForSocketFile(this.socketDir, 30_000);
     }
 
     this.socketClient = new SocketClient(this.socketDir);
-    await this.socketClient.connect();
+    try {
+      // Establish the persistent client connection directly. A separate probe
+      // can consume an available Windows named-pipe instance and make the real
+      // connection fail under high concurrency.
+      await this.socketClient.connect();
+    } catch (error) {
+      if (isServer) {
+        await releaseServerLock();
+      }
+      throw error;
+    }
   }
 
   async processTypes(request: WorkerRequest): Promise<WorkerResponse> {
@@ -182,15 +172,16 @@ class WorkerThreadTypesProcessor implements TypesProcessor {
     return this.socketClient!.sendRequest(request);
   }
 
-  terminate(): void {
+  async terminate(): Promise<void> {
     if (this.socketClient) {
       this.socketClient.close();
       this.socketClient = null;
     }
     if (this.serverWorker) {
-      this.serverWorker.terminate();
+      await this.serverWorker.terminate();
       this.serverWorker = null;
     }
+    await releaseServerLock();
   }
 }
 
@@ -219,10 +210,10 @@ export function getWorkerManager(socketDir?: string): TypesProcessor {
   return processObj[WORKER_MANAGER_KEY];
 }
 
-export function terminateWorkerManager(): void {
+export async function terminateWorkerManager(): Promise<void> {
   const processObj = process as ProcessWithWorkerManager;
   if (processObj[WORKER_MANAGER_KEY]) {
-    processObj[WORKER_MANAGER_KEY].terminate();
+    await processObj[WORKER_MANAGER_KEY].terminate();
     processObj[WORKER_MANAGER_KEY] = undefined;
   }
 }


### PR DESCRIPTION
## Summary

- keep the shared types-server election lock for the lifetime of the server
- shut validation workers down gracefully so the server and lock are released in order
- connect socket clients directly with bounded retries, avoiding probe connections that contend for Windows named-pipe instances
- add regression coverage for server election and delayed named-pipe startup

## Root cause

`docs-infra validate` creates several validation workers that share one types metadata server. The elected worker released its lock as soon as the IPC endpoint became reachable, allowing a later worker to acquire the lock and start a second server on the same Windows named pipe. Separate availability probes could also consume or contend for a pipe instance before the persistent client connected.

## Impact

`pnpm docs:api` can process documentation types in parallel on Windows without duplicate types servers failing with `EADDRINUSE`.

## Validation

- `pnpm test --run socketClient` (4 tests passed)
- `pnpm typescript`
- `pnpm eslint`
- `pnpm prettier`
- `pnpm release:build`
- `pnpm code-infra --help`
- packed `@mui/internal-docs-infra` locally and ran Base UI `pnpm docs:api` successfully with 31 workers processing 42 type files