### PR TITLE
[docs-infra] Add appRoute helper for demo e2e tests

### DIFF
--- a/docs/app/docs-infra/components/code-controller-context/demos/code-editor/test.ts
+++ b/docs/app/docs-infra/components/code-controller-context/demos/code-editor/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('code-editor re-renders the source after an edit', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-controller-context/demos/editable-toggle/test.ts
+++ b/docs/app/docs-infra/components/code-controller-context/demos/editable-toggle/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('editable-toggle starts read-only and edits after clicking Edit', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-controller-context/demos/multi-file/test.ts
+++ b/docs/app/docs-infra/components/code-controller-context/demos/multi-file/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('multi-file switches files and re-parses an edit to the second file', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/code-basic/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/code-basic/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('code-basic renders the highlighted source', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/code-highlight-init/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/code-highlight-init/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('code-highlight-init renders the source (highlight deferred to init)', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/code-transformed-addition/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/code-transformed-addition/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('code-transformed-addition renders the example source', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/code-transformed/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/code-transformed/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('code-transformed applies the TypeScript to JavaScript transform', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-files/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-files/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('demo-fallback-all-files renders the multi-file content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-variants/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback-all-variants/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('demo-fallback-all-variants swaps variants without a decode error', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-fallback/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('demo-fallback swaps the fallback for the highlighted content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-server-loaded/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-server-loaded/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('demo-server-loaded renders the server-loaded source', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo-variants/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo-variants/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('demo-variants swaps between variants', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-highlighter/demos/demo/test.ts
+++ b/docs/app/docs-infra/components/code-highlighter/demos/demo/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('demo renders the highlighted source and live component', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-provider/demos/base/test.ts
+++ b/docs/app/docs-infra/components/code-provider/demos/base/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('base renders the provided source', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-provider/demos/fetch-demo-recursive/test.ts
+++ b/docs/app/docs-infra/components/code-provider/demos/fetch-demo-recursive/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('fetch-demo-recursive renders recursively-fetched source', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/code-provider/demos/fetch-demo/test.ts
+++ b/docs/app/docs-infra/components/code-provider/demos/fetch-demo/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('fetch-demo renders source fetched from GitHub at runtime', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/coordinated-lazy/demos/compressed/test.ts
+++ b/docs/app/docs-infra/components/coordinated-lazy/demos/compressed/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('coordinated-lazy/compressed renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/coordinated-lazy/demos/initial-detailed/test.ts
+++ b/docs/app/docs-infra/components/coordinated-lazy/demos/initial-detailed/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('initial-detailed swaps the low-res preview for the detailed line', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/components/coordinated-lazy/demos/lazy-content/test.ts
+++ b/docs/app/docs-infra/components/coordinated-lazy/demos/lazy-content/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('lazy-content loads the widget on demand', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapse-to-empty/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapse-to-empty/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/collapse-to-empty renders a collapsed-to-empty block', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-code/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-code/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/collapsible-code renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-demo/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-demo/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/collapsible-demo renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-editor/test.ts
@@ -1,12 +1,9 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 /**
  * Caret state read straight from the live Selection — the source of truth the

--- a/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-transform/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/collapsible-transform/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/collapsible-transform renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/focus-code/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/focus-code/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/focus-code renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/indent-code/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/indent-code/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/indent-code renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/max-size-code/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/max-size-code/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/max-size-code renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-code-window/demos/snippet/test.ts
+++ b/docs/app/docs-infra/hooks/use-code-window/demos/snippet/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-code-window/snippet renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-coordinated/demos/anchor-pairing/test.ts
+++ b/docs/app/docs-infra/hooks/use-coordinated/demos/anchor-pairing/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-coordinated/anchor-pairing renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-coordinated/demos/cascading-loads/test.ts
+++ b/docs/app/docs-infra/hooks/use-coordinated/demos/cascading-loads/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-coordinated/cascading-loads renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-coordinated/demos/conditional-shift/test.ts
+++ b/docs/app/docs-infra/hooks/use-coordinated/demos/conditional-shift/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-coordinated/conditional-shift renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-coordinated/demos/cpu-bound/test.ts
+++ b/docs/app/docs-infra/hooks/use-coordinated/demos/cpu-bound/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-coordinated/cpu-bound renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-copier/demos/text-input-copy/test.ts
+++ b/docs/app/docs-infra/hooks/use-copier/demos/text-input-copy/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-copier/text-input-copy renders the copy control', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-demo-controller/demos/demo-live/test.ts
+++ b/docs/app/docs-infra/hooks/use-demo-controller/demos/demo-live/test.ts
@@ -1,12 +1,9 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 /**
  * Opens the demo, waits for the live preview, and warms the lazy editing engine +

--- a/docs/app/docs-infra/hooks/use-preference/demos/variant-selector/test.ts
+++ b/docs/app/docs-infra/hooks/use-preference/demos/variant-selector/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-preference/variant-selector renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-scroll-anchor/demos/chat/test.ts
+++ b/docs/app/docs-infra/hooks/use-scroll-anchor/demos/chat/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-scroll-anchor/chat renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-scroll-anchor/demos/comparison/test.ts
+++ b/docs/app/docs-infra/hooks/use-scroll-anchor/demos/comparison/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-scroll-anchor/comparison renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-scroll-anchor/demos/safari/test.ts
+++ b/docs/app/docs-infra/hooks/use-scroll-anchor/demos/safari/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-scroll-anchor/safari renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/detail-sweep/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/detail-sweep/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/detail-sweep renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/live-metrics/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/live-metrics/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/live-metrics renders its visualization', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/live-waveform/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/live-waveform/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/live-waveform renders its visualization', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/stream-sweep/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/stream-sweep/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/stream-sweep renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/streaming-bars/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/streaming-bars/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/streaming-bars renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/streaming-chart/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/streaming-chart/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/streaming-chart renders its visualization', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-stream/demos/streaming-code/test.ts
+++ b/docs/app/docs-infra/hooks/use-stream/demos/streaming-code/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-stream/streaming-code streams its source', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/basic/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/basic/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/basic renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/blocks-data-attr/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/blocks-data-attr/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/blocks-data-attr renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/blocks-inherited/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/blocks-inherited/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/blocks-inherited renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/blocks/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/blocks/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/blocks renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/class/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/class/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/class renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/data-attr/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/data-attr/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/data-attr renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/function/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/function/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/function renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-types/demos/hook/test.ts
+++ b/docs/app/docs-infra/hooks/use-types/demos/hook/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-types/hook renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/app/docs-infra/hooks/use-url-hash-state/demos/tab-navigation/test.ts
+++ b/docs/app/docs-infra/hooks/use-url-hash-state/demos/tab-navigation/test.ts
@@ -1,11 +1,8 @@
-import path from 'node:path';
 import { test, expect } from '@playwright/test';
+import { appRoute } from '@/appRoute';
 
 // The standalone demo route, derived from this file's location under `app`.
-const route = path
-  .dirname(import.meta.filename)
-  .split('/app')
-  .pop()!;
+const route = appRoute(import.meta.url);
 
 test('use-url-hash-state/tab-navigation renders its content', async ({ page }) => {
   const pageErrors: Error[] = [];

--- a/docs/appRoute.ts
+++ b/docs/appRoute.ts
@@ -1,0 +1,28 @@
+// This module lives at the docs root, so the Next.js app-router root is its `app` directory.
+// The route is derived by resolving a demo file against this captured root — not by searching the
+// path for an `app` segment — so a route segment that is itself named `app` stays correct.
+//
+// It is kept self-contained (no `@mui/internal-docs-infra` import) on purpose: Playwright loads
+// these test files with its own transpiler, which cannot resolve the workspace package's exports.
+const APP_ROOT = new URL('./app/', import.meta.url).pathname;
+
+/**
+ * The public URL route of a demo, derived from the demo file's `import.meta.url`.
+ *
+ * The route is the file's containing directory relative to the app root, with Next.js route-group
+ * segments (`(group)`) removed — those organize files without appearing in the URL. A file
+ * directly in the app root resolves to `/`.
+ */
+export function appRoute(fileUrl: string): string {
+  const dir = new URL('.', fileUrl).pathname;
+  if (!dir.startsWith(APP_ROOT)) {
+    throw new Error(`appRoute: "${fileUrl}" is not inside the app root "${APP_ROOT}".`);
+  }
+
+  const segments = dir
+    .slice(APP_ROOT.length)
+    .split('/')
+    .filter((segment) => segment && !(segment.startsWith('(') && segment.endsWith(')')));
+
+  return segments.length > 0 ? `/${segments.join('/')}` : '/';
+}


### PR DESCRIPTION
Replaces the hand-rolled `path.dirname(import.meta.filename).split('/app').pop()!` across 54 demo Playwright tests with a single `appRoute(import.meta.url)`.