### PR TITLE
[ci] Claude review: authenticate the PR head fetch so private repos work

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -191,19 +191,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # The checkout above keeps no credentials, so the agent can never read a token
-          # out of .git/config. A private repo still needs one to fetch, so supply it per
-          # command with `-c`: nothing is written to the config, and the helper reads the
-          # token from the environment so it never appears in argv either.
-          fetch() {
-            git -c credential.helper= \
-              -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
-              fetch --no-tags origin "$1"
-          }
-          fetch "pull/${PR_NUMBER}/head"
-          HEAD_SHA="$(git rev-parse FETCH_HEAD)"
-          fetch "$BASE_REF"
-          BASE_SHA="$(git merge-base FETCH_HEAD "$HEAD_SHA")"
+          # The checkout above keeps no credentials, so this fetch has none of its own and
+          # a private repo rejects it. The token goes in per command via `-c` rather than
+          # into `.git/config`, which is shared with the pr-head worktree and outlives this
+          # step. That is hygiene, not confinement: the same `github.token` is handed to the
+          # agent below so it can run `gh pr view`.
+          git -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+            fetch --no-tags origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/claude/pr-head" \
+            "+refs/heads/${BASE_REF}:refs/claude/base"
+          HEAD_SHA="$(git rev-parse refs/claude/pr-head)"
+          BASE_SHA="$(git merge-base refs/claude/base "$HEAD_SHA")"
           git worktree add --detach pr-head "$HEAD_SHA"
 
           {

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -188,11 +188,21 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
           BASE_REF: ${{ steps.progress.outputs.base_ref }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "pull/${PR_NUMBER}/head"
+          # The checkout above keeps no credentials, so the agent can never read a token
+          # out of .git/config. A private repo still needs one to fetch, so supply it per
+          # command with `-c`: nothing is written to the config, and the helper reads the
+          # token from the environment so it never appears in argv either.
+          fetch() {
+            git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f' \
+              fetch --no-tags origin "$1"
+          }
+          fetch "pull/${PR_NUMBER}/head"
           HEAD_SHA="$(git rev-parse FETCH_HEAD)"
-          git fetch --no-tags origin "$BASE_REF"
+          fetch "$BASE_REF"
           BASE_SHA="$(git merge-base FETCH_HEAD "$HEAD_SHA")"
           git worktree add --detach pr-head "$HEAD_SHA"
 


### PR DESCRIPTION
The `Fetch the PR head` step ran `git fetch` with no credentials, because the checkout above it deliberately keeps none. Anonymous fetches work on public repos, so this only broke on private callers: the first run on base-ui-plus died with `fatal: could not read Username for 'https://github.com'` before Claude ever started (mui/base-ui-plus#194).

The token now comes from a per-command credential helper, so nothing lands in `.git/config` for the agent to read later, and the token never appears in argv either. Verified against a real private-repo PR head fetch. Prerequisite for mui/mui-public#1814 since base-ui charts and mosaic are private too.
