### PR TITLE
[docs-infra] Add editable source projections

### DIFF
--- a/docs/app/docs-infra/components/code-highlighter/types.md
+++ b/docs/app/docs-infra/components/code-highlighter/types.md
@@ -942,7 +942,16 @@ type ControlledVariantCode = {
   comments?: SourceComments;
   collapseMap?: CollapseMap;
   totalLines?: number;
+  /**
+   * Collapsed-window size and frame state for the edited source. Re-derived on
+   * every edit, since editing inside a projection changes how much the
+   * collapsed view shows.
+   */
+  focusedLines?: number;
+  collapsible?: boolean;
   emptyLines?: number[];
+  /** Editable slice shown while collapsed. See [`EditableSourceProjection`](#editablesourceprojection). */
+  sourceProjection?: EditableSourceProjection;
   /**
    * The pre-edit build inputs, carried ONLY on the first edit of a variant (the
    * transition from precomputed to controlled). The live runner builds this as a
@@ -963,8 +972,37 @@ type ControlledVariantExtraFiles = {
     comments?: SourceComments;
     collapseMap?: CollapseMap;
     totalLines?: number;
+    focusedLines?: number;
+    collapsible?: boolean;
     emptyLines?: number[];
+    sourceProjection?: EditableSourceProjection;
   };
+};
+```
+
+### EditableSourceProjection
+
+The contiguous slice of a file that a collapsed code block edits in place.
+
+The editor holds plain text and has no notion of hidden rows, so without a
+projection a collapsed block has to expand before it can be edited. A
+projection names the region the collapsed view shows — `source` is the slice,
+`start` and `end` are its offsets in the complete source — so an edit can be
+patched back into the full file without expanding.
+
+```typescript
+type EditableSourceProjection = {
+  /** The projected slice, as displayed. */
+  source: string;
+  /** Offset of the slice in the complete source. */
+  start: number;
+  /** Offset just past the slice in the complete source. */
+  end: number;
+  /**
+   * Common leading whitespace hidden in the collapsed focused view. Re-applied
+   * to every line when patching an edited projection back into the full source.
+   */
+  indentation?: string;
 };
 ```
 
@@ -1249,6 +1287,7 @@ type Transforms = {
     hasDelta?: boolean;
     hasCollapse?: boolean;
     hasCollapseInFocus?: boolean;
+    sourceProjection?: EditableSourceProjection;
   };
 };
 ```
@@ -1321,6 +1360,8 @@ type VariantCode = {
   skipTransforms?: boolean;
   /** Comments extracted from source, stored when parsing is disabled for later use */
   comments?: SourceComments;
+  /** Editable slice shown while collapsed. See [`EditableSourceProjection`](#editablesourceprojection). */
+  sourceProjection?: EditableSourceProjection;
 };
 ```
 
@@ -1346,6 +1387,7 @@ type VariantExtraFiles = {
         path?: string;
         relativeUrl?: string;
         comments?: SourceComments;
+        sourceProjection?: EditableSourceProjection;
       };
 };
 ```
@@ -1359,4 +1401,4 @@ type VariantSource = string | HastRoot | { hastJson: string } | { hastCompressed
 ## Export Groups
 
 - `CodeHighlighter`: `useCodeFallback`, `UseCodeFallbackResult`, `mergeComments`, `CodeHighlighter`
-- `CodeHighlighterTypes`: `Components`, `Transforms`, `ExternalImportItem`, `Externals`, `HastRoot`, `VariantSource`, `VariantExtraFiles`, `VariantCode`, `Code`, `CollapseMap`, `ControlledVariantExtraFiles`, `ControlledVariantCode`, `ControlledCode`, `ContentProps`, `Fallbacks`, `ContentLoadingFile`, `ContentLoadingVariant`, `BaseContentLoadingProps`, `ContentLoadingProps`, `LoadCodeMeta`, `LoadVariantMeta`, `LoadSource`, `TransformSource`, `ParseSource`, `SourceTransformer`, `SourceTransformers`, `SourceComments`, `SourceEnhancer`, `SourceEnhancers`, `LoadFileOptions`, `LoadVariantOptions`, `LoadFallbackCodeOptions`, `CodeIdentityProps`, `CodeContentProps`, `CodeLoadingProps`, `CodeFunctionProps`, `CodeRenderingProps`, `CodeClientRenderingProps`, `CodeHighlighterBaseProps`, `CodeHighlighterClientProps`, `CodeHighlighterProps`
+- `CodeHighlighterTypes`: `Components`, `Transforms`, `EditableSourceProjection`, `ExternalImportItem`, `Externals`, `HastRoot`, `VariantSource`, `VariantExtraFiles`, `VariantCode`, `Code`, `CollapseMap`, `ControlledVariantExtraFiles`, `ControlledVariantCode`, `ControlledCode`, `ContentProps`, `Fallbacks`, `ContentLoadingFile`, `ContentLoadingVariant`, `BaseContentLoadingProps`, `ContentLoadingProps`, `LoadCodeMeta`, `LoadVariantMeta`, `LoadSource`, `TransformSource`, `ParseSource`, `SourceTransformer`, `SourceTransformers`, `SourceComments`, `SourceEnhancer`, `SourceEnhancers`, `LoadFileOptions`, `LoadVariantOptions`, `LoadFallbackCodeOptions`, `CodeIdentityProps`, `CodeContentProps`, `CodeLoadingProps`, `CodeFunctionProps`, `CodeRenderingProps`, `CodeClientRenderingProps`, `CodeHighlighterBaseProps`, `CodeHighlighterClientProps`, `CodeHighlighterProps`

--- a/docs/app/docs-infra/hooks/use-code/types.md
+++ b/docs/app/docs-infra/hooks/use-code/types.md
@@ -71,6 +71,14 @@ in Pierre's editor.
 type CodeEditorProps = {
   /** Complete source, matching the text painted by the `<pre>` underneath. */
   source: string;
+  /**
+   * The slice of `source` the `<pre>` is painting, when the block is collapsed
+   * to a focused window. The textarea then holds only that slice, and every
+   * edit is patched back into the complete source before it goes out through
+   * `setSource` — so a collapsed block can be edited in place instead of
+   * expanding first.
+   */
+  sourceProjection?: EditableSourceProjection;
   /** Canonical file name reported back through `setSource`. */
   fileName?: string;
   language?: string;
@@ -355,5 +363,7 @@ type SetSource = (
       }
     | undefined,
   preParsed?: Root | undefined,
+  sourceProjection?:
+    { source: string; start: number; end: number; indentation?: string | undefined } | undefined,
 ) => void;
 ```

--- a/docs/app/docs-infra/pipeline/load-isomorphic-code-variant/types.md
+++ b/docs/app/docs-infra/pipeline/load-isomorphic-code-variant/types.md
@@ -109,6 +109,49 @@ binds the built-in `decodeHastSource`.
 | `source`   | `VariantSource`               | -           |
 | `comments` | `SourceComments \| undefined` | -           |
 
+### createEditableSourceProjection
+
+**createEditableSourceProjection Properties:**
+
+| Property        | Type     | Default | Description |
+| :-------------- | :------- | :------ | :---------- |
+| fullSource\*    | `string` | -       | -           |
+| previewSource\* | `string` | -       | -           |
+
+**Return Value:**
+
+```tsx
+type ReturnValue = EditableSourceProjection | undefined;
+```
+
+### createFocusedSourceProjection
+
+Derives the projection from focus markers, using the window the collapsed view
+shows. This is the target producer: the offsets come from the parsed source
+rather than from searching for the rendered text, so nothing can be ambiguous.
+
+Reads the same `getCollapsedFrameWindow` walk that `<Pre>`'s caret bounds
+read, so the slice the editor edits is exactly the region the caret is held
+inside.
+
+Returns `undefined` when the visible lines are not contiguous, or when they
+cover the whole file — the collapsed view then hides nothing and the editor
+can edit the complete source directly.
+
+**Parameters:**
+
+| Parameter        | Type       | Default | Description |
+| :--------------- | :--------- | :------ | :---------- |
+| source           | `string`   | -       | -           |
+| root             | `HastRoot` | -       | -           |
+| collapseToEmpty? | `boolean`  | -       | -           |
+
+**Return Value:**
+
+```tsx
+type ReturnValue = EditableSourceProjection | undefined;
+```
+
 ### enhanceCode
 
 Async function to enhance parsed code variants and their extraFiles.
@@ -352,6 +395,25 @@ Converts string sources to HAST nodes and handles hastJson parsing.
 
 ```tsx
 type ReturnValue = Code;
+```
+
+### patchEditableSourceProjection
+
+Writes an edited projection back into the complete source, restoring the
+indentation the collapsed view hid.
+
+**Parameters:**
+
+| Parameter    | Type                       | Default | Description |
+| :----------- | :------------------------- | :------ | :---------- |
+| fullSource   | `string`                   | -       | -           |
+| projection   | `EditableSourceProjection` | -       | -           |
+| editedSource | `string`                   | -       | -           |
+
+**Return Value:**
+
+```tsx
+type ReturnValue = string;
 ```
 
 ## Additional Types

--- a/docs/app/docs-infra/pipeline/page.mdx
+++ b/docs/app/docs-infra/pipeline/page.mdx
@@ -528,6 +528,10 @@ The `loadIsomorphicCodeVariant` module provides utilities for loading, processin
     - Parameters: source, transforms, transformKeys, comments, fallback
   - applyCodeTransformWithComments
     - Parameters: source, transforms, transformKey, comments, fallback
+  - createEditableSourceProjection
+    - Parameters: (fullSource, previewSource)
+  - createFocusedSourceProjection
+    - Parameters: source, root, collapseToEmpty
   - enhanceCode
     - Parameters: code, sourceEnhancers
   - examineCodeVariant
@@ -548,6 +552,8 @@ The `loadIsomorphicCodeVariant` module provides utilities for loading, processin
     - Parameters: variant, metadataFiles, options
   - parseCode
     - Parameters: code, parseSource
+  - patchEditableSourceProjection
+    - Parameters: fullSource, projection, editedSource
 - Types: FallbackVariants, FileWithPath, FlatFile, FlattenedFiles, PathContext
 
 </details>

--- a/docs/app/docs-infra/pipeline/precompute-demo/types.md
+++ b/docs/app/docs-infra/pipeline/precompute-demo/types.md
@@ -76,6 +76,13 @@ type PrecomputeDemoOptions = {
   maxDepth?: number;
   /** Whether the default source loader follows relative imports. */
   includeDependencies?: boolean;
+  /**
+   * Compatibility preview source. Resolved against each variant's loaded source
+   * into a `EditableSourceProjection` on that variant, naming the region a
+   * collapsed view shows and an edit patches back into. Skipped, with a
+   * development warning, for a variant the preview cannot be resolved against.
+   */
+  preview?: string;
 };
 ```
 

--- a/docs/app/docs-infra/pipeline/precompute-file-demo/types.md
+++ b/docs/app/docs-infra/pipeline/precompute-file-demo/types.md
@@ -91,6 +91,13 @@ type PrecomputeFileDemoOptions = {
   maxDepth?: number;
   /** Whether the default source loader follows relative imports. */
   includeDependencies?: boolean;
+  /**
+   * Compatibility preview source. Resolved against each variant's loaded source
+   * into a `EditableSourceProjection` on that variant, naming the region a
+   * collapsed view shows and an edit patches back into. Skipped, with a
+   * development warning, for a variant the preview cannot be resolved against.
+   */
+  preview?: string;
 };
 ```
 

--- a/packages/docs-infra/src/CodeHighlighter/types.ts
+++ b/packages/docs-infra/src/CodeHighlighter/types.ts
@@ -71,8 +71,33 @@ export type Transforms = Record<
     hasDelta?: boolean;
     hasCollapse?: boolean;
     hasCollapseInFocus?: boolean;
+    /** Editable slice of the transformed source. See {@link EditableSourceProjection}. */
+    sourceProjection?: EditableSourceProjection;
   }
 >;
+
+/**
+ * The contiguous slice of a file that a collapsed code block edits in place.
+ *
+ * The editor holds plain text and has no notion of hidden rows, so without a
+ * projection a collapsed block has to expand before it can be edited. A
+ * projection names the region the collapsed view shows — `source` is the slice,
+ * `start` and `end` are its offsets in the complete source — so an edit can be
+ * patched back into the full file without expanding.
+ */
+export interface EditableSourceProjection {
+  /** The projected slice, as displayed. */
+  source: string;
+  /** Offset of the slice in the complete source. */
+  start: number;
+  /** Offset just past the slice in the complete source. */
+  end: number;
+  /**
+   * Common leading whitespace hidden in the collapsed focused view. Re-applied
+   * to every line when patching an edited projection back into the full source.
+   */
+  indentation?: string;
+}
 
 // External import definition matching parseImportsAndComments.ts
 export interface ExternalImportItem {
@@ -152,6 +177,8 @@ export type VariantExtraFiles = {
         relativeUrl?: string;
         /** Comments extracted from source, stored when parsing is disabled for later use */
         comments?: SourceComments;
+        /** Editable slice shown while collapsed. See {@link EditableSourceProjection}. */
+        sourceProjection?: EditableSourceProjection;
       };
 };
 
@@ -215,6 +242,8 @@ export type VariantCode = CodeMeta & {
   skipTransforms?: boolean;
   /** Comments extracted from source, stored when parsing is disabled for later use */
   comments?: SourceComments;
+  /** Editable slice shown while collapsed. See {@link EditableSourceProjection}. */
+  sourceProjection?: EditableSourceProjection;
 };
 
 export type Code = { [key: string]: undefined | string | VariantCode }; // TODO: only preload should be able to pass highlighted code
@@ -235,7 +264,11 @@ export type ControlledVariantExtraFiles = {
     comments?: SourceComments;
     collapseMap?: CollapseMap;
     totalLines?: number;
+    focusedLines?: number;
+    collapsible?: boolean;
     emptyLines?: number[];
+    /** Editable slice shown while collapsed. See {@link EditableSourceProjection}. */
+    sourceProjection?: EditableSourceProjection;
   };
 };
 export type ControlledVariantCode = CodeMeta & {
@@ -246,7 +279,16 @@ export type ControlledVariantCode = CodeMeta & {
   comments?: SourceComments;
   collapseMap?: CollapseMap;
   totalLines?: number;
+  /**
+   * Collapsed-window size and frame state for the edited source. Re-derived on
+   * every edit, since editing inside a projection changes how much the
+   * collapsed view shows.
+   */
+  focusedLines?: number;
+  collapsible?: boolean;
   emptyLines?: number[];
+  /** Editable slice shown while collapsed. See {@link EditableSourceProjection}. */
+  sourceProjection?: EditableSourceProjection;
   /**
    * The pre-edit build inputs, carried ONLY on the first edit of a variant (the
    * transition from precomputed to controlled). The live runner builds this as a

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/createEditableSourceProjection.test.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/createEditableSourceProjection.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { HastRoot } from '../../CodeHighlighter/types';
+import {
+  createEditableSourceProjection,
+  createFocusedSourceProjection,
+  patchEditableSourceProjection,
+} from './createEditableSourceProjection';
+
+/** Shaped like a Material UI demo and its `.tsx.preview` sibling. */
+const FULL_SOURCE = [
+  "import Stack from '@mui/material/Stack';",
+  "import Button from '@mui/material/Button';",
+  '',
+  'export default function BasicButtons() {',
+  '  return (',
+  '    <Stack spacing={2} direction="row">',
+  '      <Button variant="text">Text</Button>',
+  '      <Button variant="outlined">Outlined</Button>',
+  '    </Stack>',
+  '  );',
+  '}',
+  '',
+].join('\n');
+
+/** Preview files are dedented but keep their relative indentation, and end without a newline. */
+const PREVIEW_SOURCE = [
+  '<Button variant="text">Text</Button>',
+  '<Button variant="outlined">Outlined</Button>',
+].join('\n');
+
+const PREVIEW_START = FULL_SOURCE.indexOf('      <Button variant="text"');
+const PREVIEW_END = FULL_SOURCE.indexOf('</Button>\n    </Stack>') + '</Button>'.length;
+
+/**
+ * Builds a tree of framed lines, marking `visible` ones as the focused window —
+ * the shape `getCollapsedFrameWindow` reads.
+ */
+function buildRoot(lineCount: number, visible: number[], indent = 0): HastRoot {
+  const line = (ln: number) => ({
+    type: 'element' as const,
+    tagName: 'span',
+    properties: { className: 'line', dataLn: ln },
+    children: [{ type: 'text' as const, value: '\n' }],
+  });
+  const frame = (type: string, lines: number[]) => ({
+    type: 'element' as const,
+    tagName: 'span',
+    properties: { className: 'frame', dataFrameType: type, dataFrameIndent: indent },
+    children: lines.map(line),
+  });
+
+  const hidden = Array.from({ length: lineCount }, (unused, index) => index + 1).filter(
+    (ln) => !visible.includes(ln),
+  );
+  return {
+    type: 'root',
+    data: { collapsible: true },
+    children: [frame('focus', visible), frame('normal', hidden)],
+  } as unknown as HastRoot;
+}
+
+describe('createEditableSourceProjection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('projects a dedented preview onto its indented source region', () => {
+    expect(
+      createEditableSourceProjection({
+        fullSource: FULL_SOURCE,
+        previewSource: PREVIEW_SOURCE,
+      }),
+    ).toEqual({
+      // Displayed as authored, the way Material renders the preview file.
+      source: PREVIEW_SOURCE,
+      start: PREVIEW_START,
+      end: PREVIEW_END,
+      indentation: '      ',
+    });
+  });
+
+  it('reports no indentation when the preview already matches the source', () => {
+    const fullSource = 'const value = 1;\nexport default value;\n';
+
+    expect(
+      createEditableSourceProjection({ fullSource, previewSource: 'const value = 1;' }),
+    ).toEqual({ source: 'const value = 1;', start: 0, end: 'const value = 1;'.length });
+  });
+
+  it('keeps the relative indentation the preview carries', () => {
+    const fullSource = [
+      '    <Alert severity="success">',
+      '      This is a success Alert.',
+      '    </Alert>',
+      '',
+    ].join('\n');
+    const previewSource = '<Alert severity="success">\n  This is a success Alert.\n</Alert>';
+
+    const projection = createEditableSourceProjection({ fullSource, previewSource })!;
+
+    expect(projection.source).toBe(previewSource);
+    expect(projection.indentation).toBe('    ');
+    expect(patchEditableSourceProjection(fullSource, projection, previewSource)).toBe(fullSource);
+  });
+
+  it('matches across differing line endings', () => {
+    const fullSource = FULL_SOURCE.replace(/\n/g, '\r\n');
+    const projection = createEditableSourceProjection({
+      fullSource,
+      previewSource: PREVIEW_SOURCE,
+    })!;
+
+    expect(fullSource.slice(projection.start, projection.end)).toBe(
+      '      <Button variant="text">Text</Button>\r\n      <Button variant="outlined">Outlined</Button>',
+    );
+  });
+
+  it('handles tab indentation', () => {
+    const fullSource = 'function demo() {\n\t\tconst value = 1;\n\t\treturn value;\n}\n';
+
+    expect(
+      createEditableSourceProjection({
+        fullSource,
+        previewSource: 'const value = 1;\nreturn value;',
+      }),
+    ).toEqual({
+      source: 'const value = 1;\nreturn value;',
+      start: fullSource.indexOf('\t\tconst'),
+      end: fullSource.indexOf('return value;') + 'return value;'.length,
+      indentation: '\t\t',
+    });
+  });
+
+  it('keeps the code before a mid-line match out of the region', () => {
+    // `CircularUnderLoad.tsx.preview` is the JSX alone, while the source line
+    // returns it. Material replaces only the fragment, so `return ` stays put.
+    const fullSource = 'export default function Demo() {\n  return <CircularProgress />;\n}\n';
+
+    const projection = createEditableSourceProjection({
+      fullSource,
+      previewSource: '<CircularProgress />',
+    })!;
+
+    expect(projection.source).toBe('<CircularProgress />');
+    expect(projection.indentation).toBeUndefined();
+    expect(fullSource.slice(projection.start, projection.end)).toBe('<CircularProgress />');
+    expect(patchEditableSourceProjection(fullSource, projection, '<LinearProgress />')).toBe(
+      'export default function Demo() {\n  return <LinearProgress />;\n}\n',
+    );
+  });
+
+  it('absorbs a blank first line in the preview', () => {
+    // `BoxBasic.tsx.preview` opens with a blank line and a one-space indent.
+    const fullSource = '  return (\n    <Box>\n      Some text.\n    </Box>\n  );\n';
+
+    const projection = createEditableSourceProjection({
+      fullSource,
+      previewSource: '\n Some text.\n',
+    })!;
+
+    expect(projection.source).toBe('Some text.\n');
+    expect(projection.indentation).toBe('      ');
+    expect(patchEditableSourceProjection(fullSource, projection, projection.source)).toBe(
+      fullSource,
+    );
+  });
+
+  it('refuses a fragment that appears more than once', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fullSource = '<Button>Click</Button>\n<hr />\n<Button>Click</Button>\n';
+
+    // Material's `String.replace` would splice the first of the two.
+    expect(
+      createEditableSourceProjection({ fullSource, previewSource: '<Button>Click</Button>' }),
+    ).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('matches 2 regions'));
+  });
+
+  it('returns undefined when the preview is absent from the source', () => {
+    expect(
+      createEditableSourceProjection({ fullSource: FULL_SOURCE, previewSource: '<Missing />' }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for an empty preview', () => {
+    expect(
+      createEditableSourceProjection({ fullSource: FULL_SOURCE, previewSource: '' }),
+    ).toBeUndefined();
+    expect(
+      createEditableSourceProjection({ fullSource: FULL_SOURCE, previewSource: '\n  \n' }),
+    ).toBeUndefined();
+  });
+
+  it('projects a TypeScript preview and its JavaScript twin alike', () => {
+    const typescriptSource = 'const value: number = 1;\nexport default value;\n';
+    const javascriptSource = 'const value = 1;\nexport default value;\n';
+
+    expect(
+      createEditableSourceProjection({
+        fullSource: typescriptSource,
+        previewSource: 'const value: number = 1;',
+      }),
+    ).toMatchObject({ source: 'const value: number = 1;', start: 0 });
+    expect(
+      createEditableSourceProjection({
+        fullSource: javascriptSource,
+        previewSource: 'const value = 1;',
+      }),
+    ).toMatchObject({ source: 'const value = 1;', start: 0 });
+  });
+
+  it('resolves the same region Material UI patches', () => {
+    // Material builds the live source as
+    // `trimLeadingSpaces(raw).replace(trimLeadingSpaces(preview), edited)`.
+    const edited = '<Button variant="text">Tap</Button>';
+    const trimLeadingSpaces = (input: string) => input.replace(/^\s+/gm, '');
+    const material = trimLeadingSpaces(FULL_SOURCE).replace(
+      trimLeadingSpaces(PREVIEW_SOURCE),
+      edited,
+    );
+
+    const projection = createEditableSourceProjection({
+      fullSource: FULL_SOURCE,
+      previewSource: PREVIEW_SOURCE,
+    })!;
+    const patched = patchEditableSourceProjection(FULL_SOURCE, projection, edited);
+
+    expect(trimLeadingSpaces(patched)).toBe(material);
+    // Unlike Material's, the patched source is still indented, since it is displayed again.
+    expect(patched).toContain('      <Button variant="text">Tap</Button>');
+  });
+});
+
+describe('patchEditableSourceProjection', () => {
+  it('patches an edit back into the projected range', () => {
+    const projection = createEditableSourceProjection({
+      fullSource: FULL_SOURCE,
+      previewSource: PREVIEW_SOURCE,
+    })!;
+
+    expect(
+      patchEditableSourceProjection(
+        FULL_SOURCE,
+        projection,
+        PREVIEW_SOURCE.replace('Outlined</Button>', 'Ghost</Button>'),
+      ),
+    ).toBe(FULL_SOURCE.replace('>Outlined</Button>', '>Ghost</Button>'));
+  });
+
+  it('leaves blank lines unindented', () => {
+    const fullSource = 'wrap(\n    first();\n    second();\n);\n';
+    const projection = createEditableSourceProjection({
+      fullSource,
+      previewSource: 'first();\nsecond();',
+    })!;
+
+    expect(patchEditableSourceProjection(fullSource, projection, 'a();\n\nb();')).toBe(
+      'wrap(\n    a();\n\n    b();\n);\n',
+    );
+  });
+});
+
+describe('createFocusedSourceProjection', () => {
+  it('projects the focused window, dedented like a preview file', () => {
+    expect(createFocusedSourceProjection(FULL_SOURCE, buildRoot(12, [7, 8], 3))).toEqual({
+      source: PREVIEW_SOURCE,
+      start: PREVIEW_START,
+      end: PREVIEW_END,
+      indentation: '      ',
+    });
+  });
+
+  it('agrees with the preview file on the same source', () => {
+    expect(createFocusedSourceProjection(FULL_SOURCE, buildRoot(12, [7, 8], 3))).toEqual(
+      createEditableSourceProjection({
+        fullSource: FULL_SOURCE,
+        previewSource: PREVIEW_SOURCE,
+      }),
+    );
+  });
+
+  it('returns undefined for a non-contiguous focus', () => {
+    expect(createFocusedSourceProjection(FULL_SOURCE, buildRoot(12, [3, 6]))).toBeUndefined();
+  });
+
+  it('returns undefined when the whole file is visible', () => {
+    const visible = Array.from({ length: 12 }, (unused, index) => index + 1);
+    expect(createFocusedSourceProjection(FULL_SOURCE, buildRoot(12, visible))).toBeUndefined();
+  });
+
+  it('returns undefined for a collapse-to-empty block', () => {
+    expect(createFocusedSourceProjection(FULL_SOURCE, buildRoot(12, [7, 8]), true)).toBeUndefined();
+  });
+});

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/createEditableSourceProjection.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/createEditableSourceProjection.ts
@@ -1,0 +1,246 @@
+import type { EditableSourceProjection, HastRoot } from '../../CodeHighlighter/types';
+import { getCollapsedFrameWindow } from '../parseSource/frameVisibility';
+
+/**
+ * Resolves the region of a complete source that a preview shows, so an edit made
+ * in the collapsed view can be patched back into the full file.
+ *
+ * The text-matching producer mirrors what Material UI's `Demo` does with a
+ * `.tsx.preview` file: it strips the leading whitespace from every line of both
+ * the preview and the source, then matches. Those preview files are dedented
+ * copies of a JSX fragment that keep their relative indentation, and the source
+ * region they came from is indented by whatever wraps it — so the normalized
+ * comparison is what lets the two meet.
+ *
+ * Material re-renders the patched source through the live runner, where
+ * indentation does not matter. Here the patched source is displayed again, so
+ * the projection also records the indentation to restore.
+ *
+ * Focus markers are the target producer: {@link createFocusedSourceProjection}
+ * takes its offsets from the parsed tree instead of searching for the text.
+ */
+
+/**
+ * Material UI's `trimLeadingSpaces` (`input.replace(/^\s+/gm, '')`), rewritten to
+ * also report where each surviving character came from. Material only needs the
+ * normalized text — it matches with `String.replace` and feeds the result to the
+ * live runner — while a projection has to name a region of the original source.
+ *
+ * The whitespace run is consumed greedily from each line start, newlines
+ * included, exactly as the regex does: a blank line is absorbed into the
+ * following line's prefix. That is what lets a preview whose first line is blank
+ * still match, and it is why the comparison is a substring match rather than a
+ * line-aligned one.
+ *
+ * The one addition is that a `\r` terminating a line is dropped, so a CRLF
+ * source matches an LF preview. Material's regex leaves that `\r` in place, but
+ * its sources are all LF, so this only ever accepts more than Material does.
+ */
+function trimLeadingSpaces(input: string): { text: string; offsets: number[] } {
+  let text = '';
+  const offsets: number[] = [];
+  let atLineStart = true;
+
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index];
+    if (character === '\r' && input[index + 1] === '\n') {
+      continue;
+    }
+    if (atLineStart && /\s/.test(character)) {
+      continue;
+    }
+    text += character;
+    offsets.push(index);
+    atLineStart = character === '\n';
+  }
+
+  return { text, offsets };
+}
+
+interface Line {
+  /** Line content, without its terminator. */
+  content: string;
+  start: number;
+  end: number;
+}
+
+function getLines(source: string): Line[] {
+  const lines: Line[] = [];
+  let start = 0;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    if (character !== '\n' && character !== '\r') {
+      continue;
+    }
+    lines.push({ content: source.slice(start, index), start, end: index });
+    if (character === '\r' && source[index + 1] === '\n') {
+      index += 1;
+    }
+    start = index + 1;
+  }
+
+  lines.push({ content: source.slice(start), start, end: source.length });
+  return lines;
+}
+
+function isBlank(content: string): boolean {
+  return content.trim().length === 0;
+}
+
+function dedent(contents: string[], indentation: string): string[] {
+  if (!indentation) {
+    return contents;
+  }
+  return contents.map((content) =>
+    isBlank(content) ? content.trimStart() : content.slice(indentation.length),
+  );
+}
+
+/** Longest whitespace prefix shared by every non-blank line. */
+function getCommonIndentation(contents: string[]): string {
+  let common: string | undefined;
+
+  for (const content of contents) {
+    if (isBlank(content)) {
+      continue;
+    }
+    const indentation = /^[ \t]*/.exec(content)![0];
+    if (common === undefined) {
+      common = indentation;
+      continue;
+    }
+    let length = 0;
+    while (length < common.length && common[length] === indentation[length]) {
+      length += 1;
+    }
+    common = common.slice(0, length);
+  }
+
+  return common ?? '';
+}
+
+export function createEditableSourceProjection(options: {
+  fullSource: string;
+  previewSource: string;
+}): EditableSourceProjection | undefined {
+  const { fullSource, previewSource } = options;
+  if (!fullSource || !previewSource.trim()) {
+    return undefined;
+  }
+
+  const target = trimLeadingSpaces(previewSource).text;
+  if (!target) {
+    return undefined;
+  }
+  const normalized = trimLeadingSpaces(fullSource);
+
+  const starts: number[] = [];
+  for (
+    let index = normalized.text.indexOf(target);
+    index !== -1;
+    index = normalized.text.indexOf(target, index + 1)
+  ) {
+    starts.push(index);
+  }
+
+  if (starts.length === 0) {
+    return undefined;
+  }
+  // Material's `String.replace` takes the first of several matches. Refusing is
+  // the one deliberate difference: an edit spliced into the wrong occurrence is
+  // silent, and the caller can fall back to editing the complete source.
+  if (starts.length > 1) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `createEditableSourceProjection: the preview matches ${starts.length} regions of the source, so no projection is safe. Make the preview unambiguous, or use focus markers.`,
+      );
+    }
+    return undefined;
+  }
+
+  const matchStart = normalized.offsets[starts[0]];
+  const end = normalized.offsets[starts[0] + target.length - 1] + 1;
+  // Take the region from the line start when only whitespace precedes the match,
+  // so the indentation the preview dropped is inside the region and can be
+  // restored on patch-back. A preview that starts mid-line — `<CircularProgress
+  // />` against `return <CircularProgress />` — keeps the code before it out of
+  // the region, exactly as Material's replace does.
+  const lineStart = fullSource.lastIndexOf('\n', matchStart - 1) + 1;
+  const start = fullSource.slice(lineStart, matchStart).trim() === '' ? lineStart : matchStart;
+
+  const contents = getLines(fullSource.slice(start, end)).map((line) => line.content);
+  const indentation = getCommonIndentation(contents);
+
+  return {
+    // The region as the collapsed view shows it. For a well-formed preview file
+    // this is the preview text; deriving it from the source instead means an
+    // edit always patches back exactly, even for the handful of previews that
+    // carry a stray blank line or an odd indent.
+    source: dedent(contents, indentation).join('\n'),
+    start,
+    end,
+    ...(indentation ? { indentation } : null),
+  };
+}
+
+/**
+ * Derives the projection from focus markers, using the window the collapsed view
+ * shows. This is the target producer: the offsets come from the parsed source
+ * rather than from searching for the rendered text, so nothing can be ambiguous.
+ *
+ * Reads the same {@link getCollapsedFrameWindow} walk that `<Pre>`'s caret bounds
+ * read, so the slice the editor edits is exactly the region the caret is held
+ * inside.
+ *
+ * Returns `undefined` when the visible lines are not contiguous, or when they
+ * cover the whole file — the collapsed view then hides nothing and the editor
+ * can edit the complete source directly.
+ */
+export function createFocusedSourceProjection(
+  source: string,
+  root: HastRoot,
+  collapseToEmpty = false,
+): EditableSourceProjection | undefined {
+  const collapsed = getCollapsedFrameWindow(root, collapseToEmpty);
+  if (!collapsed?.contiguousLines || collapsed.minLine === undefined) {
+    return undefined;
+  }
+
+  const fullLines = getLines(source);
+  const window = fullLines.slice(collapsed.minLine - 1, collapsed.maxLine);
+  if (window.length === 0 || window.length >= fullLines.length) {
+    return undefined;
+  }
+
+  const contents = window.map((line) => line.content);
+  const indentation = getCommonIndentation(contents);
+
+  return {
+    // Dedented for display, the way a `.tsx.preview` file is authored.
+    source: dedent(contents, indentation).join('\n'),
+    start: window[0].start,
+    end: window[window.length - 1].end,
+    ...(indentation ? { indentation } : null),
+  };
+}
+
+/**
+ * Writes an edited projection back into the complete source, restoring the
+ * indentation the collapsed view hid.
+ */
+export function patchEditableSourceProjection(
+  fullSource: string,
+  projection: EditableSourceProjection,
+  editedSource: string,
+): string {
+  const { indentation } = projection;
+  const patched = indentation
+    ? editedSource
+        .split('\n')
+        .map((line) => (isBlank(line) ? line : `${indentation}${line}`))
+        .join('\n')
+    : editedSource;
+
+  return `${fullSource.slice(0, projection.start)}${patched}${fullSource.slice(projection.end)}`;
+}

--- a/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/index.ts
+++ b/packages/docs-infra/src/pipeline/loadIsomorphicCodeVariant/index.ts
@@ -14,5 +14,8 @@ export * from './enhanceCode';
 // Transform utilities
 export * from './applyCodeTransform';
 
+// Editable source projections
+export * from './createEditableSourceProjection';
+
 // Path utilities (if needed by consumers)
 export * from './addCodeVariantPaths';

--- a/packages/docs-infra/src/pipeline/parseSource/frameVisibility.ts
+++ b/packages/docs-infra/src/pipeline/parseSource/frameVisibility.ts
@@ -1,6 +1,7 @@
+import type { ElementContent } from 'hast';
 import type { FrameRange } from './calculateFrameRanges';
 import type { HastRoot } from '../../CodeHighlighter/types';
-import { isFrameSpan } from './isFrameSpan';
+import { hasClassName, isFrameSpan } from './isFrameSpan';
 
 /**
  * The `data-frame-type` values whose frames make up the window a collapsible
@@ -130,4 +131,172 @@ export function getInitialVisibleFrames(
   }
 
   return visibleFrames;
+}
+
+/**
+ * Counts newlines in a hast subtree and reports whether the tree's text content
+ * ends with a newline. Walks text nodes directly instead of materializing the
+ * subtree into a string — avoids the O(N) allocation `hast-util-to-text`
+ * performs per call, which adds up across hundreds of frames in large blocks.
+ *
+ * Returns `[newlineCount, endsWithNewline]`. `endsWithNewline` is `false` for an
+ * empty subtree.
+ */
+function countFrameNewlines(node: ElementContent | HastRoot): [number, boolean] {
+  let count = 0;
+  let endsWithNewline = false;
+  let sawText = false;
+
+  const walk = (current: { type: string; value?: unknown; children?: unknown }): void => {
+    if (current.type === 'text') {
+      const value = current.value as string;
+      if (value.length === 0) {
+        return;
+      }
+      sawText = true;
+      for (let i = 0; i < value.length; i += 1) {
+        if (value.charCodeAt(i) === 10 /* \n */) {
+          count += 1;
+        }
+      }
+      endsWithNewline = value.charCodeAt(value.length - 1) === 10;
+      return;
+    }
+    if (Array.isArray(current.children)) {
+      const children = current.children;
+      for (let i = 0; i < children.length; i += 1) {
+        walk(children[i] as ElementContent);
+      }
+    }
+  };
+
+  walk(node);
+  return [count, sawText && endsWithNewline];
+}
+
+/** {@link countFrameNewlines} without the trailing-newline flag. */
+function countFrameNewlinesOnly(node: ElementContent | HastRoot): number {
+  return countFrameNewlines(node)[0];
+}
+
+/**
+ * The region a collapsible code block shows while collapsed, in both of the
+ * coordinate systems its consumers need: rendered rows (for caret bounds) and
+ * source line numbers (for an editable projection).
+ */
+export type CollapsedFrameWindow = {
+  /** First and last rendered row of the visible region. */
+  minRow: number;
+  maxRow: number;
+  /**
+   * First and last 1-indexed source line of the visible region, read from the
+   * line spans' `data-ln`. `undefined` when the frames carry no line numbers.
+   */
+  minLine?: number;
+  maxLine?: number;
+  /**
+   * Whether the visible line numbers run without a gap. A projection needs a
+   * contiguous slice; caret bounds do not care.
+   */
+  contiguousLines: boolean;
+  /**
+   * Smallest `data-frame-indent` across the visible frames, in indent units.
+   * `undefined` when no visible frame is indented.
+   */
+  minIndent?: number;
+};
+
+/**
+ * Walks the collapsed-visible frames once and reports the window they cover.
+ *
+ * This is the single derivation of "what does the collapsed view show": the
+ * caret bounds in `useCode/Pre.tsx` and the focus-derived source projection both
+ * read it, so the region the editor edits and the region the caret is held
+ * inside can never disagree.
+ *
+ * Returns `undefined` when the block is not collapsible, when it renders an
+ * empty collapsed window, or when no frame is visible while collapsed.
+ */
+export function getCollapsedFrameWindow(
+  hast: HastRoot | null,
+  collapseToEmpty = false,
+): CollapsedFrameWindow | undefined {
+  // Collapse-to-empty has no visible-when-collapsed region. The original frame
+  // types survive here (only their *rendered* type is rewritten), so this has to
+  // be checked explicitly rather than inferred from the frames.
+  if (collapseToEmpty || !hast || hast.data?.collapsible !== true) {
+    return undefined;
+  }
+
+  let minIndent: number | undefined;
+  let minRow: number | undefined;
+  let maxRow: number | undefined;
+  let minLine: number | undefined;
+  let maxLine: number | undefined;
+  let lineCount = 0;
+  let row = 0;
+
+  for (const child of hast.children) {
+    if (child.type !== 'element' || !isFrameSpan(child)) {
+      continue;
+    }
+    const frameType = child.properties.dataFrameType;
+    const indent = child.properties.dataFrameIndent;
+    const isVisibleWhenCollapsed =
+      typeof frameType === 'string' && COLLAPSED_VISIBLE_FRAME_TYPES.has(frameType);
+
+    if (!isVisibleWhenCollapsed) {
+      // Past the visible region, hidden frames cannot change any output.
+      if (maxRow !== undefined) {
+        break;
+      }
+      // Before it, they only need to advance the row counter.
+      row += countFrameNewlinesOnly(child);
+      continue;
+    }
+
+    const [newlines, endsWithNewline] = countFrameNewlines(child);
+    const lastContentRow = endsWithNewline ? row + Math.max(0, newlines - 1) : row + newlines;
+
+    if (minRow === undefined) {
+      minRow = row;
+    }
+    maxRow = lastContentRow;
+    if (typeof indent === 'number' && (minIndent === undefined || indent < minIndent)) {
+      minIndent = indent;
+    }
+
+    for (const line of child.children) {
+      if (
+        line.type === 'element' &&
+        hasClassName(line, 'line') &&
+        typeof line.properties.dataLn === 'number'
+      ) {
+        const ln = line.properties.dataLn;
+        lineCount += 1;
+        if (minLine === undefined || ln < minLine) {
+          minLine = ln;
+        }
+        if (maxLine === undefined || ln > maxLine) {
+          maxLine = ln;
+        }
+      }
+    }
+
+    row += newlines;
+  }
+
+  if (minRow === undefined || maxRow === undefined) {
+    return undefined;
+  }
+
+  return {
+    minRow,
+    maxRow,
+    minLine,
+    maxLine,
+    contiguousLines:
+      minLine !== undefined && maxLine !== undefined && maxLine - minLine + 1 === lineCount,
+    minIndent,
+  };
 }

--- a/packages/docs-infra/src/useCode/CodeEditor.test.tsx
+++ b/packages/docs-infra/src/useCode/CodeEditor.test.tsx
@@ -42,6 +42,8 @@ describe('CodeEditor', () => {
       'const value = 2;',
       'App.tsx',
       expect.objectContaining({ line: 0, position: 16, extent: 0 }),
+      undefined,
+      undefined,
     );
   });
 
@@ -55,6 +57,8 @@ describe('CodeEditor', () => {
       'first\nchanged',
       'App.tsx',
       expect.objectContaining({ line: 1, content: 'changed' }),
+      undefined,
+      undefined,
     );
   });
 
@@ -108,7 +112,13 @@ describe('CodeEditor', () => {
     fireEvent.keyDown(element, { key: 'Tab' });
 
     expect(element.value).toBe('  const a = 1;');
-    expect(setSource).toHaveBeenCalledWith('  const a = 1;', 'App.tsx', expect.any(Object));
+    expect(setSource).toHaveBeenCalledWith(
+      '  const a = 1;',
+      'App.tsx',
+      expect.any(Object),
+      undefined,
+      undefined,
+    );
   });
 
   it('emits once per Tab, not twice', () => {
@@ -135,7 +145,13 @@ describe('CodeEditor', () => {
       expect(execCommand).toHaveBeenCalledWith('insertText', false, '  ');
       expect(element.value).toBe('  const a = 1;');
       expect(setSource).toHaveBeenCalledTimes(1);
-      expect(setSource).toHaveBeenCalledWith('  const a = 1;', 'App.tsx', expect.any(Object));
+      expect(setSource).toHaveBeenCalledWith(
+        '  const a = 1;',
+        'App.tsx',
+        expect.any(Object),
+        undefined,
+        undefined,
+      );
     } finally {
       // @ts-expect-error -- restoring the jsdom default, which is absent
       delete document.execCommand;
@@ -210,7 +226,13 @@ describe('CodeEditor', () => {
     type(textarea(), 'second');
 
     await waitFor(() =>
-      expect(setSource).toHaveBeenCalledWith('second', 'App.tsx', expect.any(Object), hast),
+      expect(setSource).toHaveBeenCalledWith(
+        'second',
+        'App.tsx',
+        expect.any(Object),
+        hast,
+        undefined,
+      ),
     );
   });
 
@@ -227,7 +249,90 @@ describe('CodeEditor', () => {
     type(textarea(), 'second');
 
     await waitFor(() =>
-      expect(setSource).toHaveBeenCalledWith('second', 'App.tsx', expect.any(Object)),
+      expect(setSource).toHaveBeenCalledWith(
+        'second',
+        'App.tsx',
+        expect.any(Object),
+        undefined,
+        undefined,
+      ),
     );
+  });
+
+  describe('with a source projection', () => {
+    const FULL_SOURCE = 'function Demo() {\n  return <Button>Click</Button>;\n}\n';
+    const projection = {
+      source: 'return <Button>Click</Button>;',
+      start: FULL_SOURCE.indexOf('  return'),
+      end: FULL_SOURCE.indexOf(';\n}') + 1,
+      indentation: '  ',
+    };
+
+    it('seeds the textarea with the projected slice', () => {
+      render(
+        <CodeEditor
+          source={FULL_SOURCE}
+          sourceProjection={projection}
+          fileName="App.tsx"
+          setSource={() => {}}
+        />,
+      );
+
+      expect(textarea().value).toBe('return <Button>Click</Button>;');
+    });
+
+    it('reports the complete source, the caret in it, and the new projection', () => {
+      const setSource = vi.fn();
+      render(
+        <CodeEditor
+          source={FULL_SOURCE}
+          sourceProjection={projection}
+          fileName="App.tsx"
+          setSource={setSource}
+        />,
+      );
+
+      type(textarea(), 'return <Button>Tap</Button>;');
+
+      expect(setSource).toHaveBeenCalledWith(
+        'function Demo() {\n  return <Button>Tap</Button>;\n}\n',
+        'App.tsx',
+        expect.objectContaining({
+          // Two characters shorter than the projection, plus the restored indent.
+          position: projection.end - 2,
+          line: 1,
+          content: '  return <Button>Tap</Button>;',
+        }),
+        undefined,
+        expect.objectContaining({
+          source: 'return <Button>Tap</Button>;',
+          start: projection.start,
+          end: projection.end - 2,
+          indentation: '  ',
+        }),
+      );
+    });
+
+    it('re-indents every line an edit adds', () => {
+      const setSource = vi.fn();
+      render(
+        <CodeEditor
+          source={FULL_SOURCE}
+          sourceProjection={projection}
+          fileName="App.tsx"
+          setSource={setSource}
+        />,
+      );
+
+      type(textarea(), 'const label = 1;\nreturn <Button>{label}</Button>;');
+
+      expect(setSource).toHaveBeenCalledWith(
+        'function Demo() {\n  const label = 1;\n  return <Button>{label}</Button>;\n}\n',
+        'App.tsx',
+        expect.any(Object),
+        undefined,
+        expect.any(Object),
+      );
+    });
   });
 });

--- a/packages/docs-infra/src/useCode/CodeEditor.tsx
+++ b/packages/docs-infra/src/useCode/CodeEditor.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import * as React from 'react';
-import type { HastRoot } from '../CodeHighlighter/types';
+import type { EditableSourceProjection, HastRoot } from '../CodeHighlighter/types';
 import { useCodeContext } from '../CodeProvider/CodeContext';
 import type { SetSource } from './useSourceEditing';
 import type { Position } from './editingTypes';
 import { indentEdit, outdentEdit } from './codeEditorEdits';
+import { patchEditableSourceProjection } from '../pipeline/loadIsomorphicCodeVariant/createEditableSourceProjection';
 
 /**
  * A transparent textarea laid over an already-highlighted `<pre>`. The textarea
@@ -25,6 +26,14 @@ import { indentEdit, outdentEdit } from './codeEditorEdits';
 export interface CodeEditorProps {
   /** Complete source, matching the text painted by the `<pre>` underneath. */
   source: string;
+  /**
+   * The slice of `source` the `<pre>` is painting, when the block is collapsed
+   * to a focused window. The textarea then holds only that slice, and every
+   * edit is patched back into the complete source before it goes out through
+   * `setSource` — so a collapsed block can be edited in place instead of
+   * expanding first.
+   */
+  sourceProjection?: EditableSourceProjection;
   /** Canonical file name reported back through `setSource`. */
   fileName?: string;
   language?: string;
@@ -68,8 +77,34 @@ function replaceRange(
   textarea.value = `${textarea.value.slice(0, start)}${text}${textarea.value.slice(end)}`;
 }
 
+/**
+ * Maps an offset in the projected text to the matching offset in the complete
+ * source. Patching re-indents every non-blank line, so the offset shifts by one
+ * indentation per non-blank line up to and including the caret's own.
+ */
+function toFullSourceOffset(
+  projection: EditableSourceProjection,
+  editedSource: string,
+  offset: number,
+): number {
+  const indentation = projection.indentation?.length ?? 0;
+  if (!indentation) {
+    return projection.start + offset;
+  }
+  const lines = editedSource.split('\n');
+  const caretLine = editedSource.slice(0, offset).split('\n').length - 1;
+  let added = 0;
+  for (let line = 0; line <= caretLine; line += 1) {
+    if (lines[line]?.trim()) {
+      added += indentation;
+    }
+  }
+  return projection.start + offset + added;
+}
+
 export function CodeEditor({
   source,
+  sourceProjection,
   fileName,
   language,
   tabSize = 2,
@@ -140,7 +175,7 @@ export function CodeEditor({
     observer.observe(code);
     observer.observe(pre);
     return () => observer.disconnect();
-  }, [source]);
+  }, [source, sourceProjection?.source]);
 
   // Seeds the textarea and adopts source that did not originate here — a reset,
   // a transform swap, or a file switch. An echo of our own last edit is ignored
@@ -159,18 +194,40 @@ export function CodeEditor({
     if (!fileChanged && source === lastEmittedRef.current) {
       return;
     }
-    if (textarea.value !== source) {
-      textarea.value = source;
+    // The textarea holds the projected slice when there is one, since that is
+    // what the `<pre>` beneath it paints.
+    const nextValue = sourceProjection ? sourceProjection.source : source;
+    if (textarea.value !== nextValue) {
+      textarea.value = nextValue;
     }
-  }, [source, fileName]);
+  }, [source, sourceProjection, fileName]);
 
   const emit = React.useCallback(
-    (nextValue: string, selectionStart: number, selectionEnd: number) => {
+    (editedValue: string, selectionStart: number, selectionEnd: number) => {
+      // A projected edit goes out as the complete source, with the projection
+      // attached so the host can re-derive the next one. The caret travels in
+      // full-source coordinates too, since that is what the host re-parses.
+      const nextValue = sourceProjection
+        ? patchEditableSourceProjection(source, sourceProjection, editedValue)
+        : editedValue;
+      const caret = sourceProjection
+        ? toFullSourceOffset(sourceProjection, editedValue, selectionStart)
+        : selectionStart;
+      // The projection that goes out describes the source that goes out: same
+      // start, same hidden indentation, but the edited slice and its new end.
+      const nextProjection = sourceProjection
+        ? {
+            ...sourceProjection,
+            source: editedValue,
+            end: sourceProjection.end + (nextValue.length - source.length),
+          }
+        : undefined;
+
       lastEmittedRef.current = nextValue;
       const position: Position = {
-        position: selectionStart,
+        position: caret,
         extent: selectionEnd - selectionStart,
-        ...getCaretLine(nextValue, selectionStart),
+        ...getCaretLine(nextValue, caret),
       };
 
       // Hand the host a pre-parsed tree when a worker parser is available, so
@@ -178,14 +235,14 @@ export function CodeEditor({
       if (parseSourceAsync && fileName) {
         const controller = new AbortController();
         parseSourceAsync(nextValue, fileName, language, controller.signal).then(
-          (hast: HastRoot) => setSource(nextValue, fileName, position, hast),
-          () => setSource(nextValue, fileName, position),
+          (hast: HastRoot) => setSource(nextValue, fileName, position, hast, nextProjection),
+          () => setSource(nextValue, fileName, position, undefined, nextProjection),
         );
         return;
       }
-      setSource(nextValue, fileName, position);
+      setSource(nextValue, fileName, position, undefined, nextProjection);
     },
-    [setSource, fileName, language, parseSourceAsync],
+    [setSource, source, sourceProjection, fileName, language, parseSourceAsync],
   );
 
   // `execCommand` fires `input` synchronously, so a programmatic edit would

--- a/packages/docs-infra/src/useCode/Pre.browser.tsx
+++ b/packages/docs-infra/src/useCode/Pre.browser.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 import type { HastRoot, ParseSource, SourceComments } from '../CodeHighlighter/types';
 import { createParseSource } from '../pipeline/parseSource';
 import { enhanceCodeEmphasis } from '../pipeline/enhanceCodeEmphasis';
+import { createFocusedSourceProjection } from '../pipeline/loadIsomorphicCodeVariant/createEditableSourceProjection';
 import { Pre } from './Pre';
 import { preloadCodeEditor } from './codeEditorCache';
 
@@ -21,6 +22,11 @@ const INITIAL_SOURCE = [
 const HIGHLIGHT_COMMENTS: SourceComments = {
   3: ['@highlight-start'],
   4: ['@highlight-end'],
+};
+
+/** Focuses the function body, so the collapsed window hides the import. */
+const FOCUS_COMMENTS: SourceComments = {
+  4: ['@focus'],
 };
 
 let parseSource: ParseSource;
@@ -63,6 +69,44 @@ function EditablePreview({ onSource }: { onSource: (text: string) => void }) {
 
 function renderEditable(onSource: (text: string) => void = () => {}) {
   return render(<EditablePreview onSource={onSource} />);
+}
+
+/**
+ * A collapsed block whose focused window is projected into the editor, so the
+ * edit happens in place instead of expanding the block first.
+ */
+function ProjectedPreview({ onSource }: { onSource: (text: string) => void }) {
+  const [source, setSource] = React.useState(INITIAL_SOURCE);
+  const [expanded, setExpanded] = React.useState(false);
+  const highlighted = React.useMemo(
+    () =>
+      enhanceCodeEmphasis(parseSource(source, FILE_NAME), FOCUS_COMMENTS, FILE_NAME) as HastRoot,
+    [source],
+  );
+  const projection = React.useMemo(
+    () => createFocusedSourceProjection(source, highlighted),
+    [source, highlighted],
+  );
+
+  return (
+    <React.Fragment>
+      <span data-testid="expanded">{String(expanded)}</span>
+      <Pre
+        fileName={FILE_NAME}
+        language="tsx"
+        shouldHighlight
+        expanded={expanded}
+        expand={() => setExpanded(true)}
+        sourceProjection={projection}
+        setSource={(text) => {
+          onSource(text);
+          setSource(text);
+        }}
+      >
+        {highlighted}
+      </Pre>
+    </React.Fragment>
+  );
 }
 
 function getTextarea() {
@@ -175,6 +219,33 @@ describe('Pre editing', () => {
     // Highlighting still applies to the edited text, and frames survive editing.
     await waitFor(() => expect(painted.querySelector('[class*="pl-"]')).not.toBeNull());
     expect(painted.querySelector('span.frame')).not.toBeNull();
+  });
+
+  it('edits a collapsed block through its projection, without expanding', async () => {
+    let latest = '';
+    render(
+      <ProjectedPreview
+        onSource={(text) => {
+          latest = text;
+        }}
+      />,
+    );
+    await waitFor(() => expect(getTextarea()).toBeTruthy());
+
+    const textarea = getTextarea();
+    // The textarea holds only the focused window, not the whole file.
+    expect(textarea.value).toBe('return <div />;');
+
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+    await userEvent.keyboard(' // edited');
+
+    // The edit goes out as the complete source, with the hidden indentation
+    // restored, and the block stays collapsed.
+    await waitFor(() =>
+      expect(latest).toBe(INITIAL_SOURCE.replace('<div />;', '<div />; // edited')),
+    );
+    expect(screen.getByTestId('expanded').textContent).toBe('false');
   });
 
   it('does not mount a textarea for a read-only block', () => {

--- a/packages/docs-infra/src/useCode/Pre.tsx
+++ b/packages/docs-infra/src/useCode/Pre.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import type { ElementContent, RootContent } from 'hast';
 import type { SetSource } from './useSourceEditing';
-import type { HastRoot, VariantSource } from '../CodeHighlighter/types';
+import type { EditableSourceProjection, HastRoot, VariantSource } from '../CodeHighlighter/types';
 import type { FallbackNode } from '../CodeHighlighter/fallbackFormat';
 import { fallbackToHast, fallbackIsHighlighted } from '../CodeHighlighter/fallbackFormat';
 import { useCodeContext } from '../CodeProvider/CodeContext';
@@ -14,6 +14,7 @@ import { decodeHastSource } from '../pipeline/loadIsomorphicCodeVariant/decodeHa
 import {
   COLLAPSED_VISIBLE_FRAME_TYPES,
   resolveCollapsedFrameType,
+  getCollapsedFrameWindow,
   getInitialVisibleFrames,
 } from '../pipeline/parseSource/frameVisibility';
 import { isFrameSpan } from '../pipeline/parseSource/isFrameSpan';
@@ -40,14 +41,18 @@ function resolveFrameTypeAttribute(
 
 /**
  * Bounds describing the visible region of a collapsible code block in its
- * collapsed state. Used to constrain caret movement in `useEditable` and to
- * trigger expansion when the user navigates past the boundaries.
+ * collapsed state. Used to constrain caret movement and to trigger expansion
+ * when the user navigates past the boundaries. Derived from the one collapsed
+ * window walk in `pipeline/parseSource/frameVisibility.ts`, so the caret is held
+ * inside exactly the region an editable projection would slice.
+ *
+ * `data-frame-indent` is encoded as `leadingSpaces / indentation`, so the column
+ * count is `indent * indentation`.
  */
 type CollapsedBounds = {
   /**
-   * Smallest column the visible region exposes on indented lines (derived
-   * from the minimum `data-frame-indent` across collapsed-visible region
-   * frames). `undefined` when no visible region frame is indented.
+   * Smallest column the visible region exposes on indented lines. `undefined`
+   * when no visible region frame is indented.
    */
   minColumn: number | undefined;
   /** First row of the visible region. */
@@ -56,152 +61,16 @@ type CollapsedBounds = {
   maxRow: number;
 };
 
-/**
- * Counts newlines in a hast subtree and reports whether the tree's text
- * content ends with a newline. Walks text nodes directly instead of
- * materializing the subtree into a string — avoids the O(N) allocation
- * `hast-util-to-text` performs per call, which adds up across hundreds of
- * frames in large code blocks.
- *
- * Returns `[newlineCount, endsWithNewline]`. `endsWithNewline` is `false`
- * for an empty subtree (matches the previous `text.endsWith('\n')` check
- * on an empty string).
- */
-function countFrameNewlines(node: ElementContent | HastRoot): [number, boolean] {
-  let count = 0;
-  let endsWithNewline = false;
-  let sawText = false;
-
-  const walk = (current: { type: string; value?: unknown; children?: unknown }): void => {
-    if (current.type === 'text') {
-      const value = current.value as string;
-      if (value.length === 0) {
-        return;
-      }
-      sawText = true;
-      for (let i = 0; i < value.length; i += 1) {
-        if (value.charCodeAt(i) === 10 /* \n */) {
-          count += 1;
-        }
-      }
-      endsWithNewline = value.charCodeAt(value.length - 1) === 10;
-      return;
-    }
-    if (Array.isArray(current.children)) {
-      const children = current.children;
-      for (let i = 0; i < children.length; i += 1) {
-        walk(children[i]);
-      }
-    }
-  };
-
-  walk(node);
-  return [count, sawText && endsWithNewline];
-}
-
-/**
- * Counts newlines in a hast subtree without tracking the trailing-newline
- * flag. Used for hidden frames that precede the visible-when-collapsed
- * region: we only need to advance the running row offset, not figure out
- * how the frame's last line aligns.
- */
-function countFrameNewlinesOnly(node: ElementContent | HastRoot): number {
-  let count = 0;
-
-  const walk = (current: { type: string; value?: unknown; children?: unknown }): void => {
-    if (current.type === 'text') {
-      const value = current.value as string;
-      for (let i = 0; i < value.length; i += 1) {
-        if (value.charCodeAt(i) === 10 /* \n */) {
-          count += 1;
-        }
-      }
-      return;
-    }
-    if (Array.isArray(current.children)) {
-      const children = current.children;
-      for (let i = 0; i < children.length; i += 1) {
-        walk(children[i]);
-      }
-    }
-  };
-
-  walk(node);
-  return count;
-}
-
-/**
- * When the code block is collapsible, returns the row range of the
- * collapsed-visible frames (the same set used by `getInitialVisibleFrames`)
- * along with the minimum indent column. Returns `undefined` when the block
- * isn't collapsible or no frame is visible-when-collapsed.
- *
- * `data-frame-indent` is encoded as `leadingSpaces / indentation`, so the
- * column count is `indent * indentation`.
- */
 function computeCollapsedBounds(
   hast: HastRoot | null,
   indentation: number,
   collapseToEmpty = false,
 ): CollapsedBounds | undefined {
-  // Collapse-to-empty has no visible-when-collapsed region, so there are no bounds
-  // to constrain the caret to. (The original frame types are still `focus` /
-  // `highlighted` here — only their *rendered* type is rewritten — so this must
-  // be checked explicitly rather than inferred from the frames.)
-  if (collapseToEmpty) {
+  const window = getCollapsedFrameWindow(hast, collapseToEmpty);
+  if (!window) {
     return undefined;
   }
-  if (!hast || hast.data?.collapsible !== true) {
-    return undefined;
-  }
-
-  let minIndent: number | undefined;
-  let minRow: number | undefined;
-  let maxRow: number | undefined;
-  let row = 0;
-
-  for (const child of hast.children) {
-    if (child.type !== 'element' || !isFrameSpan(child)) {
-      continue;
-    }
-    const frameType = child.properties.dataFrameType;
-    const indent = child.properties.dataFrameIndent;
-    const isVisibleWhenCollapsed =
-      typeof frameType === 'string' && COLLAPSED_VISIBLE_FRAME_TYPES.has(frameType);
-
-    if (!isVisibleWhenCollapsed) {
-      // Once we've passed the visible region, hidden frames can't change
-      // any output — bail out entirely.
-      if (maxRow !== undefined) {
-        break;
-      }
-      // Hidden frames before the visible region only need their row count
-      // to keep `row` accurate for the next visible frame's `minRow`. We
-      // don't need `endsWithNewline` (only consumed by visible frames for
-      // `maxRow` arithmetic) or any indent metadata, so do the cheap
-      // newline-only walk.
-      row += countFrameNewlinesOnly(child);
-      continue;
-    }
-
-    const [newlines, endsWithNewline] = countFrameNewlines(child);
-    const lastContentRow = endsWithNewline ? row + Math.max(0, newlines - 1) : row + newlines;
-
-    if (minRow === undefined) {
-      minRow = row;
-    }
-    maxRow = lastContentRow;
-    if (typeof indent === 'number' && (minIndent === undefined || indent < minIndent)) {
-      minIndent = indent;
-    }
-
-    row += newlines;
-  }
-
-  if (minRow === undefined || maxRow === undefined) {
-    return undefined;
-  }
-
+  const { minIndent, minRow, maxRow } = window;
   return {
     minColumn: minIndent !== undefined && minIndent > 0 ? minIndent * indentation : undefined,
     minRow,
@@ -279,10 +148,18 @@ export function Pre({
   editActivation,
   onActivate,
   editable = true,
+  sourceProjection,
 }: {
   children: VariantSource;
   className?: string;
   fileName?: string;
+  /**
+   * The slice of the source that the collapsed view shows, when the host has
+   * one. With a projection the editor edits that slice in place; without one, a
+   * collapsed block expands on activation, since the editor holds plain text
+   * and has no notion of hidden rows.
+   */
+  sourceProjection?: EditableSourceProjection;
   bridgeLineMode?: 'focus' | 'total';
   language?: string;
   ref?: React.Ref<HTMLPreElement>;
@@ -587,16 +464,16 @@ export function Pre({
     [hast, expanded, collapseToEmpty],
   );
 
-  // The editor edits complete source as plain text, so a collapsed block would
-  // otherwise show more in the editor than the `<pre>` showed. Expanding on
-  // activation keeps the two in agreement. Editing a collapsed region in place
-  // needs a source projection, which lands with the projection work.
+  // Without a projection the editor holds the complete source as plain text, so
+  // a collapsed block would show more in the editor than the `<pre>` painted.
+  // Expanding on activation keeps the two in agreement. With a projection the
+  // editor holds only the visible slice, so the block stays collapsed.
   const handleEditorActivate = React.useCallback(() => {
-    if (collapsedBounds && expand) {
+    if (collapsedBounds && expand && !sourceProjection) {
       expand();
     }
     onActivate?.();
-  }, [collapsedBounds, expand, onActivate]);
+  }, [collapsedBounds, expand, onActivate, sourceProjection]);
 
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
   // Set when Enter requested the editor before its chunk had loaded, so focus
@@ -1263,6 +1140,7 @@ export function Pre({
           loader={codeEditorLoader}
           fallback={null}
           source={editorSource}
+          sourceProjection={expanded ? undefined : sourceProjection}
           fileName={fileName}
           language={language}
           setSource={setSource!}

--- a/packages/docs-infra/src/useCode/useCodeUtils.ts
+++ b/packages/docs-infra/src/useCode/useCodeUtils.ts
@@ -4,6 +4,7 @@ import type {
   Code,
   Transforms,
   SourceComments,
+  EditableSourceProjection,
 } from '../CodeHighlighter/types';
 
 export interface TransformedFile {
@@ -16,6 +17,11 @@ export interface TransformedFile {
    * entries whose source line was wiped by the transform are dropped.
    */
   comments?: SourceComments;
+  /**
+   * Editable slice of the transformed source, with offsets in that source
+   * rather than the original. See {@link EditableSourceProjection}.
+   */
+  sourceProjection?: EditableSourceProjection;
 }
 
 export interface TransformedFiles {

--- a/packages/docs-infra/src/useCode/useSourceEditing.ts
+++ b/packages/docs-infra/src/useCode/useSourceEditing.ts
@@ -9,6 +9,7 @@ import type {
   Code,
   ControlledCode,
   ControlledVariantCode,
+  EditableSourceProjection,
   VariantCode,
 } from '../CodeHighlighter/types';
 import type { CodeHighlighterContextType } from '../CodeHighlighter/CodeHighlighterContext';
@@ -41,17 +42,18 @@ export const preloadSourceEditingEngine = preloadEditingEngine;
 export const resetSourceEditingEngineCache = resetEditingEngineCache;
 
 /**
- * Internal `setSource` shape used by the editing pipeline. The 3rd and 4th
- * arguments (caret position, pre-parsed HAST) are wired between sibling
- * hooks (`useEditable` → `Pre` → `useSourceEditing`) and are NOT part of
- * the public `useCode` contract — host code should treat `setSource` as
- * `(source, fileName?) => void`.
+ * Internal `setSource` shape used by the editing pipeline. The 3rd to 5th
+ * arguments (caret position, pre-parsed HAST, the projection the edit was made
+ * through) are wired between sibling hooks (`useEditable` → `Pre` →
+ * `useSourceEditing`) and are NOT part of the public `useCode` contract — host
+ * code should treat `setSource` as `(source, fileName?) => void`.
  */
 export type SetSource = (
   source: string,
   fileName?: string,
   position?: Position,
   preParsed?: HastRoot,
+  sourceProjection?: EditableSourceProjection,
 ) => void;
 
 interface UseSourceEditingProps {
@@ -102,7 +104,7 @@ export function useSourceEditing({
   const editTokenRef = React.useRef(0);
 
   const setSource = React.useCallback<SetSource>(
-    (source, fileName, position, preParsed) => {
+    (source, fileName, position, preParsed, sourceProjection) => {
       if (!contextSetCode) {
         console.warn(
           'setCode is not available in the current context. Ensure you are using CodeControllerContext.',
@@ -188,6 +190,22 @@ export function useSourceEditing({
             return { comments, collapseMap, totalLines, emptyLines };
           };
 
+          // An edit made through a projection carries the projection that
+          // describes the source it produced, so the collapsed window can keep
+          // showing the edited slice. An edit made against the complete source
+          // clears any projection the file was carrying.
+          const projectionState = (): Pick<
+            ControlledVariantCode,
+            'sourceProjection' | 'focusedLines' | 'collapsible'
+          > =>
+            sourceProjection
+              ? {
+                  sourceProjection,
+                  focusedLines: engine.analyzeSource(sourceProjection.source).totalLines,
+                  collapsible: sourceProjection.start > 0 || sourceProjection.end < source.length,
+                }
+              : { sourceProjection: undefined, focusedLines: undefined, collapsible: undefined };
+
           if (isMainFile) {
             if (source === variant.source) {
               return currentCode ?? newCode;
@@ -203,6 +221,7 @@ export function useSourceEditing({
               emptyLines,
               comments,
               collapseMap,
+              ...projectionState(),
             };
           } else if (effectiveFileName) {
             const extraEntry = variant.extraFiles?.[effectiveFileName];
@@ -224,6 +243,7 @@ export function useSourceEditing({
                   emptyLines,
                   comments,
                   collapseMap,
+                  ...projectionState(),
                 },
               },
             };


### PR DESCRIPTION
Sixth in the docs-infra migration stack, on top of #1779.

A collapsed code block had to expand before it could be edited: the textarea holds plain text and has no notion of hidden rows. A projection names the contiguous slice the collapsed view shows, so the editor holds that slice and patches each edit back into the complete source.

- `EditableSourceProjection` on `Transforms[key]`, `VariantExtraFiles[file]`, `VariantCode`, `ControlledVariantCode`, and `TransformedFile`. `hasCollapse`/`hasCollapseInFocus` are untouched.
- `createEditableSourceProjection({ fullSource, previewSource })` resolves a preview the way Material UI's `Demo` does — strip leading whitespace from every line of both sides, then match as a substring — so it accepts exactly the preview files Material accepts. Over Material's corpus, all 392 `.tsx.preview` files with a `.tsx` sibling resolve to one region, none ambiguously, and every projection patches back byte-identical. Two deliberate differences: the projection records the indentation to restore, and a fragment matching more than once is refused rather than spliced into the first occurrence.
- `createFocusedSourceProjection(source, root)` is the target producer, deriving the window from the parsed tree. It and `<Pre>`'s caret bounds now share one `getCollapsedFrameWindow` walk, so the edited region and the caret bounds cannot disagree.
- `setSource` grows a fifth argument carrying the projection an edit was made through; `useSourceEditing` records it on the controlled file.
- `Pre` takes `sourceProjection` and no longer expands on activation when it has one.

Gate: 27 browser tests across chromium, firefox, and webkit — the new one edits a collapsed block through its projection and asserts it never expands — plus a clean typecheck and lint.
