### PR TITLE
[ci] Fix the stale Node pin that broke publishing

### DIFF
--- a/.github/actions/publish-prepare/action.yml
+++ b/.github/actions/publish-prepare/action.yml
@@ -5,8 +5,7 @@ description: Common setup steps for publishing MUI packages (after checkout)
 inputs:
   node-version:
     description: 'Node.js version to set up.'
-    required: false
-    default: '22.22.3'
+    required: true
   scope-alias:
     description: >
       An npm scope mapping written as "@from:@to". The publishable workspace
@@ -21,6 +20,14 @@ inputs:
 runs:
   using: composite
   steps:
+    # Composite actions don't enforce required inputs, so an omitted version would
+    # otherwise fall through to whatever Node the runner happens to ship.
+    - name: Check inputs
+      if: inputs.node-version == ''
+      shell: bash
+      run: |
+        echo "::error::publish-prepare requires a node-version input."
+        exit 1
     - name: Set up pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
     - name: Setup Node.js

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,8 @@ jobs:
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
         uses: ./.github/actions/publish-prepare
+        with:
+          node-version: '22.23.2'
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,6 +91,8 @@ jobs:
           fetch-depth: 0 # Fetch full history for proper git operations
       - name: Prepare for publishing
         uses: ./.github/actions/publish-prepare
+        with:
+          node-version: '22.23.2'
       - name: Publish packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -90,9 +90,11 @@
       "fileMatch": ["(^|/)\\.github/workflows/.+\\.ya?ml$"],
       "matchStringsStrategy": "recursive",
       "matchStrings": [
-        // Scoped to publish-prepare so actions/setup-node inputs stay with the built-in github-actions manager.
+        // Scoped to publish-prepare so actions/setup-node inputs stay with the built-in github-actions
+        // manager. Both call forms: the local "./" path mui-public itself uses, and the pinned
+        // "mui/mui-public/...@<ref>" form consumer repos use. The local form has no "@<ref>" suffix.
         // Renovate compiles these with RE2, so no look-around: intervening lines may not start with "-", which ends the match at the next step.
-        "uses: mui/mui-public/\\.github/actions/publish-prepare@[^\\n]+\\n(?:[ \\t]*(?:[^-\\s\\n][^\\n]*)?\\n)*?[ \\t]*node-version:\\s*'?[^'\\s]+'?",
+        "uses: (?:\\./|mui/mui-public/)\\.github/actions/publish-prepare[^\\n]*\\n(?:[ \\t]*(?:[^-\\s\\n][^\\n]*)?\\n)*?[ \\t]*node-version:\\s*'?[^'\\s]+'?",
         "node-version:\\s*'?(?<currentValue>[^'\\s]+)'?"
       ],
       "depNameTemplate": "node",


### PR DESCRIPTION
`publish-prepare`'s `node-version` default sat at `22.22.3` while #1754 raised `engines.node` to `>=22.23.2`, so every publish run since Aug 21 dies on `ERR_PNPM_UNSUPPORTED_ENGINE`. Nothing tracked that default — the custom manager anchors on the pinned `mui/mui-public/...@<ref>` form, never mui-public's own local `./.github/actions/publish-prepare` call.

Pass `node-version` explicitly the way the seven consumer repos already do, and widen the manager to match the local form. The default is dropped for a fail-fast guard.
