### PR TITLE
[docs-infra] Resolve a preview file into a source projection

### DIFF
--- a/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.test.ts
+++ b/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.test.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../CodeHighlighter/types';
 import { decodeSourceToText } from '../loadIsomorphicCodeVariant/decodeSourceToText';
 import { loadIsomorphicCodeVariant } from '../loadIsomorphicCodeVariant';
+import { createParseSource } from '../parseSource';
 import { precomputeDemo } from './precomputeDemo';
 
 const parseSource: ParseSource = (source) => ({
@@ -101,6 +102,67 @@ describe('precomputeDemo', () => {
       react: [{ name: 'React', type: 'namespace' }],
     });
     expect(result.dependencies).toEqual(['file:///demos/Default.tsx', 'file:///demos/Compact.tsx']);
+  });
+
+  describe('preview projections', () => {
+    // The real parser, since a projection resolves against the text content of
+    // the parsed tree rather than the raw string.
+    const realParser = createParseSource();
+    const fullSource = [
+      'export default function Demo() {',
+      '  return (',
+      '    <button type="button">',
+      '      Click',
+      '    </button>',
+      '  );',
+      '}',
+    ].join('\n');
+
+    it('resolves a preview into a projection on each variant', async () => {
+      const result = await precomputeDemo({
+        entries: [{ name: 'Default', url: 'file:///demos/Default.tsx' }],
+        loadSource: async () => ({ source: fullSource }),
+        sourceParser: realParser,
+        output: 'hast',
+        preview: '<button type="button">\n  Click\n</button>',
+      });
+
+      expect(result.code.Default).toMatchObject({
+        sourceProjection: {
+          source: '<button type="button">\n  Click\n</button>',
+          start: fullSource.indexOf('    <button'),
+          end: fullSource.indexOf('    </button>') + '    </button>'.length,
+          indentation: '    ',
+        },
+      });
+    });
+
+    it('leaves a variant the preview does not resolve against alone', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await precomputeDemo({
+        entries: [{ name: 'Default', url: 'file:///demos/Default.tsx' }],
+        loadSource: async () => ({ source: fullSource }),
+        sourceParser: realParser,
+        output: 'hast',
+        preview: '<section>Absent</section>',
+      });
+
+      expect(result.code.Default).not.toHaveProperty('sourceProjection');
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('does not resolve'));
+      warn.mockRestore();
+    });
+
+    it('carries no projection without a preview', async () => {
+      const result = await precomputeDemo({
+        entries: [{ name: 'Default', url: 'file:///demos/Default.tsx' }],
+        loadSource: async () => ({ source: fullSource }),
+        sourceParser: realParser,
+        output: 'hast',
+      });
+
+      expect(result.code.Default).not.toHaveProperty('sourceProjection');
+    });
   });
 
   it('passes named exports, transformers, enhancers, and loading options to each entry', async () => {

--- a/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.ts
+++ b/packages/docs-infra/src/pipeline/precomputeDemo/precomputeDemo.ts
@@ -8,6 +8,8 @@ import { getFileNameFromUrl, IGNORE_COMMENT_PREFIXES } from '../loaderUtils';
 import { mergeExternals } from '../loaderUtils/mergeExternals';
 import { loadIsomorphicCodeVariant } from '../loadIsomorphicCodeVariant';
 import { createParseSource } from '../parseSource';
+import { createEditableSourceProjection } from '../loadIsomorphicCodeVariant/createEditableSourceProjection';
+import { getHastTextContent } from '../hastUtils';
 import { createLoadServerCodeSource } from '../loadServerCodeSource';
 import type { DemoEntry, PrecomputedDemo, PrecomputeDemoOptions } from './types';
 
@@ -24,6 +26,47 @@ function createEntryVariant(entry: DemoEntry): VariantCode {
     ...(entry.language ? { language: entry.language } : {}),
     ...(entry.namedExport ? { namedExport: entry.namedExport } : {}),
   };
+}
+
+/**
+ * Resolves a compatibility preview against one loaded variant, recording the
+ * region it names as the variant's editable source projection.
+ *
+ * Each variant resolves the preview on its own: a preview written against the
+ * TypeScript source may not appear in the JavaScript one, and a variant it
+ * cannot resolve against simply carries no projection.
+ */
+function resolvePreviewProjection(
+  variant: VariantCode,
+  preview: string | undefined,
+  variantName: string,
+): VariantCode {
+  if (!preview) {
+    return variant;
+  }
+
+  const { source } = variant;
+  let fullSource: string | undefined;
+  if (typeof source === 'string') {
+    fullSource = source;
+  } else if (source && 'type' in source && source.type === 'root') {
+    fullSource = getHastTextContent(source);
+  }
+  if (!fullSource) {
+    return variant;
+  }
+
+  const sourceProjection = createEditableSourceProjection({ fullSource, previewSource: preview });
+  if (!sourceProjection) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `precomputeDemo: the preview does not resolve against the "${variantName}" source, so that variant carries no projection.`,
+      );
+    }
+    return variant;
+  }
+
+  return { ...variant, sourceProjection };
 }
 
 /** Loads and processes demo source entries without a factory wrapper. */
@@ -69,7 +112,7 @@ export async function precomputeDemo(options: PrecomputeDemoOptions): Promise<Pr
   const code: PrecomputedDemo['code'] = {};
   const dependencies = new Set<string>();
   for (const { name, result } of results) {
-    code[name] = result.code;
+    code[name] = resolvePreviewProjection(result.code, options.preview, name);
     result.dependencies.forEach((dependency) => dependencies.add(dependency));
   }
 

--- a/packages/docs-infra/src/pipeline/precomputeDemo/types.ts
+++ b/packages/docs-infra/src/pipeline/precomputeDemo/types.ts
@@ -41,6 +41,13 @@ export interface PrecomputeDemoOptions {
   maxDepth?: number;
   /** Whether the default source loader follows relative imports. */
   includeDependencies?: boolean;
+  /**
+   * Compatibility preview source. Resolved against each variant's loaded source
+   * into a {@link EditableSourceProjection} on that variant, naming the region a
+   * collapsed view shows and an edit patches back into. Skipped, with a
+   * development warning, for a variant the preview cannot be resolved against.
+   */
+  preview?: string;
 }
 
 export interface PrecomputedDemo {

--- a/packages/docs-infra/src/pipeline/precomputeFileDemo/precomputeFileDemo.ts
+++ b/packages/docs-infra/src/pipeline/precomputeFileDemo/precomputeFileDemo.ts
@@ -14,6 +14,10 @@ export async function precomputeFileDemo(
     }
     return entry;
   });
-  const precomputed = await precomputeDemo({ ...options, entries });
+  const precomputed = await precomputeDemo({
+    ...options,
+    entries,
+    ...(descriptor.preview ? { preview: descriptor.preview.source } : {}),
+  });
   return { ...precomputed, descriptor };
 }


### PR DESCRIPTION
Seventh in the docs-infra migration stack, on top of #1780.

`precomputeFileDemo` already accepted a preview descriptor, but nothing read it. It now reaches `precomputeDemo`, which resolves the preview against each variant's loaded source and records the region it names as that variant's `sourceProjection`.

Each variant resolves the preview on its own: a fragment written against the TypeScript source need not appear in the JavaScript one, and a variant it cannot be resolved against carries no projection and warns in development rather than failing the build.

This is what lets a consuming docs site start a demo collapsed on its preview region, highlighted by docs-infra.
