### PR TITLE
[renovate] Widen @next/bundle-analyzer to a caret range

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -32,7 +32,7 @@
     "web-vitals": "^5.3.0"
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "16.2.11",
+    "@next/bundle-analyzer": "^16.2.11",
     "@playwright/test": "1.61.1",
     "@types/node": "22.19.0",
     "@types/react": "19.2.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
         version: 5.3.0
     devDependencies:
       '@next/bundle-analyzer':
-        specifier: 16.2.11
+        specifier: ^16.2.11
         version: 16.2.11
       '@playwright/test':
         specifier: 1.61.1

--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,8 @@
       "enabled": false
     },
     {
-      "description": "Override :pinDevDependencies for packages that are used as both a dev and non-dev dependency, so they are not pinned.",
-      "matchDepNames": ["next"],
+      "description": "Override :pinDevDependencies for Next.js packages, so they keep caret ranges and stay in one update group with the non-dev `next` dependency.",
+      "matchSourceUrls": ["https://github.com/vercel/next.js"],
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "bump"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
       "enabled": false
     },
     {
-      "description": "Override :pinDevDependencies for Next.js packages, so they keep caret ranges and stay in one update group with the non-dev `next` dependency.",
+      "description": "Override :pinDevDependencies for packages that are used as both a dev and non-dev dependency, so they are not pinned.",
       "matchSourceUrls": ["https://github.com/vercel/next.js"],
       "matchDepTypes": ["devDependencies"],
       "rangeStrategy": "bump"


### PR DESCRIPTION
`@next/bundle-analyzer` was the last Next.js package in the repo still pinned to an exact version. The override added in #1702 only matched `next` by name, so `:pinDevDependencies` kept pinning the analyzer — which pulls its minor/patch bumps out of the nextjs monorepo group into `code-infra:devDependencies` and lets it drift against a floating `next`.

Match the whole `vercel/next.js` monorepo by source URL instead. `matchDepTypes` stays scoped to `devDependencies` so the broader matcher doesn't reach docs-infra's optional `next` peer range, which needs to keep the `widen` strategy. The value in `docs/package.json` is widened by hand because neither `bump` nor `widen` un-pins an already-exact version.