### PR TITLE
[test-utils] Support root selection in conformance tests

### DIFF
--- a/packages/test-utils/src/describeConformance.test.tsx
+++ b/packages/test-utils/src/describeConformance.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { describe, expect } from 'vitest';
+import { createRenderer } from './createRenderer';
+import describeConformance from './describeConformance';
+import type { ConformanceOptions } from './describeConformance';
+import setupVitest from './setupVitest';
+
+interface TestRootProps extends React.HTMLAttributes<HTMLElement> {
+  classes?: { root: string };
+  component?: React.ElementType;
+  layout: 'inline' | 'wrapped' | 'portal';
+}
+
+const TestRoot = React.forwardRef<HTMLElement, TestRootProps>(function TestRoot(
+  { classes, className, component: Component = 'div', layout, ...props },
+  ref,
+) {
+  const root = (
+    <Component
+      {...props}
+      ref={ref}
+      className={['Test-root', classes?.root, className].filter(Boolean).join(' ')}
+      data-conformance-root=""
+    />
+  );
+
+  if (layout === 'portal') {
+    return (
+      <React.Fragment>
+        <button type="button">Open</button>
+        {ReactDOM.createPortal(root, document.body)}
+      </React.Fragment>
+    );
+  }
+
+  return layout === 'wrapped' ? <section>{root}</section> : root;
+});
+
+describe('describeConformance', () => {
+  setupVitest();
+
+  for (const layout of ['inline', 'wrapped', 'portal'] as const) {
+    for (const asyncRender of [false, true]) {
+      describe(`${layout}, ${asyncRender ? 'async' : 'sync'} render`, () => {
+        const { render } = createRenderer();
+        const getRootElement: ConformanceOptions['getRootElement'] = (result) => {
+          expect(result.container).to.be.instanceof(HTMLElement);
+          const root = result.baseElement.querySelector('[data-conformance-root]');
+
+          if (layout === 'portal') {
+            expect(result.container.querySelector('button')).to.have.text('Open');
+            expect(result.container.contains(root)).to.equal(false);
+          } else {
+            expect(result.container.querySelector('section')).not.to.equal(null);
+            expect(result.container.contains(root)).to.equal(true);
+          }
+
+          return root;
+        };
+
+        describeConformance(<TestRoot layout={layout} />, () => ({
+          muiName: 'MuiTest',
+          classes: { root: 'Test-root' },
+          refInstanceof: window.HTMLDivElement,
+          render: asyncRender ? async (node) => render(node) : render,
+          ...(layout !== 'inline' && { getRootElement }),
+          only: ['rootClass', 'mergeClassName', 'propsSpread', 'refForwarding', 'componentProp'],
+        }));
+      });
+    }
+  }
+});

--- a/packages/test-utils/src/describeConformance.test.tsx
+++ b/packages/test-utils/src/describeConformance.test.tsx
@@ -9,7 +9,7 @@ import setupVitest from './setupVitest';
 interface TestRootProps extends React.HTMLAttributes<HTMLElement> {
   classes?: { root: string };
   component?: React.ElementType;
-  layout: 'inline' | 'wrapped' | 'portal';
+  layout: 'inline' | 'text' | 'wrapped' | 'portal';
 }
 
 const TestRoot = React.forwardRef<HTMLElement, TestRootProps>(function TestRoot(
@@ -24,6 +24,10 @@ const TestRoot = React.forwardRef<HTMLElement, TestRootProps>(function TestRoot(
       data-conformance-root=""
     />
   );
+
+  if (layout === 'text') {
+    return <React.Fragment>Text before the root{root}</React.Fragment>;
+  }
 
   if (layout === 'portal') {
     return (
@@ -40,13 +44,14 @@ const TestRoot = React.forwardRef<HTMLElement, TestRootProps>(function TestRoot(
 describe('describeConformance', () => {
   setupVitest();
 
-  for (const layout of ['inline', 'wrapped', 'portal'] as const) {
+  for (const layout of ['inline', 'text', 'wrapped', 'portal'] as const) {
     for (const asyncRender of [false, true]) {
       describe(`${layout}, ${asyncRender ? 'async' : 'sync'} render`, () => {
         const { render } = createRenderer();
         const getRootElement: ConformanceOptions['getRootElement'] = (result) => {
           expect(result.container).to.be.instanceof(HTMLElement);
           const root = result.baseElement.querySelector('[data-conformance-root]');
+          expect(root, 'The test component must render a root element.').not.to.equal(null);
 
           if (layout === 'portal') {
             expect(result.container.querySelector('button')).to.have.text('Open');
@@ -64,7 +69,7 @@ describe('describeConformance', () => {
           classes: { root: 'Test-root' },
           refInstanceof: window.HTMLDivElement,
           render: asyncRender ? async (node) => render(node) : render,
-          ...(layout !== 'inline' && { getRootElement }),
+          ...((layout === 'wrapped' || layout === 'portal') && { getRootElement }),
           only: ['rootClass', 'mergeClassName', 'propsSpread', 'refForwarding', 'componentProp'],
         }));
       });

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -46,7 +46,7 @@ export interface ConformanceOptions {
   /**
    * Returns the component root for assertions that target one root.
    * Use this for portals or components inside a wrapper.
-   * The default is `result.container.firstChild`.
+   * The default is `result.container.firstElementChild`.
    * Tests that render multiple instances use their own queries.
    */
   getRootElement?: (result: MuiRenderResult) => Element | null;
@@ -97,8 +97,21 @@ function throwMissingPropError(field: string): never {
 `);
 }
 
-function defaultGetRootElement(result: MuiRenderResult) {
-  return result.container.firstChild;
+function resolveRootElement(
+  result: MuiRenderResult,
+  getRootElement: ConformanceOptions['getRootElement'],
+): Element {
+  const root = getRootElement ? getRootElement(result) : result.container.firstElementChild;
+
+  if (root === null) {
+    throw new Error(
+      'MUI: The conformance test could not find a root element. ' +
+        'Root assertions require an element. ' +
+        'Check the rendered output and the getRootElement option.',
+    );
+  }
+
+  return root;
 }
 
 /**
@@ -247,7 +260,7 @@ export function testRootClass(
   getOptions: () => ConformanceOptions,
 ) {
   it('applies the root class to the root component if it has this class', async () => {
-    const { classes, render, skip, getRootElement = defaultGetRootElement } = getOptions();
+    const { classes, render, skip, getRootElement } = getOptions();
     if (classes.root == null) {
       return;
     }
@@ -262,7 +275,7 @@ export function testRootClass(
     );
 
     // Some components pass the root class through the root component's classes prop.
-    const root = getRootElement(result);
+    const root = resolveRootElement(result, getRootElement);
     expect(root).to.have.class(className);
     expect(root).to.have.class(classes.root);
     expect(document.querySelectorAll(`.${classes.root}`).length).to.equal(1);
@@ -498,13 +511,7 @@ function testThemeDefaultProps(
   describe('theme default components:', () => {
     it("respect theme's defaultProps", async () => {
       const testProp = 'data-id';
-      const {
-        muiName,
-        render,
-        ThemeProvider,
-        createTheme,
-        getRootElement = defaultGetRootElement,
-      } = getOptions();
+      const { muiName, render, ThemeProvider, createTheme, getRootElement } = getOptions();
 
       if (!muiName) {
         throwMissingPropError('muiName');
@@ -534,17 +541,12 @@ function testThemeDefaultProps(
 
       const result = await render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
 
-      expect(getRootElement(result)).to.have.attribute(testProp, 'testProp');
+      expect(resolveRootElement(result, getRootElement)).to.have.attribute(testProp, 'testProp');
     });
   });
 
   describe('default props provider:', () => {
-    const {
-      muiName,
-      render,
-      DefaultPropsProvider,
-      getRootElement = defaultGetRootElement,
-    } = getOptions();
+    const { muiName, render, DefaultPropsProvider, getRootElement } = getOptions();
 
     it.skipIf(!DefaultPropsProvider)('respect custom default props', async function test() {
       const testProp = 'data-id';
@@ -572,7 +574,7 @@ function testThemeDefaultProps(
         </DefaultPropsProvider>,
       );
 
-      expect(getRootElement(result)).to.have.attribute(testProp, 'testProp');
+      expect(resolveRootElement(result, getRootElement)).to.have.attribute(testProp, 'testProp');
     });
   });
 }
@@ -587,14 +589,8 @@ function testThemeStyleOverrides(
 ) {
   describe('theme style overrides:', () => {
     it.skipIf(isJsdom())("respect theme's styleOverrides custom state", async function test() {
-      const {
-        muiName,
-        testStateOverrides,
-        render,
-        ThemeProvider,
-        createTheme,
-        getRootElement = defaultGetRootElement,
-      } = getOptions();
+      const { muiName, testStateOverrides, render, ThemeProvider, createTheme, getRootElement } =
+        getOptions();
 
       if (!testStateOverrides) {
         return;
@@ -642,7 +638,7 @@ function testThemeStyleOverrides(
         </ThemeProvider>,
       );
 
-      expect(getRootElement(result)).to.toHaveComputedStyle(testStyle);
+      expect(resolveRootElement(result, getRootElement)).to.toHaveComputedStyle(testStyle);
     });
 
     it.skipIf(isJsdom())("respect theme's styleOverrides slots", async function test() {
@@ -651,7 +647,7 @@ function testThemeStyleOverrides(
         testDeepOverrides,
         testRootOverrides = { slotName: 'root' },
         render,
-        getRootElement = defaultGetRootElement,
+        getRootElement,
         ThemeProvider,
         createTheme,
       } = getOptions();
@@ -714,7 +710,7 @@ function testThemeStyleOverrides(
           document.querySelector(`.${testRootOverrides.slotClassName}`),
         ).to.toHaveComputedStyle(testStyle);
       } else {
-        expect(getRootElement(result)).to.toHaveComputedStyle(testStyle);
+        expect(resolveRootElement(result, getRootElement)).to.toHaveComputedStyle(testStyle);
       }
 
       if (testDeepOverrides) {

--- a/packages/test-utils/src/describeConformance.tsx
+++ b/packages/test-utils/src/describeConformance.tsx
@@ -43,6 +43,13 @@ export interface ConformanceOptions {
   after?: () => void;
   inheritComponent?: React.ElementType;
   render: (node: React.ReactElement<DataProps>) => MuiRenderResult | Promise<MuiRenderResult>;
+  /**
+   * Returns the component root for assertions that target one root.
+   * Use this for portals or components inside a wrapper.
+   * The default is `result.container.firstChild`.
+   * Tests that render multiple instances use their own queries.
+   */
+  getRootElement?: (result: MuiRenderResult) => Element | null;
   only?: Array<keyof typeof fullSuite>;
   skip?: Array<keyof typeof fullSuite | 'classesRoot'>;
   testComponentsRootPropWith?: string;
@@ -88,6 +95,10 @@ function throwMissingPropError(field: string): never {
 
   > describeConformance(element, () => options)
 `);
+}
+
+function defaultGetRootElement(result: MuiRenderResult) {
+  return result.container.firstChild;
 }
 
 /**
@@ -236,32 +247,30 @@ export function testRootClass(
   getOptions: () => ConformanceOptions,
 ) {
   it('applies the root class to the root component if it has this class', async () => {
-    const { classes, render, skip } = getOptions();
+    const { classes, render, skip, getRootElement = defaultGetRootElement } = getOptions();
     if (classes.root == null) {
       return;
     }
 
     const className = randomStringValue();
     const classesRootClassname = randomStringValue();
-    const { container } = await render(
+    const result = await render(
       React.cloneElement(element, {
         className,
         classes: { ...classes, root: `${classes.root} ${classesRootClassname}` },
       }),
     );
 
-    // we established that the root component renders the outermost host previously. We immediately
-    // jump to the host component because some components pass the `root` class
-    // to the `classes` prop of the root component.
-    // https://github.com/mui/material-ui/blob/f9896bcd129a1209153106296b3d2487547ba205/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L101
-    expect(container.firstChild).to.have.class(className);
-    expect(container.firstChild).to.have.class(classes.root);
+    // Some components pass the root class through the root component's classes prop.
+    const root = getRootElement(result);
+    expect(root).to.have.class(className);
+    expect(root).to.have.class(classes.root);
     expect(document.querySelectorAll(`.${classes.root}`).length).to.equal(1);
 
     // classes test only for @mui/material
     if (!skip || !skip.includes('classesRoot')) {
       // Test that classes prop works
-      expect(container.firstChild).to.have.class(classesRootClassname);
+      expect(root).to.have.class(classesRootClassname);
 
       // Test that `classes` does not spread to DOM
       expect(document.querySelectorAll('[classes]').length).to.equal(0);
@@ -489,7 +498,13 @@ function testThemeDefaultProps(
   describe('theme default components:', () => {
     it("respect theme's defaultProps", async () => {
       const testProp = 'data-id';
-      const { muiName, render, ThemeProvider, createTheme } = getOptions();
+      const {
+        muiName,
+        render,
+        ThemeProvider,
+        createTheme,
+        getRootElement = defaultGetRootElement,
+      } = getOptions();
 
       if (!muiName) {
         throwMissingPropError('muiName');
@@ -517,14 +532,19 @@ function testThemeDefaultProps(
         },
       });
 
-      const { container } = await render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
+      const result = await render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
 
-      expect(container.firstChild).to.have.attribute(testProp, 'testProp');
+      expect(getRootElement(result)).to.have.attribute(testProp, 'testProp');
     });
   });
 
   describe('default props provider:', () => {
-    const { muiName, render, DefaultPropsProvider } = getOptions();
+    const {
+      muiName,
+      render,
+      DefaultPropsProvider,
+      getRootElement = defaultGetRootElement,
+    } = getOptions();
 
     it.skipIf(!DefaultPropsProvider)('respect custom default props', async function test() {
       const testProp = 'data-id';
@@ -537,7 +557,7 @@ function testThemeDefaultProps(
         throwMissingPropError('render');
       }
 
-      const { container } = await render(
+      const result = await render(
         // @ts-expect-error we skip it above.
         <DefaultPropsProvider
           value={{
@@ -552,7 +572,7 @@ function testThemeDefaultProps(
         </DefaultPropsProvider>,
       );
 
-      expect(container.firstChild).to.have.attribute(testProp, 'testProp');
+      expect(getRootElement(result)).to.have.attribute(testProp, 'testProp');
     });
   });
 }
@@ -567,7 +587,14 @@ function testThemeStyleOverrides(
 ) {
   describe('theme style overrides:', () => {
     it.skipIf(isJsdom())("respect theme's styleOverrides custom state", async function test() {
-      const { muiName, testStateOverrides, render, ThemeProvider, createTheme } = getOptions();
+      const {
+        muiName,
+        testStateOverrides,
+        render,
+        ThemeProvider,
+        createTheme,
+        getRootElement = defaultGetRootElement,
+      } = getOptions();
 
       if (!testStateOverrides) {
         return;
@@ -607,7 +634,7 @@ function testThemeStyleOverrides(
         return;
       }
 
-      const { container } = await render(
+      const result = await render(
         <ThemeProvider theme={theme}>
           {React.cloneElement(element, {
             [testStateOverrides.prop]: testStateOverrides.value,
@@ -615,7 +642,7 @@ function testThemeStyleOverrides(
         </ThemeProvider>,
       );
 
-      expect(container.firstChild).to.toHaveComputedStyle(testStyle);
+      expect(getRootElement(result)).to.toHaveComputedStyle(testStyle);
     });
 
     it.skipIf(isJsdom())("respect theme's styleOverrides slots", async function test() {
@@ -624,6 +651,7 @@ function testThemeStyleOverrides(
         testDeepOverrides,
         testRootOverrides = { slotName: 'root' },
         render,
+        getRootElement = defaultGetRootElement,
         ThemeProvider,
         createTheme,
       } = getOptions();
@@ -679,16 +707,14 @@ function testThemeStyleOverrides(
         },
       });
 
-      const { container, setProps } = await render(
-        <ThemeProvider theme={theme}>{element}</ThemeProvider>,
-      );
+      const result = await render(<ThemeProvider theme={theme}>{element}</ThemeProvider>);
 
       if (testRootOverrides.slotClassName) {
         expect(
           document.querySelector(`.${testRootOverrides.slotClassName}`),
         ).to.toHaveComputedStyle(testStyle);
       } else {
-        expect(container.firstChild).to.toHaveComputedStyle(testStyle);
+        expect(getRootElement(result)).to.toHaveComputedStyle(testStyle);
       }
 
       if (testDeepOverrides) {
@@ -713,7 +739,7 @@ function testThemeStyleOverrides(
           },
         });
 
-        setProps({ theme: themeWithoutRootOverrides });
+        result.setProps({ theme: themeWithoutRootOverrides });
 
         (Array.isArray(testDeepOverrides) ? testDeepOverrides : [testDeepOverrides]).forEach(
           (slot) => {


### PR DESCRIPTION
## Summary

Add an optional `getRootElement(renderResult)` callback to `describeConformance` for components that render through a portal or inside a wrapper.

Root-class, default-prop, and root-style assertions use the callback. The default remains `renderResult.container.firstChild`. The render result and its real DOM container stay unchanged. Tests that render multiple instances keep their own queries.

This addresses a review concern in https://github.com/mui/material-ui/pull/48823. Its current adapter substitutes an object with only `firstChild` for the test container. The new option will let Material UI remove that adapter after a package update.

## Tests

- Add 30 conformance tests for inline, wrapped, and portal roots with sync and async render functions.
- Check that root selection receives a real container with working DOM methods.
- Confirm that four wrapped-root and portal-root tests fail before the fix and pass after it.
- Pass all 42 tests in the test-utils package.
- Test a temporary copy of the updated helper with Material UI: 812 Chromium tests and 532 jsdom tests pass across Menu2 and classic button components. Remove the temporary copy after the checks.
- Pass the repository build, TypeScript, ESLint, and formatting checks. Run the Material UI prose checks.
