### PR TITLE
[docs-infra] Stop pinning the types socket to `.next/docs-infra`

### DIFF
--- a/docs/app/docs-infra/pipeline/load-precomputed-types/page.mdx
+++ b/docs/app/docs-infra/pipeline/load-precomputed-types/page.mdx
@@ -160,7 +160,6 @@ config.module.rules.push({
       options: {
         performance: { logging: true, notableMs: 100 },
         formatting: { shortTypeUnionPrintWidth: 50, defaultValueUnionPrintWidth: 40 },
-        socketDir: '.next/docs-infra',
         codeBlockEmphasisOptions: { paddingFrameMaxSize: 12, focusFramesMaxSize: 40 },
         // Strip "Documentation: <url>" suffixes from descriptions
         descriptionReplacements: [

--- a/docs/app/docs-infra/pipeline/with-docs-infra/types.md
+++ b/docs/app/docs-infra/pipeline/with-docs-infra/types.md
@@ -283,7 +283,8 @@ type WithDocsInfraOptions = {
    * Directory rooting docs-infra's build caches and coordination state — relocate it (or point it
    * at a persistent cache) and everything under it moves together: the sha256-validated JSON caches
    * (`pages-index`, `types-text`, `types-enhanced`) and the index marker directories
-   * (`index-updates`, `types-index-updates`). The types socket dir (`.next/docs-infra`) is separate.
+   * (`index-updates`, `types-index-updates`). The IPC socket used to coordinate the type workers
+   * lives outside the project, in the system temp directory, and is unaffected by this option.
    * @default '.next/cache/docs-infra'
    */
   cacheDir?: string;

--- a/packages/docs-infra/src/withDocsInfra/withDocsInfra.test.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDocsInfra.test.ts
@@ -103,7 +103,6 @@ describe('withDocsInfra', () => {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance: {},
-                socketDir: '.next/docs-infra',
                 cacheDir: '.next/cache/docs-infra',
                 updateParentIndex: defaultUpdateParentIndex,
               },
@@ -161,7 +160,6 @@ describe('withDocsInfra', () => {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance: {},
-                socketDir: '.next/docs-infra',
                 cacheDir: '.next/cache/docs-infra',
                 updateParentIndex: defaultUpdateParentIndex,
               },
@@ -236,7 +234,6 @@ describe('withDocsInfra', () => {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance: {},
-                socketDir: '.next/docs-infra',
                 cacheDir: '.next/cache/docs-infra',
                 updateParentIndex: defaultUpdateParentIndex,
               },
@@ -304,7 +301,6 @@ describe('withDocsInfra', () => {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance: {},
-                socketDir: '.next/docs-infra',
                 cacheDir: '.next/cache/docs-infra',
                 updateParentIndex: defaultUpdateParentIndex,
               },
@@ -382,7 +378,6 @@ describe('withDocsInfra', () => {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
             options: {
               performance: {},
-              socketDir: '.next/docs-infra',
               cacheDir: '.next/cache/docs-infra',
               updateParentIndex: defaultUpdateParentIndex,
             },
@@ -607,7 +602,6 @@ describe('withDocsInfra', () => {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance: {},
-                socketDir: '.next/docs-infra',
                 cacheDir: '.next/cache/docs-infra',
                 updateParentIndex: defaultUpdateParentIndex,
               },
@@ -732,7 +726,6 @@ describe('withDocsInfra', () => {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance: performanceOptions,
-                socketDir: '.next/docs-infra',
                 cacheDir: '.next/cache/docs-infra',
                 updateParentIndex: defaultUpdateParentIndex,
               },
@@ -813,7 +806,6 @@ describe('withDocsInfra', () => {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
             options: {
               performance: performanceOptions,
-              socketDir: '.next/docs-infra',
               cacheDir: '.next/cache/docs-infra',
               updateParentIndex: defaultUpdateParentIndex,
             },
@@ -965,7 +957,6 @@ describe('withDocsInfra', () => {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
             options: {
               performance: {},
-              socketDir: '.next/docs-infra',
               cacheDir: '.next/cache/docs-infra',
               updateParentIndex: defaultUpdateParentIndex,
               codeBlockEmphasisOptions,
@@ -1015,7 +1006,6 @@ describe('withDocsInfra', () => {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
             options: {
               performance: {},
-              socketDir: '.next/docs-infra',
               cacheDir: '.next/cache/docs-infra',
               updateParentIndex: defaultUpdateParentIndex,
               codeBlockEmphasisOptions,
@@ -1170,7 +1160,6 @@ describe('withDocsInfra', () => {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
             options: {
               performance: {},
-              socketDir: '.next/docs-infra',
               cacheDir: '.next/cache/docs-infra',
               updateParentIndex: defaultUpdateParentIndex,
               ordering,

--- a/packages/docs-infra/src/withDocsInfra/withDocsInfra.ts
+++ b/packages/docs-infra/src/withDocsInfra/withDocsInfra.ts
@@ -198,7 +198,8 @@ export interface WithDocsInfraOptions {
    * Directory rooting docs-infra's build caches and coordination state — relocate it (or point it
    * at a persistent cache) and everything under it moves together: the sha256-validated JSON caches
    * (`pages-index`, `types-text`, `types-enhanced`) and the index marker directories
-   * (`index-updates`, `types-index-updates`). The types socket dir (`.next/docs-infra`) is separate.
+   * (`index-updates`, `types-index-updates`). The IPC socket used to coordinate the type workers
+   * lives outside the project, in the system temp directory, and is unaffected by this option.
    * @default '.next/cache/docs-infra'
    */
   cacheDir?: string;
@@ -468,7 +469,6 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
             loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
             options: {
               performance,
-              socketDir: '.next/docs-infra',
               updateParentIndex,
               cacheDir,
               ...(codeBlockEmphasisOptions
@@ -609,7 +609,6 @@ export function withDocsInfra(options: WithDocsInfraOptions = {}) {
               loader: '@mui/internal-docs-infra/pipeline/loadPrecomputedTypes',
               options: {
                 performance,
-                socketDir: '.next/docs-infra',
                 updateParentIndex,
                 cacheDir,
                 ...(codeBlockEmphasisOptions ? { codeBlockEmphasisOptions } : {}),


### PR DESCRIPTION
Type generation talks to a background worker over a socket file, and `withDocsInfra` puts that file inside the project at `.next/docs-infra`. macOS caps socket paths at 104 bytes (Linux 108), so once the checkout sits deep enough — a git worktree, a nested CI workspace — the path is too long, the socket is never created, and every worker waits 30 seconds for a file that will never appear. The run takes minutes, fails, and never mentions the length. Reported in mui/base-ui#5588; `pnpm docs:validate` here fails the same way from a worktree.

Dropping the setting puts the socket in the system temp directory instead, in a folder named after the project path. That stays short wherever the repo lives, and still keeps parallel checkouts apart. On Windows it's a straight bug fix: the current value names one pipe shared by every checkout on the machine.

From a worktree where the path was 113 bytes, `pnpm docs:validate` goes from failing to passing in ~22s. base-ui and three sibling repos set the same value by hand; a follow-up removes the option so they can drop it too.
