### PR TITLE
[docs-infra] Discard live edits across the collapse boundary

### DIFF
--- a/docs/app/docs-infra/hooks/page.mdx
+++ b/docs/app/docs-infra/hooks/page.mdx
@@ -37,6 +37,7 @@ The `useCode` hook provides programmatic access to code display, editing, and tr
   - Architecture
   - Basic Usage
     - Live editing is loaded on demand
+    - Edits are discarded across a collapse boundary
     - Turning editing on and off
   - Types
   - Advanced Usage

--- a/docs/app/docs-infra/hooks/use-code/page.mdx
+++ b/docs/app/docs-infra/hooks/use-code/page.mdx
@@ -102,6 +102,18 @@ collapsed-frame boundaries while editing, and moving past them (e.g. pressing <k
 on the last visible line) automatically expands the block instead of stranding the
 caret in hidden lines.
 
+### Edits are discarded across a collapse boundary
+
+A collapsed block is edited through a source projection: the textarea holds only the
+visible slice, and each edit is patched back into the complete source. The expanded
+view is edited against the whole file instead, so neither draft is meaningful in the
+other view — crossing the boundary in either direction discards live edits, exactly as
+`reset()` would.
+
+The selected variant, file, and transform are preserved, and this applies to `expand()`
+and to a controlled `setExpanded(next)` write alike. Nothing is discarded when the block
+is already in the state being asked for.
+
 ### Turning editing on and off
 
 An editable block — one rendered through a controller that supplies `setCode` — is editable

--- a/packages/docs-infra/src/useCode/useCode.collapseReset.test.tsx
+++ b/packages/docs-infra/src/useCode/useCode.collapseReset.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Focused tests for `useCode` discarding live edits across the collapse
+ * boundary. A collapsed block is edited through its source projection, which
+ * covers only the visible region, and the expanded view is edited against the
+ * complete source, so neither draft survives the crossing (see `useCode.ts`).
+ */
+import * as React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// eslint-disable-next-line testing-library/no-manual-cleanup
+import { renderHook, act, cleanup } from '@testing-library/react';
+import { useCode } from './useCode';
+import type { ContentProps } from '../CodeHighlighter/types';
+import { CodeHighlighterContext } from '../CodeHighlighter/CodeHighlighterContext';
+import type { CodeHighlighterContextType } from '../CodeHighlighter/CodeHighlighterContext';
+import { CodeControllerContext } from '../CodeControllerContext/CodeControllerContext';
+import type { CodeControllerContext as CodeControllerContextType } from '../CodeControllerContext/CodeControllerContext';
+
+describe('useCode reset on expand/collapse', () => {
+  // jsdom in this runner does not expose `window.localStorage`; the preference
+  // hooks `useCode` mounts need it, so install an in-memory shim.
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+        setItem: vi.fn((key: string, value: string) => {
+          store[key] = value;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete store[key];
+        }),
+        clear: vi.fn(() => {
+          for (const key of Object.keys(store)) {
+            delete store[key];
+          }
+        }),
+        key: vi.fn(() => null),
+        length: 0,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  const contentProps: ContentProps<{}> = {
+    slug: 'reset-demo',
+    code: { Default: { fileName: 'demo.tsx', source: 'const value = 1;' } },
+  };
+
+  const editedVariant = { Default: { fileName: 'demo.tsx', source: 'const value = 2;' } };
+
+  function wrapper(
+    highlighter: Partial<CodeHighlighterContextType>,
+    controller: CodeControllerContextType,
+  ) {
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+      return React.createElement(
+        CodeControllerContext.Provider,
+        { value: controller },
+        React.createElement(
+          CodeHighlighterContext.Provider,
+          { value: highlighter as CodeHighlighterContextType },
+          children,
+        ),
+      );
+    };
+  }
+
+  function renderUseCode() {
+    const setCode = vi.fn();
+    const { result } = renderHook(() => useCode(contentProps), {
+      wrapper: wrapper({ setCode }, { code: editedVariant, setCode }),
+    });
+    return { setCode, result };
+  }
+
+  it('discards the projection edit when expanding', () => {
+    const { setCode, result } = renderUseCode();
+
+    act(() => {
+      result.current.expand();
+    });
+
+    expect(setCode).toHaveBeenCalledWith(null);
+    expect(result.current.expanded).toBe(true);
+  });
+
+  it('discards the edit when a controlled write expands the block', () => {
+    const { setCode, result } = renderUseCode();
+
+    act(() => {
+      result.current.setExpanded(true);
+    });
+
+    expect(setCode).toHaveBeenCalledWith(null);
+    expect(result.current.expanded).toBe(true);
+  });
+
+  it('does not reset when the block is already expanded', () => {
+    const { setCode, result } = renderUseCode();
+
+    act(() => {
+      result.current.setExpanded(true);
+    });
+    setCode.mockClear();
+
+    act(() => {
+      result.current.expand();
+      result.current.setExpanded(true);
+    });
+
+    expect(setCode).not.toHaveBeenCalled();
+  });
+
+  it('discards the complete-source edit when collapsing', () => {
+    const { setCode, result } = renderUseCode();
+
+    act(() => {
+      result.current.setExpanded(true);
+    });
+    setCode.mockClear();
+
+    act(() => {
+      result.current.setExpanded(false);
+    });
+
+    expect(setCode).toHaveBeenCalledWith(null);
+    expect(result.current.expanded).toBe(false);
+  });
+
+  it('does not reset when the block is already collapsed', () => {
+    const { setCode, result } = renderUseCode();
+
+    act(() => {
+      result.current.setExpanded(false);
+    });
+
+    expect(setCode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/docs-infra/src/useCode/useCode.ts
+++ b/packages/docs-infra/src/useCode/useCode.ts
@@ -551,7 +551,7 @@ export function useCode<T extends {} = {}>(
   // naturally waiting on in-flight swaps. `setExpanded` stays direct
   // so explicit controlled-state writes remain synchronous regardless
   // of swap phase.
-  const setExpanded = uiState.setExpanded;
+  const rawSetExpanded = uiState.setExpanded;
   const swapInFlight = transforming !== null || !!context?.deferHighlight;
   const [pendingExpand, setPendingExpand] = React.useState(false);
   // Keep the latest `onExpand` in a ref so the stable `expand` callback below
@@ -560,23 +560,55 @@ export function useCode<T extends {} = {}>(
   React.useLayoutEffect(() => {
     onExpandRef.current = onExpand;
   });
+  // Crossing the collapsed/expanded boundary discards controller-owned edits.
+  // A collapsed block is edited through a source projection covering only the
+  // visible slice, and the expanded view is edited against the complete source,
+  // so neither draft is meaningful in the other view.
+  const resetSource = sourceEditing.reset;
   const expand = React.useCallback(() => {
+    if (uiState.expanded) {
+      return;
+    }
     // Notify the host synchronously, while the block is still collapsed, so it
     // can capture the pre-expansion layout and engage a scroll anchor (the
     // expansion itself is deferred below via `pendingExpand`). This mirrors the
     // timing of clicking the expand toggle, where the host anchors the scroll
     // before the layout changes.
     onExpandRef.current?.();
+    resetSource?.();
     setPendingExpand(true);
-  }, []);
+  }, [uiState.expanded, resetSource]);
+  const collapse = React.useCallback(() => {
+    if (!uiState.expanded) {
+      return;
+    }
+    resetSource?.();
+    rawSetExpanded(false);
+  }, [uiState.expanded, resetSource, rawSetExpanded]);
+  // Controlled writes stay synchronous — unlike `expand()`, they don't queue
+  // behind an in-flight swap — but they cross the same boundary, so they
+  // discard the edit too.
+  const setExpanded = React.useCallback(
+    (nextExpanded: boolean) => {
+      if (!nextExpanded) {
+        collapse();
+        return;
+      }
+      if (!uiState.expanded) {
+        resetSource?.();
+      }
+      rawSetExpanded(true);
+    },
+    [collapse, uiState.expanded, resetSource, rawSetExpanded],
+  );
   React.useEffect(() => {
     if (pendingExpand && !swapInFlight) {
       /* eslint-disable react-hooks/set-state-in-effect -- intentional queue drain: commit deferred expand only after in-flight swaps settle (swapInFlight transitions false on a later render); see comment above re: flicker-avoidance and same-batch synchronous-expand semantics */
       setPendingExpand(false);
-      setExpanded(true);
+      rawSetExpanded(true);
       /* eslint-enable react-hooks/set-state-in-effect */
     }
-  }, [pendingExpand, swapInFlight, setExpanded]);
+  }, [pendingExpand, swapInFlight, rawSetExpanded]);
 
   // Partner variant whose per-file line counts feed `<Pre>`'s bridge
   // computation. `null` when no variant swap is in flight (the bridge
@@ -653,7 +685,6 @@ export function useCode<T extends {} = {}>(
 
   // Discard live edits when the reader switches language.
   const rawSelectTransform = transformManagement.selectTransform;
-  const resetSource = sourceEditing.reset;
   const hasControlledEdits = Boolean(controllerContext?.code);
   const selectTransform = React.useCallback(
     (transformName: string | null) => {


### PR DESCRIPTION
Eighth in the docs-infra migration stack, on top of #1781.

A collapsed block is edited through its source projection, which covers only the visible slice, while an expanded block is edited against the complete file. Neither draft is meaningful in the other view: carrying a projection edit into the expanded source shows the reader a partial edit of a file they can now see in full, and carrying a complete-source edit back into the collapsed view hides the lines it touched.

Expanding and collapsing now reset the controlled source first, the same way switching language already does. The selected variant, file, and transform are preserved, and nothing is discarded when the block is already in the state being asked for. Controlled `setExpanded` writes stay synchronous — unlike `expand()` they don't queue behind an in-flight swap — but cross the same boundary and reset too.

Gate: 5 new unit tests, 27 browser tests across chromium, firefox, and webkit, a clean typecheck, lint, and `docs:validate`.
