### PR TITLE
[renovate] Group jsdom with @types/jsdom

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -163,6 +163,11 @@
       "matchPackageNames": ["@definitelytyped/*"]
     },
     {
+      "groupName": "jsdom",
+      "description": "Keep jsdom and its DefinitelyTyped declarations on compatible versions.",
+      "matchPackageNames": ["jsdom", "@types/jsdom"]
+    },
+    {
       "groupName": "node",
       "description": "Restricts Node.js version bumps in Github Actions workflows.",
       "extends": ["group:nodeJs"],

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -164,7 +164,7 @@
     },
     {
       "groupName": "jsdom",
-      "description": "Keep jsdom and its DefinitelyTyped declarations on compatible versions.",
+      "description": "Keep jsdom and its type declarations in sync.",
       "matchPackageNames": ["jsdom", "@types/jsdom"]
     },
     {


### PR DESCRIPTION
## Summary

- add a dedicated Renovate group for `jsdom` and `@types/jsdom`
- keep runtime and declaration major upgrades in the same pull request

## Why

`@types/jsdom` describes the `jsdom` API and follows its major versions, but the general DefinitelyTyped grouping currently separates their major upgrades. A later package rule gives both dependencies the same final `groupName`, avoiding temporary version mismatches and duplicate review work.

In repositories using the experimental preset, non-major updates remain in the broader `npm non-major` group because that later rule still takes precedence.

## Validation

- `pnpm install --no-frozen-lockfile`
- `pnpm release:build`
- `pnpm prettier`
- `pnpm eslint --ignore-pattern '.context/**'`
- `pnpm typescript`
- `pnpm test --run` (277 files, 5,651 tests)
- `pnpm code-infra --help`
- `git diff --check`
