### PR TITLE
[code-infra] Remove manual tagging fallback from release skill

### DIFF
--- a/skills/mui-release/stage-2-publish-packages.md
+++ b/skills/mui-release/stage-2-publish-packages.md
@@ -17,4 +17,3 @@ Requires stage 1 complete. Before merging, verify the PR still has the `release`
 ## Troubleshooting
 
 - **Publish reports "no new packages to publish":** the workflow ran against a commit whose package versions are already on npm — usually a wrong SHA (e.g. the picker's pre-selected default). Re-dispatch with `--sha <merge-commit-sha>` of the release PR.
-- **Tagging step fails:** create the tag manually and **annotated**: `git tag -a v<X.Y.Z> -m "Version <X.Y.Z>" && git push upstream --tag`.


### PR DESCRIPTION
Drops the manual `git tag` fallback from the stage 2 troubleshooting list.
It should not have been there at all since tagging happens during the release CI, not manually.