### PR TITLE
[code-infra] Ensure `pnpm` version from `packageManager` is being used

### DIFF
--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -85,7 +85,7 @@ commands:
       - run:
           name: Shim pnpm in node_modules/.bin
           # Tools that spawn `pnpm` the npm-run-path way (publint packing through tinyexec) rebuild PATH as:
-          # 1. every node_modules/.bin from the working directory upwards 
+          # 1. every node_modules/.bin from the working directory upwards
           # 2. the directory holding the Node binary
           # 3. the inherited PATH.
           #

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -82,6 +82,18 @@ commands:
                   if [ -n "$args" ]; then
                     pnpm code-infra set-version-overrides --pkg $args
                   fi
+      - run:
+          name: Shim pnpm in node_modules/.bin
+          # Tools that spawn `pnpm` the npm-run-path way (publint packing through tinyexec) rebuild PATH as:
+          # 1. every node_modules/.bin from the working directory upwards 
+          # 2. the directory holding the Node binary
+          # 3. the inherited PATH.
+          #
+          # cimg/node runs an unpinned `npm install -g pnpm`, so those tools reach that version ahead of the shims installed above.
+          # Corepack exports COREPACK_ROOT to everything it spawns, which stops pnpm from switching to the version in `packageManager`.
+          command: |
+            mkdir -p node_modules/.bin
+            corepack enable pnpm --install-directory node_modules/.bin
   eslint:
     description: 'Runs ESLint on the codebase'
     steps:


### PR DESCRIPTION
Issue in https://github.com/mui/base-ui-mosaic/pull/341
in package verification
https://app.circleci.com/pipelines/github/mui/base-ui-mosaic/3376/workflows/f8c52312-5826-47b4-9dd8-789d43e0fea7/jobs/47341

Tested it with
https://github.com/mui/base-ui-mosaic/pull/341/changes/6fbb4fdb16f20f09e911d8e404f221207606ea2e
(reverted afterwards)
The step passes
https://app.circleci.com/pipelines/github/mui/base-ui-mosaic/3378/workflows/fc1bac95-4a5b-4b17-b706-7404a137c5d8/jobs/47371