### PR TITLE
[code-infra] Add skill to handle full release lifecycle

### DIFF
--- a/skills/mui-release/SKILL.md
+++ b/skills/mui-release/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: mui-release
+description: Run or assist a release in any MUI repo - prepare the release PR (version bump, changelog, release:version), merge it and trigger the npm publish workflow, deploy docs, publish the GitHub release, and announce.
+argument-hint: '[target-version]'
+---
+
+# MUI Release
+
+Every MUI repo releases through the same staged pipeline. Each stage depends on the previous one completing — never start a stage before its predecessor is done. This skill describes the shared skeleton; the details vary per repo.
+
+**Resumable:** the skill can be invoked at any stage — a release often spans multiple sessions (e.g. the PR was created and merged earlier, and the user now wants to trigger the npm publish). In the pipeline chart below, each stage is followed by the observable evidence that it is complete: resume at the first stage whose evidence is missing. Confirm the detected stage with the user before continuing; earlier stages' outputs are inputs, not work to redo.
+
+**Source of truth:** the target repo's `scripts/README.md` is the authoritative, evolving runbook. Always read it in the target checkout before releasing; use this skill to know what the stages mean and what to expect. Where the README contradicts this skill, the README wins. Repo-specific steps (docs release pages, hotfix flows, prerelease handling, first-time package publishing) live only there.
+
+## The pipeline
+
+Each stage's instructions live in its own file — after detecting and confirming the current stage, read **that stage's file**:
+
+```txt
+Stage 1: Prepare the release PR          → stage-1-prepare-pr.md
+   ↓ (open PR with the `release` label, approved, CI green)
+Stage 2: Merge the PR, then publish      → stage-2-publish-packages.md
+   ↓ (`release` PR merged, packages on npm at the new version,
+      draft GitHub release created)
+Stage 3: Publish the docs                → stage-3-publish-docs.md
+   ↓ (docs live for the new version)
+Stage 4: Publish the GitHub release,     → stage-4-github-release.md
+         then announce
+   ↓ (published non-draft GitHub release for the current root
+      package.json version → release done; next one starts at Stage 1)
+```
+
+Verify each stage's evidence with read-only commands (run in the target checkout; `<version>` is the root `package.json` version):
+
+```bash
+# release PR: open (stage 1) or merged (stage 2 done merging)
+gh pr list --label release --state open --json number,title,reviewDecision
+gh pr list --label release --state merged --limit 1 --json number,title,mergedAt
+gh pr checks <number>                      # CI green?
+
+# packages on npm at the new version
+npm view <main-package>@<version> version
+
+# GitHub release: exists? still a draft?
+gh release list --limit 5 --json tagName,isDraft,isLatest
+gh release view "v<version>" --json tagName,isDraft
+
+# docs live for the new version
+curl -s <docs-url> | grep "<version>"      # or check the Netlify dashboard
+```
+
+## Not covered
+
+Repo-specific extras (docs release pages, hotfix branch flows, prerelease progressions, docs-only deploys, first-time package publishing / trusted-publishing setup) — read the target repo's `scripts/README.md` for those. Repos without that runbook: read their release workflow directly.

--- a/skills/mui-release/SKILL.md
+++ b/skills/mui-release/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: '[target-version]'
 
 Every MUI repo releases through the same staged pipeline. Each stage depends on the previous one completing — never start a stage before its predecessor is done. This skill describes the shared skeleton; the details vary per repo.
 
-**Resumable:** the skill can be invoked at any stage — a release often spans multiple sessions (e.g. the PR was created and merged earlier, and the user now wants to trigger the npm publish). In the pipeline chart below, each stage is followed by the observable evidence that it is complete: resume at the first stage whose evidence is missing. Confirm the detected stage with the user before continuing; earlier stages' outputs are inputs, not work to redo.
+**Resumable:** the skill can be invoked at any stage — a release often spans multiple sessions (e.g. the PR was created and merged earlier, and the user now wants to trigger the npm publish). In the pipeline diagram below, each arrow out of a stage states the observable evidence that the stage is complete: resume at the first stage whose evidence is missing. Confirm the detected stage with the user before continuing; earlier stages' outputs are inputs, not work to redo.
 
 **Source of truth:** the target repo's `scripts/README.md` is the authoritative, evolving runbook. Always read it in the target checkout before releasing; use this skill to know what the stages mean and what to expect. Where the README contradicts this skill, the README wins. Repo-specific steps (docs release pages, hotfix flows, prerelease handling, first-time package publishing) live only there.
 
@@ -16,18 +16,17 @@ Every MUI repo releases through the same staged pipeline. Each stage depends on 
 
 Each stage's instructions live in its own file — after detecting and confirming the current stage, read **that stage's file**:
 
-```txt
-Stage 1: Prepare the release PR          → stage-1-prepare-pr.md
-   ↓ (open PR with the `release` label, approved, CI green)
-Stage 2: Merge the PR, then publish      → stage-2-publish-packages.md
-   ↓ (`release` PR merged, packages on npm at the new version,
-      draft GitHub release created)
-Stage 3: Publish the docs                → stage-3-publish-docs.md
-   ↓ (docs live for the new version)
-Stage 4: Publish the GitHub release,     → stage-4-github-release.md
-         then announce
-   ↓ (published non-draft GitHub release for the current root
-      package.json version → release done; next one starts at Stage 1)
+```mermaid
+flowchart TD
+    S1["Stage 1: Prepare the release PR\n(stage-1-prepare-pr.md)"]
+    S2["Stage 2: Merge the PR, then publish\n(stage-2-publish-packages.md)"]
+    S3["Stage 3: Publish the docs\n(stage-3-publish-docs.md)"]
+    S4["Stage 4: Publish the GitHub release, then announce\n(stage-4-github-release.md)"]
+
+    S1 -- "open PR with the release label,\napproved, CI green" --> S2
+    S2 -- "release PR merged, packages on npm at\nthe new version, draft GitHub release created" --> S3
+    S3 -- "docs live for the new version" --> S4
+    S4 -- "published non-draft GitHub release for the\ncurrent root package.json version\n(release done, next one starts at Stage 1)" --> S1
 ```
 
 Verify each stage's evidence with read-only commands (run in the target checkout; `<version>` is the root `package.json` version):

--- a/skills/mui-release/SKILL.md
+++ b/skills/mui-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mui-release
-description: Run or assist a release in any MUI repo - prepare the release PR (version bump, changelog, release:version), merge it and trigger the npm publish workflow, deploy docs, publish the GitHub release, and announce.
+description: Run or assist a release in any MUI repo, at any stage - release PR, npm publish, docs deploy, GitHub release.
 argument-hint: '[target-version]'
 ---
 
@@ -10,7 +10,7 @@ Every MUI repo releases through the same staged pipeline. Each stage depends on 
 
 **Resumable:** the skill can be invoked at any stage — a release often spans multiple sessions (e.g. the PR was created and merged earlier, and the user now wants to trigger the npm publish). In the pipeline diagram below, each arrow out of a stage states the observable evidence that the stage is complete: resume at the first stage whose evidence is missing. Confirm the detected stage with the user before continuing; earlier stages' outputs are inputs, not work to redo.
 
-**Source of truth:** the target repo's `scripts/README.md` is the authoritative, evolving runbook. Always read it in the target checkout before releasing; use this skill to know what the stages mean and what to expect. Where the README contradicts this skill, the README wins. Repo-specific steps (docs release pages, hotfix flows, prerelease handling, first-time package publishing) live only there.
+**Source of truth:** the target repo's `scripts/README.md` is the authoritative, evolving runbook. Always read it in the target checkout before releasing; use this skill to know what the stages mean and what to expect. Where the README contradicts this skill, the README wins. Repo-specific steps (docs release pages, hotfix flows, prerelease progressions, docs-only deploys, first-time package publishing) live only there. Repos without that runbook: read their release workflow directly.
 
 ## The pipeline
 
@@ -47,7 +47,3 @@ gh release view "v<version>" --json tagName,isDraft
 # docs live for the new version
 curl -s <docs-url> | grep "<version>"      # or check the Netlify dashboard
 ```
-
-## Not covered
-
-Repo-specific extras (docs release pages, hotfix branch flows, prerelease progressions, docs-only deploys, first-time package publishing / trusted-publishing setup) — read the target repo's `scripts/README.md` for those. Repos without that runbook: read their release workflow directly.

--- a/skills/mui-release/stage-1-prepare-pr.md
+++ b/skills/mui-release/stage-1-prepare-pr.md
@@ -9,9 +9,8 @@ All preparation lands as a normal PR against the branch being released (usually 
 5. Clean the generated changelog: match the format of the repo's existing GitHub releases, describe breaking changes explicitly, fix package-name casing. Preserve any marker comments the script inserts — downstream automation may depend on them.
 6. Version the packages with `pnpm release:version` — an **interactive** (PTY) script that confirms the new version of each workspace package before bumping it (along with inter-package dependency ranges). Ask the user to run it in their own terminal and end the turn there. On the next turn, verify the outcome from `git diff` (which packages were bumped and to what) instead of the command's output, against these rules:
    - Only bump packages that have changes since the last release — but if the tooling detects **any** change, do not skip the bump.
-   - Packages that track the root version must be bumped to exactly the root `package.json` version, even if that skips version numbers.
-   - Double-check the repo's **main package** specifically: it must end up at the root `package.json` version even when nothing changed in it — the script skips packages without changes, so this one may need a manual bump after the run.
-7. Open the PR titled `[release] <target-version>` (e.g. `[release] v1.2.0`) with the `release` label — stage 2 finds the release PR by this label — and wait for review and green CI. Keep the PR description minimal: none at all, or a single line when something genuinely needs calling out (the changelog in the diff is the description).
+   - Packages that track the root version — the repo's **main package** above all — must end up at exactly the root `package.json` version, even if that skips version numbers or the package had no changes of its own. The script skips unchanged packages, so the main package may need a manual bump after the run.
+7. Open the PR titled `[release] <target-version>` (e.g. `[release] v1.2.0`) with the `release` label — stage 2 finds the release PR by this label. Keep the PR description minimal: none at all, or a single line when something genuinely needs calling out (the changelog in the diff is the description).
 
 Some repos ship an interactive script (e.g. `pnpm release:prepare`) that automates this stage end to end — prefer it when the README offers one.
 

--- a/skills/mui-release/stage-1-prepare-pr.md
+++ b/skills/mui-release/stage-1-prepare-pr.md
@@ -7,10 +7,11 @@ All preparation lands as a normal PR against the branch being released (usually 
 3. Bump the root `package.json` version to the target release version.
 4. Generate the changelog with `pnpm release:changelog` and **prepend** the output to the top-level `CHANGELOG.md`. Run with `--help` for options (comparison range, target branch, token flags).
 5. Clean the generated changelog: match the format of the repo's existing GitHub releases, describe breaking changes explicitly, fix package-name casing. Preserve any marker comments the script inserts — downstream automation may depend on them.
-6. Run `pnpm release:version` — an **interactive** script that walks through the workspace packages, confirming the new version of each package with the user before bumping it (along with inter-package dependency ranges). Run it in interactive mode in a real terminal; when working as an agent, have the user run it so they answer the per-package prompts. Rules that apply everywhere:
+6. Version the packages with `pnpm release:version` — an **interactive** (PTY) script that confirms the new version of each workspace package before bumping it (along with inter-package dependency ranges). Ask the user to run it in their own terminal and end the turn there. On the next turn, verify the outcome from `git diff` (which packages were bumped and to what) instead of the command's output, against these rules:
    - Only bump packages that have changes since the last release — but if the tooling detects **any** change, do not skip the bump.
    - Packages that track the root version must be bumped to exactly the root `package.json` version, even if that skips version numbers.
-7. Open the PR titled `[release] <target-version>` (e.g. `[release] v1.2.0`) with the `release` label — stage 2 finds the release PR by this label — and wait for review and green CI.
+   - Double-check the repo's **main package** specifically: it must end up at the root `package.json` version even when nothing changed in it — the script skips packages without changes, so this one may need a manual bump after the run.
+7. Open the PR titled `[release] <target-version>` (e.g. `[release] v1.2.0`) with the `release` label — stage 2 finds the release PR by this label — and wait for review and green CI. Keep the PR description minimal: none at all, or a single line when something genuinely needs calling out (the changelog in the diff is the description).
 
 Some repos ship an interactive script (e.g. `pnpm release:prepare`) that automates this stage end to end — prefer it when the README offers one.
 

--- a/skills/mui-release/stage-1-prepare-pr.md
+++ b/skills/mui-release/stage-1-prepare-pr.md
@@ -1,0 +1,21 @@
+# Stage 1 — Prepare the release PR
+
+All preparation lands as a normal PR against the branch being released (usually the repo's default branch, `master` in MUI repos; prereleases or older majors may release from a version branch — the README says which). Some repos require specific git remotes (an `upstream` pointing at the MUI repo, sometimes a dedicated docs remote) — check the README's prerequisites first.
+
+1. Create a branch off the up-to-date upstream release branch (`git fetch upstream --tags` first — the changelog script compares against the last tag).
+2. Ask the user for the target release version, showing them the current version (the root `package.json` version and the latest release tag) alongside the question so they can make an informed choice. If they passed a version when invoking the skill, use that instead of asking. Never pick the target version yourself.
+3. Bump the root `package.json` version to the target release version.
+4. Generate the changelog with `pnpm release:changelog` and **prepend** the output to the top-level `CHANGELOG.md`. Run with `--help` for options (comparison range, target branch, token flags).
+5. Clean the generated changelog: match the format of the repo's existing GitHub releases, describe breaking changes explicitly, fix package-name casing. Preserve any marker comments the script inserts — downstream automation may depend on them.
+6. Run `pnpm release:version` — an **interactive** script that walks through the workspace packages, confirming the new version of each package with the user before bumping it (along with inter-package dependency ranges). Run it in interactive mode in a real terminal; when working as an agent, have the user run it so they answer the per-package prompts. Rules that apply everywhere:
+   - Only bump packages that have changes since the last release — but if the tooling detects **any** change, do not skip the bump.
+   - Packages that track the root version must be bumped to exactly the root `package.json` version, even if that skips version numbers.
+7. Open the PR titled `[release] <target-version>` (e.g. `[release] v1.2.0`) with the `release` label — stage 2 finds the release PR by this label — and wait for review and green CI.
+
+Some repos ship an interactive script (e.g. `pnpm release:prepare`) that automates this stage end to end — prefer it when the README offers one.
+
+**Stage complete when:** the PR is approved and CI is green.
+
+## Troubleshooting
+
+- **Changelog script fails:** build the changelog manually from the GitHub compare view between the last tag and the release branch (`github.com/mui/<repo>/compare/<lastTag>...<branch>`).

--- a/skills/mui-release/stage-2-publish-packages.md
+++ b/skills/mui-release/stage-2-publish-packages.md
@@ -1,0 +1,20 @@
+# Stage 2 — Merge the PR, then publish the packages
+
+Requires stage 1 complete (approved PR, green CI). Before proceeding, verify there is a recently merged (or about-to-merge) PR carrying the `release` label — that PR is the release commit; if it's missing the label, add it before triggering the publish.
+
+1. Just before merging, the user announces a **merge freeze** on the team's Slack channel so nothing else lands until the release and docs deploy are done — as an agent, remind them of this step.
+2. Merge the release PR.
+3. Trigger the publish. It always runs through the repo's `publish.yml` GitHub Actions workflow, never from a local machine. Two trigger styles exist:
+   - **CLI:** `pnpm release:publish` finds the latest merged release PR, asks for confirmation, and dispatches the workflow (pass `--sha <sha>` to target a specific commit).
+   - **GitHub UI:** open the publish workflow → "Run workflow", supplying the release commit SHA and options.
+
+   Common options either way: a dry-run mode for debugging (also as `pnpm release:publish:dry-run`), an npm dist-tag for legacy/canary versions, and whether to auto-create the GitHub release.
+
+4. The run pauses on the `npm-publish` environment: click "Review deployments" and approve it. **Never approve workflow runs you didn't initiate.**
+
+**Stage complete when:** the workflow has published the packages to npm and created a **draft** GitHub release from the changelog.
+
+## Troubleshooting
+
+- **Publish reports "no new packages to publish":** you're likely pointed at the wrong npm registry (e.g. a leftover local-registry config from dry runs) — `npm config delete registry`.
+- **Tagging step fails:** create the tag manually and **annotated**: `git tag -a v<X.Y.Z> -m "Version <X.Y.Z>" && git push upstream --tag`.

--- a/skills/mui-release/stage-2-publish-packages.md
+++ b/skills/mui-release/stage-2-publish-packages.md
@@ -1,11 +1,11 @@
 # Stage 2 — Merge the PR, then publish the packages
 
-Requires stage 1 complete (approved PR, green CI). Before proceeding, verify there is a recently merged (or about-to-merge) PR carrying the `release` label — that PR is the release commit; if it's missing the label, add it before triggering the publish.
+Requires stage 1 complete. Before merging, verify the PR still has the `release` label — the publish tooling finds the release PR by it.
 
 1. Just before merging, the user announces a **merge freeze** on the team's Slack channel so nothing else lands until the release and docs deploy are done — as an agent, remind them of this step.
 2. Merge the release PR.
 3. Trigger the publish. It always runs through the repo's `publish.yml` GitHub Actions workflow, never from a local machine. Two trigger styles exist:
-   - **CLI:** `pnpm release:publish` finds the latest merged release PR, asks for confirmation, and dispatches the workflow (pass `--sha <sha>` to target a specific commit).
+   - **CLI:** `pnpm release:publish` finds the latest merged release PR, asks for confirmation, and dispatches the workflow. To publish from the exact release commit, pass the release PR's merge commit SHA on the default branch: `pnpm release:publish --sha <merge-commit-sha>` (get it with `gh pr view <number> --json mergeCommit`).
    - **GitHub UI:** open the publish workflow → "Run workflow", supplying the release commit SHA and options.
 
    Common options either way: a dry-run mode for debugging (also as `pnpm release:publish:dry-run`), an npm dist-tag for legacy/canary versions, and whether to auto-create the GitHub release.

--- a/skills/mui-release/stage-2-publish-packages.md
+++ b/skills/mui-release/stage-2-publish-packages.md
@@ -4,8 +4,8 @@ Requires stage 1 complete. Before merging, verify the PR still has the `release`
 
 1. Just before merging, the user announces a **merge freeze** on the team's Slack channel so nothing else lands until the release and docs deploy are done — as an agent, remind them of this step.
 2. Merge the release PR.
-3. Trigger the publish. It always runs through the repo's `publish.yml` GitHub Actions workflow, never from a local machine. Two trigger styles exist:
-   - **CLI:** `pnpm release:publish` finds the latest merged release PR, asks for confirmation, and dispatches the workflow. To publish from the exact release commit, pass the release PR's merge commit SHA on the default branch: `pnpm release:publish --sha <merge-commit-sha>` (get it with `gh pr view <number> --json mergeCommit`).
+3. Trigger the publish. It always runs through the repo's `publish.yml` GitHub Actions workflow, never from a local machine:
+   - **CLI:** `pnpm release:publish` (maps to `code-infra publish`) finds the latest merged release PR, asks for confirmation, and dispatches the workflow. To publish from the exact release commit, pass the release PR's merge commit SHA on the default branch: `pnpm release:publish --sha <merge-commit-sha>` (get it with `gh pr view <number> --json mergeCommit`).
    - **GitHub UI:** open the publish workflow → "Run workflow", supplying the release commit SHA and options.
 
    Common options either way: a dry-run mode for debugging (also as `pnpm release:publish:dry-run`), an npm dist-tag for legacy/canary versions, and whether to auto-create the GitHub release.

--- a/skills/mui-release/stage-3-publish-docs.md
+++ b/skills/mui-release/stage-3-publish-docs.md
@@ -1,0 +1,7 @@
+# Stage 3 — Publish the docs
+
+Requires stage 2 complete (packages published — docs must reference versions that exist on npm).
+
+`pnpm docs:deploy` pushes the release commit to the repo's docs deployment target — a versioned `docs-vX` branch or a dedicated docs repo/branch, mapped to the live docs domain. Force-pushing is expected. Deploys run on Netlify; follow progress on the site's Netlify dashboard. The README documents the branch scheme and URLs.
+
+**Stage complete when:** the Netlify deploy has finished and the docs are live.

--- a/skills/mui-release/stage-4-github-release.md
+++ b/skills/mui-release/stage-4-github-release.md
@@ -1,0 +1,8 @@
+# Stage 4 — Publish the GitHub release, then announce
+
+Requires stage 3 complete (docs live).
+
+1. Review the draft release on the repo's GitHub releases page and publish it — this is what creates the release tag. Check **Set as a pre-release** for unstable versions.
+2. The user lifts the merge freeze on Slack and follows the team's internal announcement instructions (linked from the repo's README, typically a Notion "Releases" page) — as an agent, remind them of both.
+
+**Stage complete when:** the GitHub release is public (non-draft) — the release is done. The freeze lift and announcement are on the user's side; remind them.

--- a/skills/mui-release/stage-4-github-release.md
+++ b/skills/mui-release/stage-4-github-release.md
@@ -2,7 +2,10 @@
 
 Requires stage 3 complete (docs live).
 
-1. Review the draft release on the repo's GitHub releases page and publish it — this is what creates the release tag. Check **Set as a pre-release** for unstable versions.
-2. The user lifts the merge freeze on Slack and follows the team's internal announcement instructions (linked from the repo's README, typically a Notion "Releases" page) — as an agent, remind them of both.
+1. Review the draft release on the repo's GitHub releases page and publish it. Mark it correctly for what's being released:
+   - Stable release on the current major → **Set as the latest release**.
+   - Release for an older major → do **not** set as latest — the current major's release must keep the "Latest" badge.
+   - Unstable version (alpha/beta/RC) → check **Set as a pre-release** instead.
+2. The user lifts the merge freeze on Slack and follows the team's internal announcement instructions — as an agent, remind them of both.
 
 **Stage complete when:** the GitHub release is public (non-draft) — the release is done. The freeze lift and announcement are on the user's side; remind them.


### PR DESCRIPTION
Adds a generic `mui-release` agent skill condensing the release runbooks (`scripts/README.md`) shared across MUI repos (base-ui, material-ui, mui-x) into a four-stage pipeline:

1. **Prepare the release PR** — version bump, changelog, interactive `release:version`, PR with the `release` label.
2. **Merge the PR, then publish the packages** — merge freeze, `publish.yml` workflow, `npm-publish` environment approval.
3. **Publish the docs** — `docs:deploy` to the repo's docs branch/repo via Netlify.
4. **Publish the GitHub release, then announce** — publish the draft release (creates the tag), lift the freeze, announce.
