### PR TITLE
Claude review: instruct the agent not to add its own footer

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -279,7 +279,10 @@ jobs:
             Return the complete Markdown review as the `review` field of your final
             structured output — that is the deliverable, which this workflow publishes to
             the PR. Do not post to GitHub or write any files yourself; you have no write
-            access, so the attempt only costs turns.
+            access, so the attempt only costs turns. Do not add a "🤖 Review generated
+            with …" sign-off or any attribution footer: that line belongs to whoever posts
+            the comment, and here that is this workflow, not you — your skill adds it only
+            when it posts the comment itself, which it is not doing here.
 
             A `[TURN BUDGET]` counter is injected after each tool call, showing turns
             used and the soft limit. Finishing the review is the priority — once you reach
@@ -375,13 +378,6 @@ jobs:
             // {review: "<markdown>"}, so it is well-formed by construction; on a failed or
             // aborted run it is empty ({}) and falls through to the "no report" failure below.
             let report = (JSON.parse(process.env.STRUCTURED_OUTPUT || '{}').review || '').trim();
-            // The skill may append its own "🤖 Review generated with …" sign-off (its
-            // attribution convention when it thinks it is publishing); the workflow owns the
-            // footer below, so strip a trailing sign-off and any dangling rule to avoid two.
-            report = report
-              .replace(/\n*🤖 Review generated with[^\n]*$/i, '')
-              .replace(/\n*---\s*$/, '')
-              .trim();
             const limit = 65536 - footer.length; // GitHub's comment body limit
             if (report.length > limit) {
               const notice = '\n\n_Report truncated to fit a comment._';

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -375,6 +375,13 @@ jobs:
             // {review: "<markdown>"}, so it is well-formed by construction; on a failed or
             // aborted run it is empty ({}) and falls through to the "no report" failure below.
             let report = (JSON.parse(process.env.STRUCTURED_OUTPUT || '{}').review || '').trim();
+            // The skill may append its own "🤖 Review generated with …" sign-off (its
+            // attribution convention when it thinks it is publishing); the workflow owns the
+            // footer below, so strip a trailing sign-off and any dangling rule to avoid two.
+            report = report
+              .replace(/\n*🤖 Review generated with[^\n]*$/i, '')
+              .replace(/\n*---\s*$/, '')
+              .trim();
             const limit = 65536 - footer.length; // GitHub's comment body limit
             if (report.length > limit) {
               const notice = '\n\n_Report truncated to fit a comment._';


### PR DESCRIPTION
Reviews rendered two `🤖 Review generated with Claude Code` footers: the skill appends its own attribution sign-off (it treats the returned review as "posting"), then the Publish step adds the workflow footer with stats.

Fix it in the workflow prompt (central, so it covers every caller regardless of their skill): tell the agent to return the review only and not add any `🤖 Review generated with …` sign-off, since here the *workflow* posts, not the agent — matching the skill's own rule that attribution is only for when it posts the comment itself.