### PR TITLE
[frontend-public] Fix HiBob main team name

### DIFF
--- a/apps/code-infra-dashboard/app/api/mui-about/route.ts
+++ b/apps/code-infra-dashboard/app/api/mui-about/route.ts
@@ -144,8 +144,11 @@ export async function GET() {
       if (teams.includes('X')) {
         team = 'X';
       }
-      if (teams.includes('MUI')) {
-        team = 'MUI';
+
+      // We use the Root level team to not show any specific team.
+      // It's for cases where the person title is enough to communicate where the focus is.
+      if (teams.includes('Root level')) {
+        team = 'Root level';
       }
       const location = city === country ? city : `${customCity ?? city}, ${country}`;
 
@@ -156,7 +159,7 @@ export async function GET() {
 
       return {
         name: employee.displayName,
-        title: team === 'MUI' ? title : `${title} — ${team}`,
+        title: team === 'Root level' ? title : `${title} — ${team}`,
         about: employee.about?.custom?.field_1690557141686 ?? null,
         location,
         locationCountry: countryToISO[country] ?? null,


### PR DESCRIPTION
Some cleanup, as we can't use "MUI" anymore for the top-level company team. MUI is being repurposed for the library (replaces Material UI), and the company will need to find a different name, so we can already start to anticipate this change.