### PR TITLE
[code-infra] Use current GitHub REST API

### DIFF
--- a/packages/code-infra/src/cli/cmdPublish.mjs
+++ b/packages/code-infra/src/cli/cmdPublish.mjs
@@ -30,7 +30,13 @@ import { getCurrentGitSha, getRepositoryInfo, remoteGitTagExists } from '../util
 const isCI = envCI().isCi;
 
 function getOctokit() {
-  return new Octokit({ authStrategy: isCI ? createActionAuth : persistentAuthStrategy });
+  const octokit = new Octokit({
+    authStrategy: isCI ? createActionAuth : persistentAuthStrategy,
+  });
+  octokit.hook.before('request', (requestOptions) => {
+    requestOptions.headers['x-github-api-version'] = '2026-03-10';
+  });
+  return octokit;
 }
 
 /**


### PR DESCRIPTION
## Summary

- send X-GitHub-Api-Version: 2026-03-10 on requests from the publish CLI
- stop Octokit from warning that the workflow dispatch uses the retiring 2022-11-28 API version

## Validation

- verified the generated workflow dispatch request carries x-github-api-version: 2026-03-10
