### PR TITLE
[docs-infra] Keep `keyof` over a built-in as written

### DIFF
--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/builtInTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/builtInTypes.ts
@@ -7,25 +7,14 @@ import type * as tae from 'typescript-api-extractor';
 const BUILT_IN_NAMESPACES = ['React', 'JSX', 'HTML', 'CSS', 'SVG', 'Omit', 'Pick', 'Partial'];
 
 /**
- * Matches a type name against the built-in list. Namespaces always match in full;
- * `nameMatches` decides how strictly the bare name is compared.
- */
-function matchesBuiltIn(
-  typeName: tae.TypeName,
-  nameMatches: (name: string, builtIn: string) => boolean,
-): boolean {
-  const name = typeName.name || '';
-  return BUILT_IN_NAMESPACES.some(
-    (builtIn) => nameMatches(name, builtIn) || (typeName.namespaces?.includes(builtIn) ?? false),
-  );
-}
-
-/**
- * Checks if a type name belongs to a built-in namespace that should be skipped
- * during external type collection.
+ * Checks if a type name belongs to a built-in namespace.
+ *
+ * Names are compared whole: a `PickerConfig` of ours is not the built-in `Pick`.
  */
 export function isBuiltInTypeName(typeName: tae.TypeName): boolean {
-  return matchesBuiltIn(typeName, (name, builtIn) => name.startsWith(builtIn));
+  return BUILT_IN_NAMESPACES.some(
+    (builtIn) => typeName.name === builtIn || (typeName.namespaces?.includes(builtIn) ?? false),
+  );
 }
 
 /** The name a type is written as, for the node kinds that carry one. */
@@ -38,14 +27,9 @@ function namedAs(type: tae.AnyType): tae.TypeName | undefined {
  *
  * A wrapper qualifies only when its arguments do too: the keys of `Omit<Config, 'size'>`
  * come from `Config`, so naming the wrapper would describe nothing.
- *
- * The bare name is compared in full here, where `isBuiltInTypeName` compares a prefix.
- * Over-matching only costs a repeated definition when deciding what to collect, but this
- * decides whether a type's members are shown at all, so a `PickerConfig` of ours must not
- * be taken for the built-in `Pick`.
  */
 function namesOnlyBuiltIns(typeName: tae.TypeName): boolean {
-  if (!matchesBuiltIn(typeName, (name, builtIn) => name === builtIn)) {
+  if (!isBuiltInTypeName(typeName)) {
     return false;
   }
   return (typeName.typeArguments ?? []).every((argument) => {

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/builtInTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/builtInTypes.ts
@@ -23,26 +23,20 @@ function namedAs(type: tae.AnyType): tae.TypeName | undefined {
 }
 
 /**
- * Whether a name, and everything it wraps, is built-in.
+ * Whether a type is one the reader already knows, rather than one these docs describe.
  *
  * A wrapper qualifies only when its arguments do too: the keys of `Omit<Config, 'size'>`
  * come from `Config`, so naming the wrapper would describe nothing.
  */
-function namesOnlyBuiltIns(typeName: tae.TypeName): boolean {
-  if (!isBuiltInTypeName(typeName)) {
-    return false;
-  }
-  return (typeName.typeArguments ?? []).every((argument) => {
-    const argumentName = namedAs(argument.type);
-    // Literals and intrinsics name nothing, so they cannot disqualify their wrapper.
-    return argumentName === undefined || namesOnlyBuiltIns(argumentName);
-  });
-}
-
-/**
- * Whether a type is one the reader already knows, rather than one these docs describe.
- */
 export function isBuiltInTypeReference(type: tae.AnyType): boolean {
   const typeName = namedAs(type);
-  return typeName !== undefined && namesOnlyBuiltIns(typeName);
+  if (typeName === undefined || !isBuiltInTypeName(typeName)) {
+    return false;
+  }
+  return (
+    typeName.typeArguments?.every(
+      // Literals and intrinsics name nothing, so they cannot disqualify their wrapper.
+      (argument) => namedAs(argument.type) === undefined || isBuiltInTypeReference(argument.type),
+    ) ?? true
+  );
 }

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/builtInTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/builtInTypes.ts
@@ -1,0 +1,64 @@
+import type * as tae from 'typescript-api-extractor';
+
+/**
+ * Type namespaces the reader is expected to know, which these docs are therefore not
+ * responsible for describing.
+ */
+const BUILT_IN_NAMESPACES = ['React', 'JSX', 'HTML', 'CSS', 'SVG', 'Omit', 'Pick', 'Partial'];
+
+/**
+ * Matches a type name against the built-in list. Namespaces always match in full;
+ * `nameMatches` decides how strictly the bare name is compared.
+ */
+function matchesBuiltIn(
+  typeName: tae.TypeName,
+  nameMatches: (name: string, builtIn: string) => boolean,
+): boolean {
+  const name = typeName.name || '';
+  return BUILT_IN_NAMESPACES.some(
+    (builtIn) => nameMatches(name, builtIn) || (typeName.namespaces?.includes(builtIn) ?? false),
+  );
+}
+
+/**
+ * Checks if a type name belongs to a built-in namespace that should be skipped
+ * during external type collection.
+ */
+export function isBuiltInTypeName(typeName: tae.TypeName): boolean {
+  return matchesBuiltIn(typeName, (name, builtIn) => name.startsWith(builtIn));
+}
+
+/** The name a type is written as, for the node kinds that carry one. */
+function namedAs(type: tae.AnyType): tae.TypeName | undefined {
+  return 'typeName' in type ? type.typeName : undefined;
+}
+
+/**
+ * Whether a name, and everything it wraps, is built-in.
+ *
+ * A wrapper qualifies only when its arguments do too: the keys of `Omit<Config, 'size'>`
+ * come from `Config`, so naming the wrapper would describe nothing.
+ *
+ * The bare name is compared in full here, where `isBuiltInTypeName` compares a prefix.
+ * Over-matching only costs a repeated definition when deciding what to collect, but this
+ * decides whether a type's members are shown at all, so a `PickerConfig` of ours must not
+ * be taken for the built-in `Pick`.
+ */
+function namesOnlyBuiltIns(typeName: tae.TypeName): boolean {
+  if (!matchesBuiltIn(typeName, (name, builtIn) => name === builtIn)) {
+    return false;
+  }
+  return (typeName.typeArguments ?? []).every((argument) => {
+    const argumentName = namedAs(argument.type);
+    // Literals and intrinsics name nothing, so they cannot disqualify their wrapper.
+    return argumentName === undefined || namesOnlyBuiltIns(argumentName);
+  });
+}
+
+/**
+ * Whether a type is one the reader already knows, rather than one these docs describe.
+ */
+export function isBuiltInTypeReference(type: tae.AnyType): boolean {
+  const typeName = namedAs(type);
+  return typeName !== undefined && namesOnlyBuiltIns(typeName);
+}

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/externalTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/externalTypes.ts
@@ -9,6 +9,7 @@ import {
   isTypeOperatorType,
   isTypeQueryType,
 } from './typeGuards';
+import { isBuiltInTypeName } from './builtInTypes';
 import { groupType, UNION_OR_INTERSECTION } from './precedence';
 
 /**
@@ -37,63 +38,6 @@ export interface ExternalTypesCollector {
   pattern?: RegExp;
   /** Map of original export names to dotted display names, used to identify renamed own types */
   typeNameMap?: Record<string, string>;
-}
-
-/**
- * Built-in type namespaces that should not be collected as external types.
- */
-const BUILT_IN_NAMESPACES = ['React', 'JSX', 'HTML', 'CSS', 'SVG', 'Omit', 'Pick', 'Partial'];
-
-/**
- * Checks if a type name belongs to a built-in namespace that should be skipped
- * during external type collection.
- */
-export function isBuiltInTypeName(typeName: tae.TypeName): boolean {
-  const name = typeName.name || '';
-  return BUILT_IN_NAMESPACES.some(
-    (ns) => name.startsWith(ns) || (typeName.namespaces?.includes(ns) ?? false),
-  );
-}
-
-/** The name a type is written as, for the node kinds that carry one. */
-function namedAs(type: tae.AnyType): tae.TypeName | undefined {
-  return 'typeName' in type ? type.typeName : undefined;
-}
-
-/**
- * Whether a name is built-in, matched by whole segment rather than by prefix.
- *
- * `isBuiltInTypeName` matches prefixes, which is harmless where it decides whether to
- * repeat a definition. Here it decides whether a type's members are shown at all, so a
- * `PickerConfig` of ours must not be taken for the built-in `Pick`.
- */
-function namesBuiltIn(typeName: tae.TypeName): boolean {
-  return BUILT_IN_NAMESPACES.some(
-    (ns) => typeName.name === ns || (typeName.namespaces?.includes(ns) ?? false),
-  );
-}
-
-/** Whether a type names something this page is responsible for documenting. */
-function referencesDocumentedType(type: tae.AnyType): boolean {
-  const typeName = namedAs(type);
-  if (!typeName) {
-    // Literals and intrinsics name nothing, so they leave the verdict to their siblings.
-    return false;
-  }
-  if (!namesBuiltIn(typeName)) {
-    return true;
-  }
-  return (typeName.typeArguments ?? []).some((argument) => referencesDocumentedType(argument.type));
-}
-
-/**
- * Whether a type is one the reader already knows, rather than one this page documents.
- *
- * A utility wrapper qualifies only when everything it wraps is built-in too: the keys of
- * `Omit<Config, 'size'>` come from `Config`, so naming the wrapper would document nothing.
- */
-export function isBuiltInTypeReference(type: tae.AnyType): boolean {
-  return namedAs(type) !== undefined && !referencesDocumentedType(type);
 }
 
 /**

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/externalTypes.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/externalTypes.ts
@@ -55,6 +55,47 @@ export function isBuiltInTypeName(typeName: tae.TypeName): boolean {
   );
 }
 
+/** The name a type is written as, for the node kinds that carry one. */
+function namedAs(type: tae.AnyType): tae.TypeName | undefined {
+  return 'typeName' in type ? type.typeName : undefined;
+}
+
+/**
+ * Whether a name is built-in, matched by whole segment rather than by prefix.
+ *
+ * `isBuiltInTypeName` matches prefixes, which is harmless where it decides whether to
+ * repeat a definition. Here it decides whether a type's members are shown at all, so a
+ * `PickerConfig` of ours must not be taken for the built-in `Pick`.
+ */
+function namesBuiltIn(typeName: tae.TypeName): boolean {
+  return BUILT_IN_NAMESPACES.some(
+    (ns) => typeName.name === ns || (typeName.namespaces?.includes(ns) ?? false),
+  );
+}
+
+/** Whether a type names something this page is responsible for documenting. */
+function referencesDocumentedType(type: tae.AnyType): boolean {
+  const typeName = namedAs(type);
+  if (!typeName) {
+    // Literals and intrinsics name nothing, so they leave the verdict to their siblings.
+    return false;
+  }
+  if (!namesBuiltIn(typeName)) {
+    return true;
+  }
+  return (typeName.typeArguments ?? []).some((argument) => referencesDocumentedType(argument.type));
+}
+
+/**
+ * Whether a type is one the reader already knows, rather than one this page documents.
+ *
+ * A utility wrapper qualifies only when everything it wraps is built-in too: the keys of
+ * `Omit<Config, 'size'>` come from `Config`, so naming the wrapper would document nothing.
+ */
+export function isBuiltInTypeReference(type: tae.AnyType): boolean {
+  return namedAs(type) !== undefined && !referencesDocumentedType(type);
+}
+
 /**
  * Checks whether a type name belongs to one of the module's own exports.
  * Matches both direct export names (e.g., `AlertDialogRootChangeEventReason`)

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.test.ts
@@ -441,7 +441,7 @@ describe('formatType', () => {
     'declare namespace React { namespace JSX { interface IntrinsicElements { a: unknown; div: unknown; } } }',
     'type Exclude<T, U> = T extends U ? never : T;',
     'type Omit<T, K> = { [P in Exclude<keyof T, K>]: T[P] };',
-    // Shares a prefix with the built-in `Pick` without being one of it.
+    // Shares a prefix with the built-in `Pick` without being one.
     'interface PickerConfig { hour: string; minute: string; }',
   ].join('\n');
 

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.test.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.test.ts
@@ -437,6 +437,12 @@ describe('formatType', () => {
     'interface Config { size: string; color: string; }',
     'interface Meta { id: string; }',
     "type Tone = 'muted' | 'loud';",
+    // A built-in namespace, and the utility types that wrap other types by name.
+    'declare namespace React { namespace JSX { interface IntrinsicElements { a: unknown; div: unknown; } } }',
+    'type Exclude<T, U> = T extends U ? never : T;',
+    'type Omit<T, K> = { [P in Exclude<keyof T, K>]: T[P] };',
+    // Shares a prefix with the built-in `Pick` without being one of it.
+    'interface PickerConfig { hour: string; minute: string; }',
   ].join('\n');
 
   /** Formats one property of the parsed interface, the way the props tables do. */
@@ -512,6 +518,23 @@ describe('formatType', () => {
       // The operator stays whole here, so its base constraint must not be flattened into
       // the union alongside the sibling literal.
       expect(formatProp(source, 'key', { preserveTypeParameters: true })).toBe("'size' | keyof T");
+    });
+
+    it('should keep a keyof operator over a built-in type as written', () => {
+      const source = 'export interface Props {\n  tag?: keyof React.JSX.IntrinsicElements;\n}';
+      // Readers already know the built-in, and its keys are too many to be worth listing.
+      expect(formatProp(source, 'tag')).toBe('keyof React.JSX.IntrinsicElements');
+    });
+
+    it('should expand a keyof operator over a built-in wrapping a documented type', () => {
+      const source = "export interface Props {\n  key?: keyof Omit<Config, 'size'>;\n}";
+      // The keys come from `Config`, so naming the wrapper would document nothing.
+      expect(formatProp(source, 'key')).toBe("'color'");
+    });
+
+    it('should expand a keyof operator over a type that merely starts with a built-in name', () => {
+      const source = 'export interface Props {\n  unit?: keyof PickerConfig;\n}';
+      expect(formatProp(source, 'unit')).toBe("'hour' | 'minute'");
     });
 
     it('should expand a keyof operator over a type query', () => {

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.ts
@@ -17,13 +17,13 @@ import {
   isInternalTypeName,
 } from './typeGuards';
 import {
-  isBuiltInTypeReference,
   isOwnTypeName,
   maybeCollectExternalUnion,
   maybeCollectExternalFunction,
   maybeCollectExternalReference,
 } from './externalTypes';
 import type { ExternalTypesCollector } from './externalTypes';
+import { isBuiltInTypeReference } from './builtInTypes';
 import { prettyFormat } from './format';
 import { groupType, UNION, UNION_OR_INTERSECTION } from './precedence';
 
@@ -53,7 +53,9 @@ export interface FormatTypeOptions {
  *
  * Both the union branch and the operator branch ask this, so they cannot disagree about
  * which operators expand. `formatExternalTypeDefinition` takes no options and always
- * expands, so it deliberately does not share this rule.
+ * expands, so it deliberately does not share this rule: an operator reached through a
+ * collected type still shows its keys in the External Types section, whichever reason
+ * kept it by name here.
  */
 function resolvedOperatorKeys(
   type: tae.AnyType,

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.ts
@@ -47,9 +47,9 @@ export interface FormatTypeOptions {
  * `keyof T` to its base constraint, which holds no type parameter to recover `T` from.
  *
  * A built-in operand is kept by name too. Its keys are the reader's to already know, and
- * listing them buries the page: `keyof React.JSX.IntrinsicElements` says what 178 tag
- * names do not. Types the page is responsible for documenting still expand, since nothing
- * else on the page would tell the reader what their keys are.
+ * listing them buries the page: `keyof React.JSX.IntrinsicElements` says what a wall of
+ * tag names does not. Types the page is responsible for documenting still expand, since
+ * nothing else on the page would tell the reader what their keys are.
  *
  * Both the union branch and the operator branch ask this, so they cannot disagree about
  * which operators expand. `formatExternalTypeDefinition` takes no options and always

--- a/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.ts
+++ b/packages/docs-infra/src/pipeline/loadServerTypesMeta/formatType.ts
@@ -17,6 +17,7 @@ import {
   isInternalTypeName,
 } from './typeGuards';
 import {
+  isBuiltInTypeReference,
   isOwnTypeName,
   maybeCollectExternalUnion,
   maybeCollectExternalFunction,
@@ -44,6 +45,12 @@ export interface FormatTypeOptions {
  *
  * A type parameter operand is kept by name in raw declarations: the checker resolves
  * `keyof T` to its base constraint, which holds no type parameter to recover `T` from.
+ *
+ * A built-in operand is kept by name too. Its keys are the reader's to already know, and
+ * listing them buries the page: `keyof React.JSX.IntrinsicElements` says what 178 tag
+ * names do not. Types the page is responsible for documenting still expand, since nothing
+ * else on the page would tell the reader what their keys are.
+ *
  * Both the union branch and the operator branch ask this, so they cannot disagree about
  * which operators expand. `formatExternalTypeDefinition` takes no options and always
  * expands, so it deliberately does not share this rule.
@@ -56,6 +63,9 @@ function resolvedOperatorKeys(
     return undefined;
   }
   if (preserveTypeParameters && isTypeParameterType(type.type)) {
+    return undefined;
+  }
+  if (isBuiltInTypeReference(type.type)) {
     return undefined;
   }
   return type.resolvedType;


### PR DESCRIPTION
A `keyof` over a built-in now renders as written instead of expanding. `keyof React.JSX.IntrinsicElements` says what a wall of tag names does not, and readers already know the type. Types this package documents still expand, since nothing else on the page would tell the reader what their keys are.

A utility wrapper counts as built-in only when everything it wraps does too — the keys of `Omit<Config, 'size'>` come from `Config`, so naming the wrapper would describe nothing.

`isBuiltInTypeName` moves to its own module and now compares names in full rather than by prefix, so a `PickerConfig` of ours is not taken for the built-in `Pick`. That also affects which types the External Types section skips; regenerating base-ui gives byte-identical output either way, because the own-type check that follows already catches anything the docs export.

Against base-ui at upstream master (on top of the canary.41 bump in mui/base-ui#5616), one file changes: `use-render/types.md` goes from 555 lines to 199, and `Field.Error`'s `match` keeps all 11 `ValidityState` keys.

Raised by @michaldudak in mui/base-ui#5616.