### PR TITLE
[code-infra] Manage the publish-prepare Node.js version with Renovate

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -91,8 +91,8 @@
       "matchStringsStrategy": "recursive",
       "matchStrings": [
         // Scoped to publish-prepare so actions/setup-node inputs stay with the built-in github-actions manager.
-        // The lookahead stops the match at the next step, so a step without the input never borrows the following one.
-        "uses: mui/mui-public/\\.github/actions/publish-prepare@[^\\n]+\\n(?:(?![^\\n]*-\\s+(?:name|uses):)[^\\n]*\\n)*?\\s*node-version:\\s*'?[^'\\s]+'?",
+        // Renovate compiles these with RE2, so no look-around: intervening lines may not start with "-", which ends the match at the next step.
+        "uses: mui/mui-public/\\.github/actions/publish-prepare@[^\\n]+\\n(?:[ \\t]*(?:[^-\\s\\n][^\\n]*)?\\n)*?[ \\t]*node-version:\\s*'?[^'\\s]+'?",
         "node-version:\\s*'?(?<currentValue>[^'\\s]+)'?"
       ],
       "depNameTemplate": "node",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -83,6 +83,21 @@
       "depNameTemplate": "node",
       "datasourceTemplate": "node-version",
       "versioningTemplate": "node"
+    },
+    {
+      "description": "Custom manager for the Node.js version passed to the publish-prepare action",
+      "customType": "regex",
+      "fileMatch": ["(^|/)\\.github/workflows/.+\\.ya?ml$"],
+      "matchStringsStrategy": "recursive",
+      "matchStrings": [
+        // Scoped to publish-prepare so actions/setup-node inputs stay with the built-in github-actions manager.
+        // The lookahead stops the match at the next step, so a step without the input never borrows the following one.
+        "uses: mui/mui-public/\\.github/actions/publish-prepare@[^\\n]+\\n(?:(?![^\\n]*-\\s+(?:name|uses):)[^\\n]*\\n)*?\\s*node-version:\\s*'?[^'\\s]+'?",
+        "node-version:\\s*'?(?<currentValue>[^'\\s]+)'?"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Renovate's built-in `github-actions` manager only detects `node-version` on `actions/setup-node`. The same input passed to `mui/mui-public/.github/actions/publish-prepare` is invisible to it, so those pins drift until a Publish Dry Run job fails.

That just happened on https://github.com/mui/material-ui/pull/48896: the bump moved `engines.node` to `>=22.23.2` but left three `publish-prepare` inputs at 22.23.1, and Publish Dry Run failed with `ERR_PNPM_UNSUPPORTED_ENGINE`. I fixed those by hand; this PR stops the next one.

Current drift across the repos that call the action:

| Repo | pin |
|---|---|
| mui-x | 22.23.2 |
| material-ui | 22.23.2 (just fixed by hand) |
| material-ui-docs | 22.23.1 |
| base-ui | 22.22.3 |
| base-ui-charts | 22.22.3 |
| base-ui-plus | 22.22.3 |
| mui-public | no pin, uses the action default |

## Validation

Renovate compiles custom-manager `matchStrings` with RE2, not the JS engine, so I rebuilt both patterns from the committed JSON with the `re2` package and ran them over the real workflow files:

```
RE2 compile: OK
OK   material-ui/ci.yml             steps=1 matched=1 values=[22.23.2]
OK   material-ui/publish.yml        steps=2 matched=2 values=[22.23.2, 22.23.2]
OK   BLANK/blank-line.yml           steps=1 matched=1 values=[22.23.2]
OK   NEG/no-input.yml               steps=1 matched=0 values=[]
OK   base-ui/ci.yml                 steps=1 matched=1 values=[22.22.3]
OK   base-ui/publish.yml            steps=1 matched=1 values=[22.22.3]
OK   base-ui-plus/publish.yml       steps=1 matched=1 values=[22.22.3]
OK   material-ui-docs/publish.yml   steps=2 matched=2 values=[22.23.1, 22.23.1]
OK   mui-x/ci.yml                   steps=1 matched=1 values=[22.23.2]
OK   mui-x/publish.yml              steps=1 matched=1 values=[22.23.2]

managed 10 real pins across 6 repos (plus the BLANK fixture); left 5 setup-node pins to the built-in manager
```

Three cases drove the shape of the pattern:

- `mui-x/ci.yml` puts a comment line between `with:` and `node-version:`, so the match cannot assume a fixed line offset.
- `NEG/no-input.yml` is a `publish-prepare` step with no `node-version` input, followed by a `setup-node` step that has one. The step boundary ends the match, so it does not borrow the following pin.
- `BLANK/blank-line.yml` has a blank line inside the step, which an earlier version of the pattern silently dropped.

RE2 rejects look-around, so the step boundary is a positive character class rather than a negative lookahead: an intervening line may be blank, or may start after its indent with any token except `-`.

`matchStringsStrategy: recursive` keeps the scoping pattern and the capture separate, so the `actions/setup-node` inputs in the same files stay with the built-in manager instead of being double-managed.

## Follow-up, not in this PR

The action's own default is `'22.22.3'` in `.github/actions/publish-prepare/action.yml`. This repo's `publish.yml` passes no input, so it publishes on that version. Worth bumping, and it is unmanaged by Renovate too.

## Note

`fileMatch` matches the five existing custom managers here. Renovate renamed it to `managerFilePatterns` in v41 and we run v43, so the whole block is due a rename in a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
