### PR TITLE
[docs-infra] Collect shared test utils in a package test/ folder

### DIFF
--- a/packages/docs-infra/src/useCode/useTransformManagement.test.ts
+++ b/packages/docs-infra/src/useCode/useTransformManagement.test.ts
@@ -16,7 +16,7 @@ import {
   registerPeer as registerCoordinatedPeer,
   announceTarget as announceCoordinatedTarget,
 } from '../useCoordinated/coordinatePreference';
-import { resetCoordinatorsForTests as resetCoordinatedForTests } from '../useCoordinated/coordinatePreference.testUtils';
+import { resetCoordinatorsForTests as resetCoordinatedForTests } from '../../test/coordinatePreference';
 
 /**
  * Test-only bridge: register a phantom peer on the new coordination

--- a/packages/docs-infra/src/useCoordinated/coordinatePreference.test.ts
+++ b/packages/docs-infra/src/useCoordinated/coordinatePreference.test.ts
@@ -12,7 +12,7 @@ import {
 import {
   resetCoordinatorsForTests,
   getCoordinatorStatsForTests,
-} from './coordinatePreference.testUtils';
+} from '../../test/coordinatePreference';
 import {
   registerLayoutShiftSource,
   whenLayoutShiftsSettled,

--- a/packages/docs-infra/src/useCoordinated/coordinatePreference.ts
+++ b/packages/docs-infra/src/useCoordinated/coordinatePreference.ts
@@ -422,8 +422,8 @@ let encodeTargetImpl: (value: unknown) => string = (value) => {
 
 /**
  * Set a custom target encoder. Returns a function that restores the
- * previous encoder. Intended for tests; consumed via
- * `coordinatePreference.testUtils`.
+ * previous encoder. Intended for tests; consumed via the test helpers
+ * in `test/coordinatePreference`.
  */
 function setTargetEncoder(impl: (value: unknown) => string): () => void {
   const previous = encodeTargetImpl;
@@ -1332,12 +1332,12 @@ export function getBarrierAnnounceTime<TValue>(
 }
 
 /**
- * Internal handles for the `coordinatePreference.testUtils` sibling.
+ * Internal handles for the `test/coordinatePreference` test helpers.
  *
  * Not part of the public API. Do not import this from production
- * code or from tests directly — use the helpers re-exported from
- * `./coordinatePreference.testUtils` instead so that the boundary
- * between runtime API and test affordances stays clear.
+ * code or from tests directly — use the helpers exported from
+ * `test/coordinatePreference` instead so that the boundary between
+ * runtime API and test affordances stays clear.
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention, no-underscore-dangle -- intentional sentinel name marking this as a test-only sibling import
 export const __testInternals = {

--- a/packages/docs-infra/src/useCoordinated/useCoordinated.test.tsx
+++ b/packages/docs-infra/src/useCoordinated/useCoordinated.test.tsx
@@ -8,7 +8,7 @@ import { useCoordinated } from './useCoordinated';
 import {
   resetCoordinatorsForTests,
   getCoordinatorStatsForTests,
-} from './coordinatePreference.testUtils';
+} from '../../test/coordinatePreference';
 import { registerLayoutShiftSource, resetLayoutShiftGate } from './layoutShiftGate';
 
 afterEach(() => {

--- a/packages/docs-infra/test/coordinatePreference.ts
+++ b/packages/docs-infra/test/coordinatePreference.ts
@@ -1,17 +1,17 @@
 /**
- * Test-only affordances for `coordinatePreference`. Kept in a sibling
- * file so the production module's public surface (`registerPeer`,
- * `announceTarget`, `reportValue`, `hasEverAnnounced`,
- * `getBarrierAnnounceTime`) stays free of helpers that should never
- * be reachable from runtime code or re-exported from the package
- * entry.
+ * Test-only affordances for `coordinatePreference`. Kept in the package's
+ * `test/` folder, outside `src/`, so the production module's public surface
+ * (`registerPeer`, `announceTarget`, `reportValue`, `hasEverAnnounced`,
+ * `getBarrierAnnounceTime`) stays free of helpers that should never be
+ * reachable from runtime code — and so these never reach the published build,
+ * which only compiles `src/`.
  *
  * The implementation here reaches into `__testInternals` from
- * `coordinatePreference.ts`. That export is the only sanctioned
- * channel into module-private state and is marked `__`-prefixed so
- * accidental imports are obvious in code review.
+ * `coordinatePreference.ts`. That export is the only sanctioned channel into
+ * module-private state and is marked `__`-prefixed so accidental imports are
+ * obvious in code review.
  */
-import { __testInternals } from './coordinatePreference';
+import { __testInternals } from '../src/useCoordinated/coordinatePreference';
 
 const { channels, setTargetEncoder } = __testInternals;
 

--- a/packages/docs-infra/tsconfig.build.json
+++ b/packages/docs-infra/tsconfig.build.json
@@ -11,5 +11,9 @@
     "outDir": "build/esm",
     "paths": {}
   },
+  // Only src ships: the declaration build stays anchored to rootDir "./src",
+  // leaving the package's test/ helpers (added to tsconfig.json's include for
+  // type-checking) out of the emitted output.
+  "include": ["src"],
   "exclude": ["**/*.spec.*", "**/*.test.*"]
 }

--- a/packages/docs-infra/tsconfig.json
+++ b/packages/docs-infra/tsconfig.json
@@ -9,5 +9,5 @@
     "resolveJsonModule": true,
     "types": ["react", "node"]
   },
-  "include": ["src"]
+  "include": ["src", "test"]
 }


### PR DESCRIPTION
Shared test-only helpers had no home the build reliably ignores — `coordinatePreference.testUtils.ts` was compiled and published as dead code, since neither the `.test.`/`.spec.` build excludes nor tsgo matched a `.testUtils.ts` suffix.

Move it to `packages/docs-infra/test/`, a sibling of `src/`. The build only compiles `src/` (`rootDir: ./src`), so anything under `test/` is structurally outside the published output — no naming suffix to remember, no way to leak. `tsconfig.json` includes `test/` for type-checking; `tsconfig.build.json` pins its own include back to `src/` so declaration emit stays anchored to the rootDir.