### PR TITLE
[docs-infra] Flatten relative files in precomputeDemo

### DIFF
--- a/docs/app/docs-infra/pipeline/page.mdx
+++ b/docs/app/docs-infra/pipeline/page.mdx
@@ -1209,6 +1209,7 @@ Use `precomputeDemo` to load and process demo source files without a factory wra
   - Basic usage
   - Multiple variants
   - Grammar selection
+  - Relative files
   - Configuration
   - Types
     - `precomputeDemo`

--- a/docs/app/docs-infra/pipeline/parse-source/types.md
+++ b/docs/app/docs-infra/pipeline/parse-source/types.md
@@ -144,17 +144,6 @@ type ReturnValue = void;
 
 `.js` and `.jsx` resolve to `source.tsx` rather than `source.js`.
 
-TypeScript is a superset of JavaScript, so the richer grammar classifies
-everything the JavaScript one does and more: regular expression literals,
-private class fields, and the identifiers in an expression all stay
-unclassified under `source.js`, and `default` in `export default` comes back
-as a constant rather than a keyword. Comparisons are unaffected — `a < b` is
-still punctuation, not the start of an element.
-
-Sharing one grammar across the JavaScript family also keeps a file and its
-TypeScript twin highlighted identically, which matters wherever both are
-shown behind a language toggle.
-
 ```typescript
 type extensionMap = Record<string, string>;
 ```

--- a/docs/app/docs-infra/pipeline/precompute-demo/page.mdx
+++ b/docs/app/docs-infra/pipeline/precompute-demo/page.mdx
@@ -46,6 +46,12 @@ const result = await precomputeDemo({
 });
 ```
 
+## Relative files
+
+Files reached through relative imports are presented as siblings of the entry, whatever their position on disk, and their imports are rewritten to match. A demo importing `../../shared/data.ts` shows a `data.ts` file importable as `./data`, so a reader sees a self-contained folder rather than the demo's place in a repository. Each file keeps a `relativeUrl` pointing at its real location.
+
+Supply your own `loadSource` if a project needs the resolved paths kept instead.
+
 ## Configuration
 
 The default pipeline reads local files, recursively resolves relative imports, highlights source, and applies focus and emphasis markers. Override `loadSource`, `sourceParser`, `sourceTransformers`, or `sourceEnhancers` to replace individual stages.

--- a/packages/docs-infra/src/pipeline/parseSource/grammarMaps.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/grammarMaps.ts
@@ -7,17 +7,6 @@
 
 /**
  * `.js` and `.jsx` resolve to `source.tsx` rather than `source.js`.
- *
- * TypeScript is a superset of JavaScript, so the richer grammar classifies
- * everything the JavaScript one does and more: regular expression literals,
- * private class fields, and the identifiers in an expression all stay
- * unclassified under `source.js`, and `default` in `export default` comes back
- * as a constant rather than a keyword. Comparisons are unaffected — `a < b` is
- * still punctuation, not the start of an element.
- *
- * Sharing one grammar across the JavaScript family also keeps a file and its
- * TypeScript twin highlighted identically, which matters wherever both are
- * shown behind a language toggle.
  */
 export const extensionMap: Record<string, string> = {
   '.js': 'source.tsx',

--- a/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.test.ts
+++ b/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.test.ts
@@ -175,10 +175,12 @@ describe('precomputeDemo', () => {
       output: 'hast',
     });
 
+    // Every file is presented as a sibling of the entry, whatever its position
+    // on disk, with `relativeUrl` keeping the real location.
     expect(result.code.Default).toMatchObject({
       extraFiles: {
         'helper.ts': { language: 'typescript' },
-        'nested/data.ts': { language: 'typescript' },
+        'data.ts': { language: 'typescript', relativeUrl: './nested/data.ts' },
       },
       fileName: 'BasicButtons.tsx',
       language: 'tsx',
@@ -186,6 +188,30 @@ describe('precomputeDemo', () => {
     expect(result.externals).toEqual({
       react: [{ isType: undefined, name: 'React', type: 'namespace' }],
     });
+  });
+
+  it('rewrites the imports of flattened files to match', async () => {
+    const result = await precomputeDemo({
+      entries: [
+        {
+          name: 'Default',
+          url: new URL('./fixtures/material-demo/BasicButtons.tsx', import.meta.url).href,
+        },
+      ],
+      output: 'hast',
+    });
+    const variant = result.code.Default;
+    if (!variant || typeof variant === 'string') {
+      throw new Error('Expected a precomputed variant');
+    }
+    const helper = variant.extraFiles?.['helper.ts'];
+    if (!helper || typeof helper === 'string') {
+      throw new Error('Expected a processed helper file');
+    }
+
+    // `helper.ts` imports `./nested/data` on disk; the reader sees a folder
+    // where every file sits beside the entry, so the import has to match.
+    expect(decodeSourceToText(helper.source, helper.fallback)).toContain("from './data'");
   });
 
   it('derives focused source from the one-file target fixture', async () => {

--- a/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.ts
+++ b/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.ts
@@ -47,7 +47,7 @@ export async function precomputeDemo(options: PrecomputeDemoOptions): Promise<Pr
         FOCUS_COMMENT_PREFIX,
         ...IGNORE_COMMENT_PREFIXES,
       ],
-      storeAt: 'canonical',
+      storeAt: 'flat',
     });
   const sourceParser = options.sourceParser ?? createParseSource();
   const sourceEnhancers = options.sourceEnhancers ?? [createEnhanceCodeEmphasis()];

--- a/packages/docs-infra/src/pipeline/precomputeFileDemo/precomputeFileDemo.test.ts
+++ b/packages/docs-infra/src/pipeline/precomputeFileDemo/precomputeFileDemo.test.ts
@@ -29,7 +29,7 @@ describe('precomputeFileDemo', () => {
     expect(result.code.Default).toMatchObject({
       extraFiles: {
         'helper.ts': { language: 'typescript' },
-        'nested/data.ts': { language: 'typescript' },
+        'data.ts': { language: 'typescript', relativeUrl: './nested/data.ts' },
       },
       fileName: 'BasicButtons.tsx',
     });


### PR DESCRIPTION
Stacked on #1775 → #1774 → #1773. Review those first.

## Problem

`precomputeDemo` stored relative files at their resolved paths, so a demo importing a file from elsewhere in the repository showed a tab reading `../../../data/experiments/docs-infra/notesData.ts`. The reader is looking at a demo, not at a repository layout.

## Change

Files are presented as siblings of the entry and their imports are rewritten to match — `storeAt: 'flat'`, which is what `loadPrecomputedCodeHighlighter` already uses. `precomputeDemo` was the odd one out at `canonical`.

```
before  extraFiles: { 'helper.ts', 'nested/data.ts' }   helper imports './nested/data'
after   extraFiles: { 'helper.ts', 'data.ts' }          helper imports './data'
```

Each file keeps a `relativeUrl` (`'./nested/data.ts'`) so consumers can still resolve the real location.

No option to opt out: a project that needs the resolved paths can pass its own `loadSource`, which is the existing escape hatch for every other stage.