### PR TITLE
[code-infra] Migrate GitHub Actions to pnpm/setup

### DIFF
--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -21,16 +21,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up pnpm
-      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-    - name: Setup Node.js
-      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+    - name: Set up pnpm and Node.js
+      uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
       with:
-        node-version: ${{ inputs.node-version }}
-        # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-        cache: 'pnpm'
-        registry-url: 'https://registry.npmjs.org'
-        package-manager-cache: false
+        runtime: node@${{ inputs.node-version }}
+        cache: true
+        # Installed explicitly below with --frozen-lockfile.
+        install: false
     # Ensure npm 11.5.1 or later is installed
     - name: Update npm
       shell: bash

--- a/.github/workflows/ci-base.yml
+++ b/.github/workflows/ci-base.yml
@@ -28,21 +28,13 @@ jobs:
         with:
           # fetch all tags which are required for `pnpm release:changelog`
           fetch-depth: 0
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Use specific Node.js version
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: ${{ inputs.node-version != '' }}
+      - name: Set up pnpm and Node.js
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version: ${{ inputs.node-version }}
-      - name: Use Node.js version from repo
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: ${{ inputs.node-version == '' }}
-        with:
-          node-version-file: 'package.json'
-          # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-          cache: 'pnpm'
-      - run: pnpm install
+          # Without an explicit version, falls back to `devEngines.runtime`
+          # in the caller repo's package.json, then to Node LTS.
+          runtime: ${{ inputs.node-version != '' && format('node@{0}', inputs.node-version) || 'node' }}
+          cache: true
       - run: pnpm release:build
       - name: Publish packages to pkg.pr.new
         uses: mui/mui-public/.github/actions/ci-publish@487b5aad17ff4335a4863ac74b0e08e501947184 # master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,11 @@ jobs:
         with:
           # fetch all tags which are required for `pnpm release:changelog`
           fetch-depth: 0
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Use Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      - name: Set up pnpm and Node.js
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version: '22.23.2'
-          cache: 'pnpm' # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
-      - run: pnpm install
+          runtime: node@22.23.2
+          cache: true
       - name: Cache Next.js build
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/dependabot-dedupe.yml
+++ b/.github/workflows/dependabot-dedupe.yml
@@ -36,12 +36,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-      - name: Set up Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2.0.2
         with:
-          node-version-file: 'package.json'
-          cache: 'pnpm'
+          cache: true
+          # `pnpm dedupe` below does its own install; skip the action's.
+          install: false
       # --ignore-scripts: don't run the bumped dependency's lifecycle scripts
       # just to rewrite the lockfile.
       - name: Run dedupe

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,19 @@
     "description": "Match the schedule above. Lock file maintenance defaults to its own Monday window, which would open the group PR a second time outside the weekly one.",
     "schedule": "* 5-9 * * 7"
   },
+  "customManagers": [
+    {
+      "description": "Custom manager for the default Node.js version of the publish-prepare action",
+      "customType": "regex",
+      "fileMatch": ["(^|/)\\.github/actions/publish-prepare/action\\.ya?ml$"],
+      "matchStrings": [
+        "node-version:\\s*\\n(?:[ \\t]+(?:description|required)[^\\n]*\\n)*[ \\t]+default:\\s*'(?<currentValue>[^']+)'"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
+    }
+  ],
   "packageRules": [
     {
       "description": "Skip major @mui/* updates in apps/tools-public — Toolpad Studio constrains peer deps and these PRs always fail.",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -98,6 +98,18 @@
       "depNameTemplate": "node",
       "datasourceTemplate": "node-version",
       "versioningTemplate": "node"
+    },
+    {
+      "description": "Custom manager for the Node.js version in pnpm/setup runtime inputs",
+      "customType": "regex",
+      "fileMatch": ["(^|/)\\.github/(workflows|actions)/.+\\.ya?ml$"],
+      "matchStrings": [
+        // Requires a digit after node@ so runtime expressions like node@${{ inputs.node-version }} are left alone.
+        "runtime:\\s*'?node@(?<currentValue>\\d[^'\\s]*)'?"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version",
+      "versioningTemplate": "node"
     }
   ],
   "vulnerabilityAlerts": {

--- a/renovate/experimental.json
+++ b/renovate/experimental.json
@@ -22,7 +22,7 @@
     },
     {
       "groupName": "GitHub Actions non-major",
-      "description": "Most action updates arrive as digest updates because of helpers:pinGitHubActionDigests. Matching the action depType leaves uses-with alone, so actions/setup-node's Node version stays in the node group.",
+      "description": "Most action updates arrive as digest updates because of helpers:pinGitHubActionDigests. Matching the action depType leaves uses-with alone, so Node versions in action inputs stay in the node group.",
       "matchManagers": ["github-actions"],
       "matchDepTypes": ["action"],
       "matchUpdateTypes": ["minor", "patch", "digest", "pin", "bump"],


### PR DESCRIPTION
Migrates all local workflows and composite actions from `pnpm/action-setup` + `actions/setup-node` to the new [`pnpm/setup`](https://github.com/pnpm/setup) action (v2.0.2, SHA-pinned).

`pnpm/setup@v2` installs pnpm's self-contained binary, installs Node.js via `pnpm runtime set` (replacing `actions/setup-node`), caches the pnpm store, and runs `pnpm install` automatically — so each setup site collapses into a single step.

## Changes

- **ci.yml**: single setup step with `runtime: node@22.23.2`; drops the explicit `pnpm install` (auto-install covers it).
- **ci-base.yml** (reusable workflow): the two conditional `setup-node` steps become one expression — `node@<input>` when `node-version` is passed, bare `node` otherwise. Input contract unchanged, callers need no edits.
- **dependabot-dedupe.yml**: `install: false` so auto-install doesn't run the bumped dependency's lifecycle scripts; no Node runtime needed since the job only runs `pnpm dedupe` and git.
- **publish-prepare/action.yml** (composite action): `install: false` to keep the explicit `pnpm install --frozen-lockfile`. Dropping `setup-node` also drops `registry-url`, which is safe because publishing uses npm OIDC trusted publishing and npm's default registry is already `registry.npmjs.org`.

## Behavior changes for downstream repos

1. `pnpm/setup` doesn't read `engines.node`. Callers of `ci-base.yml` that omit `node-version` now fall back to `devEngines.runtime` in their `package.json`, then Node LTS (previously `engines.node`).

