### PR TITLE
[code-infra] Permit the empty aria-activedescendant SSR placeholder

### DIFF
--- a/packages/code-infra/src/brokenLinksChecker/__fixtures__/static-site/recommended-defaults.html
+++ b/packages/code-infra/src/brokenLinksChecker/__fixtures__/static-site/recommended-defaults.html
@@ -16,5 +16,11 @@
     <form action="javascript:throw new Error('not hydrated')">
       <button type="submit">Submit</button>
     </form>
+
+    <!-- A combobox keeps an empty aria-activedescendant while its popup is open
+         and writes the active option's id imperatively after hydration, so the
+         empty placeholder is what static HTML carries. -->
+    <label for="combobox">Search</label>
+    <input id="combobox" role="combobox" aria-expanded="true" aria-activedescendant="" />
   </body>
 </html>

--- a/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
+++ b/packages/code-infra/src/brokenLinksChecker/crawlWorker.mjs
@@ -199,6 +199,18 @@ if (pageData.status < 200 || pageData.status >= 400) {
             elements: [
               'html5',
               {
+                '*': {
+                  attributes: {
+                    // Comboboxes keep `aria-activedescendant` on the input while
+                    // their popup is open and write the active option's id
+                    // imperatively after hydration, so the empty placeholder is
+                    // what static HTML carries. Permit it while keeping the
+                    // default check (`^\s*\S+\s*$`) for every other value.
+                    'aria-activedescendant': {
+                      enum: ['/^\\s*\\S+\\s*$/', ''],
+                    },
+                  },
+                },
                 form: {
                   attributes: {
                     // React renders `action="javascript:throw new Error(...)"` on

--- a/packages/code-infra/src/brokenLinksChecker/index.test.ts
+++ b/packages/code-infra/src/brokenLinksChecker/index.test.ts
@@ -305,9 +305,11 @@ describe('Broken Links Checker', () => {
 
     // Validate with recommended rules only (no caller-supplied overrides), so
     // this exercises the mui:recommended baseline in isolation. The fixture page
-    // relies on two defaults: `no-missing-references` is off (portaled targets
-    // are absent from static HTML) and the `<form>` action enum permits React's
-    // SSR sentinel value `javascript:throw new Error(...)`. Neither should report.
+    // relies on three defaults: `no-missing-references` is off (portaled targets
+    // are absent from static HTML), the `<form>` action enum permits React's SSR
+    // sentinel value `javascript:throw new Error(...)`, and the
+    // `aria-activedescendant` enum permits the empty placeholder a combobox
+    // renders while open. None should report.
     const result = await crawl({
       startCommand: `${servePath} ${fixtureDir} -p ${port}`,
       host,


### PR DESCRIPTION
html-validate 11 (adopted in #1629) started validating ARIA attribute values, so `mui:recommended` now reports `aria-activedescendant=""` as an error where v10 did not. Comboboxes keep that attribute on the input while the popup is open and write the active option's id imperatively after hydration, so the empty placeholder is what statically rendered HTML carries — it is gone by the time the page is interactive.

Permit it the same way the `<form>` action sentinel already is, keeping the default non-blank check for every other value (a whitespace-only value still reports). This unblocks mui/material-ui#48878, where the docs page rendering `<Autocomplete open>` trips it.