### PR TITLE
[ci] Drop unused pull-requests write from Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -103,14 +103,16 @@ jobs:
     concurrency:
       group: claude-review-${{ github.event.issue.number }}
       cancel-in-progress: false
-    # Least privilege. Note: GitHub has no comment-only scope — issues/pull-requests
-    # write also allow editing metadata, labels, and submitting reviews, more than we
-    # use; the tool allowlist below is what actually restricts Claude.
+    # Least privilege. The review only ever posts one top-level comment, which is an
+    # issue comment even on a PR, so pull-requests stays read (the prep step and
+    # `gh pr view` need PR metadata). Note: GitHub has no comment-only scope — issues
+    # write also allows editing issue metadata and labels, more than we use; the tool
+    # allowlist below is what actually restricts Claude.
     permissions:
       contents: read # read the repo; never write to it
       id-token: write # mint the GitHub OIDC token exchanged for a Claude token via WIF
-      issues: write # needed to comment (also covers the PR top-level comment)
-      pull-requests: write # needed to post inline review comments
+      issues: write # needed to comment (covers the PR top-level comment)
+      pull-requests: read # read PR metadata; nothing here writes to the PR
     steps:
       # The repo default branch (trusted — it hosts the review skill) is checked out at
       # the root; the PR head is fetched as data only in the next step. Never checkout
@@ -269,8 +271,8 @@ jobs:
           # ./pr-head in the working dir — re-check "never execute PR code" before then.
           #
           # --comment, not inline: the skill's inline path prefers `gh api` (not
-          # allowlisted); to switch, re-add mcp__github_inline_comment__create_inline_comment
-          # and name it in the prompt.
+          # allowlisted); to switch, re-add mcp__github_inline_comment__create_inline_comment,
+          # name it in the prompt, and raise the job's pull-requests permission to write.
           #
           # --model: the review model; subagents inherit it.
           claude_args: |


### PR DESCRIPTION
Follows up on a review nit on mui/base-ui#5323, which applies to the reusable workflow itself and not just base-ui's caller stub.

The review posts one top-level comment via `gh pr comment` — an issue comment even on a PR — and the inline-comment tool isn't in the allowlist, so `issues: write` already covers it. The job keeps `pull-requests: read` for PR metadata (`gh pr view`).

This also unblocks base-ui#5323: its stub already grants `pull-requests: read`, but pins this workflow at d7a7219, which declares `write`. A caller granting less than the called workflow declares is a hard failure ("The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: read'"), not a silent cap — so that stub needs its pin bumped past this commit before its first `@claude review`.

Only smoke-testable after merge: `issue_comment` always runs the default-branch copy of the workflow, so a `@claude review` on this PR would exercise master's version, not this one.