### PR TITLE
[code-infra] Install pnpm over the image's copy instead of shimming it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/worktree-pnpm-standalone-install/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/master/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/master/.circleci/orbs/code-infra.yml
+  # TEMPORARY: pointed at this PR's branch so CI exercises the orb change. Revert to master before merging.
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/worktree-pnpm-standalone-install/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/master/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/worktree-pnpm-standalone-install/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2.1
 
 orbs:
-  # TEMPORARY: pointed at this PR's branch so CI exercises the orb change. Revert to master before merging.
-  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/worktree-pnpm-standalone-install/.circleci/orbs/code-infra.yml
+  code-infra: https://raw.githubusercontent.com/mui/mui-public/refs/heads/master/.circleci/orbs/code-infra.yml
 
 parameters:
   workflow:

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -16,6 +16,13 @@ commands:
             # Only the binaries need to go: they are what sits in the probed directory, and the package
             # they link to is unreachable once they are gone.
             node_bin_dir=$(dirname "$(command -v node)")
+            # TEMPORARY smoke test: what the image shipped, before we remove it. Run from /tmp so pnpm
+            # does not self-switch to the pinned version and hide its own.
+            if [ -e "$node_bin_dir/pnpm" ]; then
+              echo "SMOKE before: $node_bin_dir/pnpm is version $(cd /tmp && "$node_bin_dir/pnpm" --version)"
+            else
+              echo "SMOKE before: no pnpm at $node_bin_dir"
+            fi
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
             # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm
@@ -43,6 +50,38 @@ commands:
             node --version
             command -v pnpm
             pnpm --version
+      - run:
+          name: TEMPORARY smoke test - npm-run-path resolution
+          command: |
+            node -e '
+              const { execFileSync } = require("node:child_process");
+              const path = require("node:path");
+              // Rebuild PATH exactly as npm-run-path does for tools like publint: every
+              // node_modules/.bin from the cwd upwards, then the directory holding the node
+              // binary, then the inherited PATH. This is the lookup that reached the image pnpm.
+              const dirs = [];
+              for (let dir = process.cwd(); ; ) {
+                dirs.push(path.join(dir, "node_modules", ".bin"));
+                const parent = path.dirname(dir);
+                if (parent === dir) break;
+                dir = parent;
+              }
+              dirs.push(path.dirname(process.execPath));
+              const env = { ...process.env, PATH: [...dirs, process.env.PATH].join(path.delimiter) };
+              const run = (cmd, args) => execFileSync(cmd, args, { env }).toString().trim();
+
+              const resolved = run("sh", ["-c", "command -v pnpm"]);
+              const reported = run("pnpm", ["--version"]);
+              const pinned = require("./package.json").packageManager.split("@")[1].split("+")[0];
+              console.log("SMOKE after:  npm-run-path resolves pnpm to " + resolved);
+              console.log("SMOKE after:  that pnpm reports " + reported + ", packageManager pins " + pinned);
+              console.log("SMOKE after:  node binary dir is " + path.dirname(process.execPath));
+              if (reported !== pinned) {
+                console.error("SMOKE FAILED: expected " + pinned + ", got " + reported);
+                process.exit(1);
+              }
+              console.log("SMOKE PASSED");
+            '
 
   install-deps:
     description: 'Installs JavaScript dependencies using pnpm'

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -17,12 +17,6 @@ commands:
             # holding the node binary, so the install below puts the pinned version back here. Where the
             # prefix differs, this still removes the copy that would shadow it.
             node_bin_dir=$(dirname "$(command -v node)")
-            # TEMPORARY smoke test: what the image shipped. Run from /tmp so pnpm does not self-switch.
-            if [ -e "$node_bin_dir/pnpm" ]; then
-              echo "SMOKE before: $node_bin_dir/pnpm is version $(cd /tmp && "$node_bin_dir/pnpm" --version)"
-            else
-              echo "SMOKE before: no pnpm at $node_bin_dir"
-            fi
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
             # Installing the pinned version keeps pnpm from forking a second pnpm on every invocation
@@ -43,37 +37,6 @@ commands:
             node --version
             command -v pnpm
             pnpm --version
-      - run:
-          name: TEMPORARY smoke test - npm-run-path resolution
-          command: |
-            node -e '
-              const { execFileSync } = require("node:child_process");
-              const path = require("node:path");
-              // Rebuild PATH exactly as npm-run-path does for tools like publint.
-              const dirs = [];
-              for (let dir = process.cwd(); ; ) {
-                dirs.push(path.join(dir, "node_modules", ".bin"));
-                const parent = path.dirname(dir);
-                if (parent === dir) break;
-                dir = parent;
-              }
-              dirs.push(path.dirname(process.execPath));
-              const env = { ...process.env, PATH: [...dirs, process.env.PATH].join(path.delimiter) };
-              const run = (cmd, args) => execFileSync(cmd, args, { env }).toString().trim();
-
-              const resolved = run("sh", ["-c", "command -v pnpm"]);
-              const reported = run("pnpm", ["--version"]);
-              const pinned = require("./package.json").packageManager.split("@")[1].split("+")[0];
-              console.log("SMOKE after:  npm-run-path resolves pnpm to " + resolved);
-              console.log("SMOKE after:  that pnpm reports " + reported + ", packageManager pins " + pinned);
-              console.log("SMOKE after:  node binary dir is " + path.dirname(process.execPath));
-              if (reported !== pinned) {
-                console.error("SMOKE FAILED: expected " + pinned + ", got " + reported);
-                process.exit(1);
-              }
-              console.log("SMOKE PASSED");
-            '
-
   install-deps:
     description: 'Installs JavaScript dependencies using pnpm'
     parameters:

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -12,33 +12,27 @@ commands:
           # it and install the pinned version, rather than shimming a third pnpm in front of both.
           command: |
             sudo=''
-            if [ "$(id -u)" != '0' ]; then
-              sudo='sudo'
-            fi
-            $sudo npm uninstall -g pnpm
-            # npm's global prefix is not always the directory holding the node binary.
+            [ "$(id -u)" = '0' ] || sudo='sudo'
+            # Only the binaries need to go: they are what sits in the probed directory, and the package
+            # they link to is unreachable once they are gone.
             node_bin_dir=$(dirname "$(command -v node)")
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
-            # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm on
-            # every invocation.
-            spec=$(node -p "require('./package.json').packageManager || ''" 2>/dev/null || true)
+            # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm
+            # on every invocation. Read it from the repository root rather than the working directory,
+            # which for some jobs is a nested fixture with a package.json of its own.
+            root=$(git rev-parse --show-toplevel)
+            spec=$(node -p "require('$root/package.json').packageManager || ''")
             case "$spec" in
-              # Jobs running from a nested package.json without the field have no pin in reach, and
-              # leave pnpm to switch itself.
-              '')
-                version=''
-                ;;
-              pnpm@*)
-                version=${spec#pnpm@}
-                version=${version%%+*}
-                ;;
+              pnpm@*) ;;
               *)
-                echo "Expected package.json#packageManager to name pnpm, got '$spec'" >&2
+                echo "Expected $root/package.json#packageManager to name pnpm, got '${spec:-<missing>}'" >&2
                 exit 1
                 ;;
             esac
-            curl -fsSL https://get.pnpm.io/install.sh | env ${version:+PNPM_VERSION=$version} SHELL=/bin/bash sh -
+            version=${spec#pnpm@}
+            version=${version%%+*}
+            curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION="$version" SHELL=/bin/bash sh -
 
             # Each CircleCI step is a non-login shell, which never reads the rc file `pnpm setup` wrote.
             echo 'export PNPM_HOME="$HOME/.pnpm"' >> "$BASH_ENV"

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -29,11 +29,14 @@ commands:
               }
               console.log(pinned);
             ')
+            # `pnpm setup` installs into PNPM_HOME and puts the binaries in its `bin` subdirectory.
+            # Set it here rather than reading it back afterwards, so both lines below agree with it.
+            export PNPM_HOME="$HOME/.local/share/pnpm"
             curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION="$version" SHELL=/bin/bash sh -
 
             # Each CircleCI step is a non-login shell, which never reads the rc file `pnpm setup` wrote.
-            echo 'export PNPM_HOME="$HOME/.pnpm"' >> "$BASH_ENV"
-            echo 'export PATH="$PNPM_HOME:$PATH"' >> "$BASH_ENV"
+            echo "export PNPM_HOME='$PNPM_HOME'" >> "$BASH_ENV"
+            echo 'export PATH="$PNPM_HOME/bin:$PATH"' >> "$BASH_ENV"
       - run:
           name: View install environment
           command: |

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -13,13 +13,20 @@ commands:
           command: |
             sudo=''
             [ "$(id -u)" = '0' ] || sudo='sudo'
-            # Only the binaries need to go: they are what sits in the probed directory, and the package
-            # they link to is unreachable once they are gone.
+            # Cleared before installing rather than after: npm's global prefix is normally the directory
+            # holding the node binary, so the install below puts the pinned version back here. Where the
+            # prefix differs, this still removes the copy that would shadow it.
             node_bin_dir=$(dirname "$(command -v node)")
+            # TEMPORARY smoke test: what the image shipped. Run from /tmp so pnpm does not self-switch.
+            if [ -e "$node_bin_dir/pnpm" ]; then
+              echo "SMOKE before: $node_bin_dir/pnpm is version $(cd /tmp && "$node_bin_dir/pnpm" --version)"
+            else
+              echo "SMOKE before: no pnpm at $node_bin_dir"
+            fi
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
-            # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm
-            # on every invocation.
+            # Installing the pinned version keeps pnpm from forking a second pnpm on every invocation
+            # to switch to the one `packageManager` names.
             version=$(node -e '
               const { packageManager = "" } = require("./package.json");
               const [, pinned] = /^pnpm@([^+]+)/.exec(packageManager) || [];
@@ -29,20 +36,43 @@ commands:
               }
               console.log(pinned);
             ')
-            # `pnpm setup` installs into PNPM_HOME and puts the binaries in its `bin` subdirectory.
-            # Set it here rather than reading it back afterwards, so both lines below agree with it.
-            export PNPM_HOME="$HOME/.local/share/pnpm"
-            curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION="$version" SHELL=/bin/bash sh -
-
-            # Each CircleCI step is a non-login shell, which never reads the rc file `pnpm setup` wrote.
-            echo "export PNPM_HOME='$PNPM_HOME'" >> "$BASH_ENV"
-            echo 'export PATH="$PNPM_HOME/bin:$PATH"' >> "$BASH_ENV"
+            $sudo npm install -g "pnpm@$version"
       - run:
           name: View install environment
           command: |
             node --version
             command -v pnpm
             pnpm --version
+      - run:
+          name: TEMPORARY smoke test - npm-run-path resolution
+          command: |
+            node -e '
+              const { execFileSync } = require("node:child_process");
+              const path = require("node:path");
+              // Rebuild PATH exactly as npm-run-path does for tools like publint.
+              const dirs = [];
+              for (let dir = process.cwd(); ; ) {
+                dirs.push(path.join(dir, "node_modules", ".bin"));
+                const parent = path.dirname(dir);
+                if (parent === dir) break;
+                dir = parent;
+              }
+              dirs.push(path.dirname(process.execPath));
+              const env = { ...process.env, PATH: [...dirs, process.env.PATH].join(path.delimiter) };
+              const run = (cmd, args) => execFileSync(cmd, args, { env }).toString().trim();
+
+              const resolved = run("sh", ["-c", "command -v pnpm"]);
+              const reported = run("pnpm", ["--version"]);
+              const pinned = require("./package.json").packageManager.split("@")[1].split("+")[0];
+              console.log("SMOKE after:  npm-run-path resolves pnpm to " + resolved);
+              console.log("SMOKE after:  that pnpm reports " + reported + ", packageManager pins " + pinned);
+              console.log("SMOKE after:  node binary dir is " + path.dirname(process.execPath));
+              if (reported !== pinned) {
+                console.error("SMOKE FAILED: expected " + pinned + ", got " + reported);
+                process.exit(1);
+              }
+              console.log("SMOKE PASSED");
+            '
 
   install-deps:
     description: 'Installs JavaScript dependencies using pnpm'

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -42,13 +42,6 @@ commands:
             node --version
             command -v pnpm
             pnpm --version
-            # The invariant the step above exists to hold: nothing shadows the pinned pnpm from the
-            # directory `npm-run-path` reaches before PATH.
-            node_bin_dir=$(dirname "$(command -v node)")
-            if [ -e "$node_bin_dir/pnpm" ]; then
-              echo "A pnpm at $node_bin_dir/pnpm shadows the one this job installed" >&2
-              exit 1
-            fi
 
   install-deps:
     description: 'Installs JavaScript dependencies using pnpm'

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -2,28 +2,52 @@ version: 2.1
 
 commands:
   install-pnpm:
-    description: 'Installs pnpm package manager using corepack'
+    description: 'Installs the pnpm version pinned in package.json#packageManager'
     steps:
       - run:
-          name: Set npm registry public signing keys
-          command: |
-            echo "export COREPACK_INTEGRITY_KEYS='$(curl https://registry.npmjs.org/-/npm/v1/keys | jq -c '{npm: .keys}')'" >> $BASH_ENV
-      - run:
           name: Install pnpm package manager
-          # See https://stackoverflow.com/a/73411601
+          # cimg/node ships an unpinned `npm install -g pnpm`, and npm puts it next to the node binary.
+          # That directory is the one `npm-run-path` probes before PATH, so tools that spawn `pnpm` that
+          # way — publint packing through tinyexec — reach it rather than the version pinned here. Remove
+          # it and install the pinned version, rather than shimming a third pnpm in front of both.
           command: |
-            if [ "${IS_BROWSER_ENV}" = "1" ]; then
-              corepack enable
-            else
-              corepack enable --install-directory ~/bin
+            sudo=''
+            if [ "$(id -u)" != '0' ]; then
+              sudo='sudo'
             fi
+            $sudo npm uninstall -g pnpm
+            # npm's global prefix is not always the directory holding the node binary.
+            node_bin_dir=$(dirname "$(command -v node)")
+            $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
+
+            # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm on
+            # every invocation. Jobs running from a nested package.json without the field find no pin, and
+            # fall back to letting pnpm switch itself.
+            spec=$(node -p "require('./package.json').packageManager || ''" 2>/dev/null || true)
+            version=''
+            case "$spec" in
+              pnpm@*)
+                version=${spec#pnpm@}
+                version=${version%%+*}
+                ;;
+            esac
+            curl -fsSL https://get.pnpm.io/install.sh | env ${version:+PNPM_VERSION=$version} SHELL=/bin/bash sh -
+
+            # Each CircleCI step is a non-login shell, which never reads the rc file `pnpm setup` wrote.
+            echo 'export PNPM_HOME="$HOME/.pnpm"' >> "$BASH_ENV"
+            echo 'export PATH="$PNPM_HOME:$PATH"' >> "$BASH_ENV"
       - run:
           name: View install environment
           command: |
             node --version
+            command -v pnpm
             pnpm --version
-            if [ "${IS_BROWSER_ENV}" = "1" ]; then
-              echo "Is browser image"
+            # The invariant the step above exists to hold: nothing shadows the pinned pnpm from the
+            # directory `npm-run-path` reaches before PATH.
+            node_bin_dir=$(dirname "$(command -v node)")
+            if [ -e "$node_bin_dir/pnpm" ]; then
+              echo "A pnpm at $node_bin_dir/pnpm shadows the one this job installed" >&2
+              exit 1
             fi
 
   install-deps:

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -9,7 +9,7 @@ commands:
           # cimg/node ships an unpinned `npm install -g pnpm`, and npm puts it next to the node binary.
           # That directory is the one `npm-run-path` probes before PATH, so tools that spawn `pnpm` that
           # way — publint packing through tinyexec — reach it rather than the version pinned here. Remove
-          # it and install the pinned version, rather than shimming a third pnpm in front of both.
+          # it and install the pinned version.
           command: |
             sudo=''
             [ "$(id -u)" = '0' ] || sudo='sudo'

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -16,13 +16,6 @@ commands:
             # Only the binaries need to go: they are what sits in the probed directory, and the package
             # they link to is unreachable once they are gone.
             node_bin_dir=$(dirname "$(command -v node)")
-            # TEMPORARY smoke test: what the image shipped, before we remove it. Run from /tmp so pnpm
-            # does not self-switch to the pinned version and hide its own.
-            if [ -e "$node_bin_dir/pnpm" ]; then
-              echo "SMOKE before: $node_bin_dir/pnpm is version $(cd /tmp && "$node_bin_dir/pnpm" --version)"
-            else
-              echo "SMOKE before: no pnpm at $node_bin_dir"
-            fi
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
             # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm
@@ -50,38 +43,6 @@ commands:
             node --version
             command -v pnpm
             pnpm --version
-      - run:
-          name: TEMPORARY smoke test - npm-run-path resolution
-          command: |
-            node -e '
-              const { execFileSync } = require("node:child_process");
-              const path = require("node:path");
-              // Rebuild PATH exactly as npm-run-path does for tools like publint: every
-              // node_modules/.bin from the cwd upwards, then the directory holding the node
-              // binary, then the inherited PATH. This is the lookup that reached the image pnpm.
-              const dirs = [];
-              for (let dir = process.cwd(); ; ) {
-                dirs.push(path.join(dir, "node_modules", ".bin"));
-                const parent = path.dirname(dir);
-                if (parent === dir) break;
-                dir = parent;
-              }
-              dirs.push(path.dirname(process.execPath));
-              const env = { ...process.env, PATH: [...dirs, process.env.PATH].join(path.delimiter) };
-              const run = (cmd, args) => execFileSync(cmd, args, { env }).toString().trim();
-
-              const resolved = run("sh", ["-c", "command -v pnpm"]);
-              const reported = run("pnpm", ["--version"]);
-              const pinned = require("./package.json").packageManager.split("@")[1].split("+")[0];
-              console.log("SMOKE after:  npm-run-path resolves pnpm to " + resolved);
-              console.log("SMOKE after:  that pnpm reports " + reported + ", packageManager pins " + pinned);
-              console.log("SMOKE after:  node binary dir is " + path.dirname(process.execPath));
-              if (reported !== pinned) {
-                console.error("SMOKE FAILED: expected " + pinned + ", got " + reported);
-                process.exit(1);
-              }
-              console.log("SMOKE PASSED");
-            '
 
   install-deps:
     description: 'Installs JavaScript dependencies using pnpm'

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -21,14 +21,21 @@ commands:
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
             # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm on
-            # every invocation. Jobs running from a nested package.json without the field find no pin, and
-            # fall back to letting pnpm switch itself.
+            # every invocation.
             spec=$(node -p "require('./package.json').packageManager || ''" 2>/dev/null || true)
-            version=''
             case "$spec" in
+              # Jobs running from a nested package.json without the field have no pin in reach, and
+              # leave pnpm to switch itself.
+              '')
+                version=''
+                ;;
               pnpm@*)
                 version=${spec#pnpm@}
                 version=${version%%+*}
+                ;;
+              *)
+                echo "Expected package.json#packageManager to name pnpm, got '$spec'" >&2
+                exit 1
                 ;;
             esac
             curl -fsSL https://get.pnpm.io/install.sh | env ${version:+PNPM_VERSION=$version} SHELL=/bin/bash sh -

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -22,16 +22,16 @@ commands:
             # on every invocation. Read it from the repository root rather than the working directory,
             # which for some jobs is a nested fixture with a package.json of its own.
             root=$(git rev-parse --show-toplevel)
-            spec=$(node -p "require('$root/package.json').packageManager || ''")
-            case "$spec" in
-              pnpm@*) ;;
-              *)
-                echo "Expected $root/package.json#packageManager to name pnpm, got '${spec:-<missing>}'" >&2
-                exit 1
-                ;;
-            esac
-            version=${spec#pnpm@}
-            version=${version%%+*}
+            version=$(node -e '
+              const root = process.argv[1];
+              const { packageManager = "" } = require(root + "/package.json");
+              const [, pinned] = /^pnpm@([^+]+)/.exec(packageManager) || [];
+              if (!pinned) {
+                console.error(`Expected ${root}/package.json#packageManager to name pnpm, got "${packageManager}"`);
+                process.exit(1);
+              }
+              console.log(pinned);
+            ' "$root")
             curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION="$version" SHELL=/bin/bash sh -
 
             # Each CircleCI step is a non-login shell, which never reads the rc file `pnpm setup` wrote.

--- a/.circleci/orbs/code-infra.yml
+++ b/.circleci/orbs/code-infra.yml
@@ -19,19 +19,16 @@ commands:
             $sudo rm -f "$node_bin_dir/pnpm" "$node_bin_dir/pnpx"
 
             # Pinning PNPM_VERSION lets pnpm skip its version switch instead of forking a second pnpm
-            # on every invocation. Read it from the repository root rather than the working directory,
-            # which for some jobs is a nested fixture with a package.json of its own.
-            root=$(git rev-parse --show-toplevel)
+            # on every invocation.
             version=$(node -e '
-              const root = process.argv[1];
-              const { packageManager = "" } = require(root + "/package.json");
+              const { packageManager = "" } = require("./package.json");
               const [, pinned] = /^pnpm@([^+]+)/.exec(packageManager) || [];
               if (!pinned) {
-                console.error(`Expected ${root}/package.json#packageManager to name pnpm, got "${packageManager}"`);
+                console.error(`Expected package.json#packageManager to name pnpm, got "${packageManager}"`);
                 process.exit(1);
               }
               console.log(pinned);
-            ' "$root")
+            ')
             curl -fsSL https://get.pnpm.io/install.sh | PNPM_VERSION="$version" SHELL=/bin/bash sh -
 
             # Each CircleCI step is a non-login shell, which never reads the rc file `pnpm setup` wrote.


### PR DESCRIPTION
Alternative to #1830.

cimg/node installs an unpinned pnpm next to the node binary, and that directory is searched before PATH by anything using `npm-run-path`. So publint 0.3.24, which now packs through the package manager, gets the image's pnpm rather than the pinned one, and `COREPACK_ROOT` stops it correcting itself. #1830 adds a third pnpm to `node_modules/.bin` to win that search; this installs the pinned version into that directory instead, so the pnpm found first *is* the right one.

Corepack goes with it, which pnpm now recommends against for CI and [Node 25 no longer ships](https://github.com/nodejs/node/pull/61207). Installing an exact version also stops pnpm forking a second pnpm on every call to switch to the one `packageManager` names, and a `packageManager` that doesn't name pnpm fails the step.

Verified on CI by temporarily pointing this repo's orb at the branch and printing what a rebuilt `npm-run-path` lookup resolves to (both commits since reverted). On `cimg/node`, `/usr/local/bin/pnpm` was the image's 11.18.0 and is now the pinned 11.22.0; on the Playwright executor the same holds at `/usr/bin`. Note that CI on a branch normally loads the orb from `refs/heads/master`, so changes to this file are not otherwise exercised here.
