### PR TITLE
[docs-infra] Bump typescript-api-extractor to 1.0.0-beta.6

### DIFF
--- a/docs/app/docs-infra/components/coordinated-lazy/types.md
+++ b/docs/app/docs-infra/components/coordinated-lazy/types.md
@@ -262,7 +262,7 @@ also call it directly for a custom chunk renderer.
 | Parameter | Type                            | Default | Description |
 | :-------- | :------------------------------ | :------ | :---------- |
 | config    | `CreateChunkConfig<{}, P, O>`   | -       | -           |
-| props     | `ChunkComponentProps<{}, P, O>` | -       | -           |
+| props     | `ChunkComponentProps<{}, P, O>` | `{}`    | -           |
 
 **useChunk Return Value:**
 

--- a/docs/app/docs-infra/factories/abstract-create-types/types.md
+++ b/docs/app/docs-infra/factories/abstract-create-types/types.md
@@ -107,14 +107,14 @@ type AbstractCreateTypesOptions<T extends {} = {}> = {
    * Defaults to `[enhanceCodeInline]` when undefined.
    * Pass an empty array to disable all enhancers.
    */
-  enhancers?: Pluggable[];
+  enhancers?: PluggableList;
   /**
    * Rehype plugins to run on inline HAST fields (shortType and default).
    * Can be overridden by TypesTableMeta.enhancersInline.
    * Defaults to `[enhanceCodeInline]` when undefined.
    * Pass an empty array to disable all inline enhancers.
    */
-  enhancersInline?: Pluggable[];
+  enhancersInline?: PluggableList;
   /**
    * Custom component tag name to use instead of `<a>` for type reference links.
    * When set, enhanceCodeTypes emits elements with this tag name,
@@ -283,14 +283,14 @@ type TypesTableMeta = {
    * Defaults to `[enhanceCodeInline]` when undefined.
    * Pass an empty array to disable all enhancers.
    */
-  enhancers?: Pluggable[];
+  enhancers?: PluggableList;
   /**
    * Rehype plugins to run on inline HAST fields (shortType and default).
    * If set, completely overrides enhancersInline from AbstractCreateTypesOptions.
    * Defaults to `[enhanceCodeInline]` when undefined.
    * Pass an empty array to disable all inline enhancers.
    */
-  enhancersInline?: Pluggable[];
+  enhancersInline?: PluggableList;
   /**
    * Controls when expensive detailedType and formattedCode HAST fields are
    * converted to fully-highlighted JSX.

--- a/docs/app/docs-infra/hooks/use-code-window/types.md
+++ b/docs/app/docs-infra/hooks/use-code-window/types.md
@@ -40,7 +40,7 @@ with any highlighter that marks frames with data attributes.
 
 | Parameter | Type                   | Default | Description |
 | :-------- | :--------------------- | :------ | :---------- |
-| options   | `UseCodeWindowOptions` | -       | -           |
+| options   | `UseCodeWindowOptions` | `{}`    | -           |
 
 **useCodeWindow Return Value:**
 

--- a/docs/app/docs-infra/hooks/use-coordinated/types.md
+++ b/docs/app/docs-infra/hooks/use-coordinated/types.md
@@ -19,7 +19,7 @@ reason).
 
 | Parameter | Type                      | Default | Description |
 | :-------- | :------------------------ | :------ | :---------- |
-| options?  | `CreateSettleGateOptions` | -       | -           |
+| options?  | `CreateSettleGateOptions` | `{}`    | -           |
 
 **Return Value:**
 
@@ -192,10 +192,10 @@ absent).
 
 **useSettleGate Parameters:**
 
-| Parameter | Type                 | Default | Description |
-| :-------- | :------------------- | :------ | :---------- |
-| settled   | `boolean`            | -       | -           |
-| gate      | `SettleGate \| null` | -       | -           |
+| Parameter | Type                 | Default          | Description |
+| :-------- | :------------------- | :--------------- | :---------- |
+| settled   | `boolean`            | -                | -           |
+| gate      | `SettleGate \| null` | `pageSettleGate` | -           |
 
 **useSettleGate Return Value:**
 

--- a/docs/app/docs-infra/hooks/use-demo/types.md
+++ b/docs/app/docs-infra/hooks/use-demo/types.md
@@ -90,7 +90,7 @@ Export a variant as a standalone project with metadata files properly scoped
 | Parameter   | Type           | Default | Description |
 | :---------- | :------------- | :------ | :---------- |
 | variantCode | `VariantCode`  | -       | -           |
-| config?     | `ExportConfig` | -       | -           |
+| config?     | `ExportConfig` | `{}`    | -           |
 
 **Return Value:**
 
@@ -109,7 +109,7 @@ Returns an object with the exported VariantCode and entrypoint path
 | Parameter   | Type                                                                    | Default | Description |
 | :---------- | :---------------------------------------------------------------------- | :------ | :---------- |
 | variantCode | `VariantCode`                                                           | -       | -           |
-| config?     | `Omit<ExportConfig, 'viteConfig' \| 'packageType' \| 'htmlSkipJsLink'>` | -       | -           |
+| config?     | `Omit<ExportConfig, 'viteConfig' \| 'packageType' \| 'htmlSkipJsLink'>` | `{}`    | -           |
 
 **Return Value:**
 

--- a/docs/app/docs-infra/hooks/use-local-storage-state/types.md
+++ b/docs/app/docs-infra/hooks/use-local-storage-state/types.md
@@ -11,7 +11,7 @@
 | Parameter    | Type                            | Default | Description                                                                                        |
 | :----------- | :------------------------------ | :------ | :------------------------------------------------------------------------------------------------- |
 | key          | `string \| null`                | -       | localStorage key. If null, persistence is disabled and&#xA;the hook behaves like regular useState. |
-| initializer? | `string \| Initializer \| null` | -       | Initial value or function returning initial value                                                  |
+| initializer? | `string \| Initializer \| null` | `null`  | Initial value or function returning initial value                                                  |
 
 **Return Value:**
 

--- a/docs/app/docs-infra/hooks/use-preference/types.md
+++ b/docs/app/docs-infra/hooks/use-preference/types.md
@@ -16,7 +16,7 @@ and automatic optimization for single-option scenarios.
 | :---------- | :----------------------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | type        | `'variant' \| 'transform'`                 | -       | Type of preference, affects the storage key prefix                                                                                                      |
 | name        | `string \| string[]`                       | -       | Variant/transform name(s). Arrays are sorted and joined to form the storage key.&#xA;Single-element arrays disable persistence (no choice to remember). |
-| initializer | `string \| (() => string \| null) \| null` | -       | Initial value or function returning initial value                                                                                                       |
+| initializer | `string \| (() => string \| null) \| null` | `null`  | Initial value or function returning initial value                                                                                                       |
 
 **usePreference Return Value:**
 

--- a/docs/app/docs-infra/hooks/use-stream/types.md
+++ b/docs/app/docs-infra/hooks/use-stream/types.md
@@ -77,7 +77,7 @@ commit all settle. Each chunk also registers with the page-global gate (via
 
 | Parameter | Type                         | Default | Description |
 | :-------- | :--------------------------- | :------ | :---------- |
-| options   | `UseStreamControllerOptions` | -       | -           |
+| options   | `UseStreamControllerOptions` | `{}`    | -           |
 
 **useStreamController Return Value:**
 

--- a/docs/app/docs-infra/pipeline/with-docs-infra/types.md
+++ b/docs/app/docs-infra/pipeline/with-docs-infra/types.md
@@ -12,7 +12,7 @@ Get default MDX options for docs-infra
 
 | Parameter      | Type                  | Default | Description |
 | :------------- | :-------------------- | :------ | :---------- |
-| customOptions? | `DocsInfraMdxOptions` | -       | -           |
+| customOptions? | `DocsInfraMdxOptions` | `{}`    | -           |
 
 **Return Value:**
 
@@ -44,7 +44,7 @@ Use getDocsInfraMdxOptions() with createMDX for MDX integration.
 
 | Parameter | Type                   | Default | Description |
 | :-------- | :--------------------- | :------ | :---------- |
-| options?  | `WithDocsInfraOptions` | -       | -           |
+| options?  | `WithDocsInfraOptions` | `{}`    | -           |
 
 **Return Value:**
 

--- a/packages/docs-infra/package.json
+++ b/packages/docs-infra/package.json
@@ -147,7 +147,7 @@
     "remark-stringify": "^11.0.0",
     "remark-typography": "^0.7.3",
     "sucrase": "^3.35.1",
-    "typescript-api-extractor": "1.0.0-beta.4",
+    "typescript-api-extractor": "1.0.0-beta.6",
     "uint8-to-base64": "^0.2.1",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,7 +632,7 @@ importers:
         version: 11.2.0
       es-toolkit:
         specifier: ^1.49.0
-        version: 1.49.0
+        version: 1.51.0
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
@@ -879,7 +879,7 @@ importers:
         version: 4.0.1
       es-toolkit:
         specifier: ^1.49.0
-        version: 1.49.0
+        version: 1.51.0
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -953,8 +953,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.3
       typescript-api-extractor:
-        specifier: 1.0.0-beta.4
-        version: 1.0.0-beta.4(typescript@6.0.3)
+        specifier: 1.0.0-beta.6
+        version: 1.0.0-beta.6
       uint8-to-base64:
         specifier: ^0.2.1
         version: 0.2.1
@@ -1082,7 +1082,7 @@ importers:
         version: 0.7.1
       es-toolkit:
         specifier: ^1.49.0
-        version: 1.49.0
+        version: 1.51.0
       format-util:
         specifier: ^1.0.5
         version: 1.0.5
@@ -6530,8 +6530,8 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
-  es-toolkit@1.49.0:
-    resolution: {integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==}
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
 
   es7-shim@6.0.0:
     resolution: {integrity: sha512-aiQ/QyJBVJbabtsSediM1S4qI+P3p8F5J5YR5o/bH003BCnnclzxK9pi5Qd2Hg01ktAtZCaQBdejHrkOBGwf5Q==}
@@ -10208,11 +10208,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  typescript-api-extractor@1.0.0-beta.4:
-    resolution: {integrity: sha512-tVSlm5uZ3/cIWe1Rjg0ehVa7VdbwFECHm6HHc9d+dyWmcDiuHGQXOKRYADFatc9tqgIPodZ4tvJJbCyYG807JQ==}
+  typescript-api-extractor@1.0.0-beta.6:
+    resolution: {integrity: sha512-l+JzdLi1e56mc4ARk8CdHdEsjzmqBNsyX67d+KwU2BprhXutdjNnhmaEeY0SSWh/RfuvSxNajLncILCL8vDozQ==}
     engines: {node: '>=22'}
-    peerDependencies:
-      typescript: ^5.8 || ^6.0
 
   typescript-eslint@8.65.0:
     resolution: {integrity: sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==}
@@ -16715,7 +16713,7 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
-  es-toolkit@1.49.0: {}
+  es-toolkit@1.51.0: {}
 
   es7-shim@6.0.0:
     dependencies:
@@ -21331,9 +21329,9 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-api-extractor@1.0.0-beta.4(typescript@6.0.3):
+  typescript-api-extractor@1.0.0-beta.6:
     dependencies:
-      es-toolkit: 1.49.0
+      es-toolkit: 1.51.0
       typescript: 6.0.3
 
   typescript-eslint@8.65.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):


### PR DESCRIPTION
`typescript-api-extractor` 1.0.0-beta.6 resolves default values for optional parameters that beta.4 left blank, and renders declared type aliases (`PluggableList`) instead of expanding them (`Pluggable[]`). Regenerating the affected `types.md` files is what makes `docs:validate` pass again — the diff is confined to the `Default` column plus those two alias renames.

This is split out of #1754 rather than committed onto it, since Renovate force-pushes its branches and would drop the commit. The regenerated markdown is only correct under beta.6, so the bump ships with it to keep master self-consistent; #1754 goes green once it rebases on top.
