### PR TITLE
[code-infra] Use installed CLI for version overrides

### DIFF
--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -74,45 +74,13 @@ commands:
                   done
 
                   args="${filtered# }"
+                  # Install from the repository lockfile before running code-infra.
+                  # Using the installed binary avoids a separate `pnpm dlx`
+                  # dependency graph that can diverge from the trusted lockfile.
+                  pnpm install
+
                   if [ -n "$args" ]; then
-                    # Resolve code-infra from the lockfile instead of using the
-                    # floating `@canary` tag.
-                    manifest="$(pnpm ls @mui/internal-code-infra --filter . --json --depth 0 --lockfile-only)"
-                    code_infra_version="$(node -p '
-                      const [project] = JSON.parse(process.argv[1]);
-                      ({ ...project?.dependencies, ...project?.devDependencies })["@mui/internal-code-infra"]?.version ?? ""
-                    ' "$manifest")"
-
-                    if [[ -z "$code_infra_version" || "$code_infra_version" == "null" ]]; then
-                      echo "Could not resolve @mui/internal-code-infra from the lockfile"
-                      exit 1
-                    fi
-
-                    if [[ "$code_infra_version" == link:* ]]; then
-                      # Install dependencies before using the local CLI. This is
-                      # slower, but allows repositories that own code-infra to
-                      # test changes to it from the current branch.
-                      pnpm install
-                      pnpm code-infra set-version-overrides --pkg $args
-                      exit 0
-                    fi
-
-                    # `pnpm dlx` installs code-infra into an isolated temp dir
-                    # outside the workspace, so it can't see this repo's
-                    # pnpm-workspace.yaml and runs with pnpm 11's strict build
-                    # defaults. With a cold store it must build transitive deps
-                    # that have install scripts (e.g. sharp, unrs-resolver), and
-                    # because CircleCI runs steps under a TTY it drops into the
-                    # interactive "Choose which packages to build" picker and
-                    # hangs until the idle timeout. `--config.strict-dep-builds=false`
-                    # only downgrades the hard error to a warning; the picker is
-                    # gated on stdin being a TTY, so we also redirect stdin from
-                    # /dev/null to force non-interactive (warn + skip). code-infra
-                    # only needs `pnpm info`/`pnpm dedupe`, so skipped dependency
-                    # build scripts are irrelevant.
-                    pnpm dlx --config.strict-dep-builds=false "@mui/internal-code-infra@$code_infra_version" set-version-overrides --pkg $args < /dev/null
-                  else
-                    pnpm install
+                    pnpm code-infra set-version-overrides --pkg $args
                   fi
   eslint:
     description: 'Runs ESLint on the codebase'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Always reference these instructions first and fallback to search or bash command
 
 ### Bootstrap, Build, and Test the Repository
 
-- **Prerequisites**: Node.js 22.22.3+ required. Install pnpm: `npm install -g pnpm@11.1.2`
+- **Prerequisites**: Node.js 22.23.2+ required. Install pnpm: `npm install -g pnpm@11.22.0`
 - **Install dependencies**: `pnpm install --no-frozen-lockfile` -- takes 15-20 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Build all packages**: `pnpm release:build` -- takes 5-10 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.
 - **Type checking**: `pnpm typescript` -- takes 10-15 seconds. **NEVER CANCEL**. Set timeout to 30+ minutes.


### PR DESCRIPTION
## Summary

- install workspace dependencies from the committed lockfile before applying version overrides
- run the lockfile-installed `code-infra` binary instead of creating a separate `pnpm dlx` dependency graph
- avoid trust-policy failures caused by newly resolved `dlx` transitive dependencies
- align the documented Node.js and pnpm prerequisites with `package.json`

## Validation

- Base UI React 18 smoke test: `pnpm install` followed by `pnpm code-infra set-version-overrides --pkg react@18`

### Base UI React 18 CircleCI timing

Compared the latest successful React 18 workflow on `master` with [Base UI PR #5565](https://github.com/mui/base-ui/pull/5565). Values in each cell are **master → PR**.

| Job | Install dependencies | Total job time |
| --- | ---: | ---: |
| [Typechecking](https://circleci.com/gh/mui/base-ui/357218) | 62.8s → 89.4s (**+26.7s / +42.5%**) | 86.9s → 112.6s (**+25.7s / +29.5%**) |
| [JSDOM](https://circleci.com/gh/mui/base-ui/357217) | 82.5s → 56.5s (**-26.0s / -31.5%**) | 262.2s → 225.2s (**-36.9s / -14.1%**) |
| [Browser](https://circleci.com/gh/mui/base-ui/357216) | 70.4s → 59.4s (**-11.0s / -15.7%**) | 199.8s → 171.2s (**-28.6s / -14.3%**) |
| **Combined** | **215.6s → 205.3s (-10.3s / -4.8%)** | **548.9s → 509.0s (-39.8s / -7.3%)** |

The complete workflow wall time decreased from **4m25s to 3m48s**, a **37s (14.0%) reduction**.

All three PR jobs started with cold pnpm stores (`reused 0`), so Typechecking did not miss a dependency cache that the other jobs hit. Its lockfile-policy verification took **36.1s** and logged **17 registry requests exceeding 10s**, compared with **23.1s / 0 slow requests** for JSDOM and **24.5s / 0 slow requests** for Browser. The TypeScript test itself changed only from **11.6s to 13.0s**. This indicates that the isolated Typechecking increase was npm registry/network variance rather than a caching difference or a meaningful execution regression. As this is a single-run comparison, individual job timings remain sensitive to network conditions.