### PR TITLE
[code-infra] Respect `ARGOS_BRANCH` and `ARGOS_COMMIT` in `argos-push`

### DIFF
--- a/packages/code-infra/src/cli/cmdArgosPush.mjs
+++ b/packages/code-infra/src/cli/cmdArgosPush.mjs
@@ -47,7 +47,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
 
     const argosToken = requireEnv('ARGOS_TOKEN');
     const circleSha1 = requireEnv('CIRCLE_SHA1');
-    // Lets a job report another branch, for example to skip the auto-approval of master builds.
+    // Let's a job report another branch, for example to skip the auto-approval of master builds.
     const branch = process.env.ARGOS_BRANCH || requireEnv('CIRCLE_BRANCH');
     const circleBuildNum = requireEnv('CIRCLE_BUILD_NUM');
 

--- a/packages/code-infra/src/cli/cmdArgosPush.mjs
+++ b/packages/code-infra/src/cli/cmdArgosPush.mjs
@@ -47,7 +47,8 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
 
     const argosToken = requireEnv('ARGOS_TOKEN');
     const circleSha1 = requireEnv('CIRCLE_SHA1');
-    const circleBranch = requireEnv('CIRCLE_BRANCH');
+    // Lets a job report another branch, for example to skip the auto-approval of master builds.
+    const branch = process.env.ARGOS_BRANCH || requireEnv('CIRCLE_BRANCH');
     const circleBuildNum = requireEnv('CIRCLE_BUILD_NUM');
 
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'argos-screenshots-'));
@@ -93,7 +94,7 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         const result = await upload({
           root: `${tempDir}/${i}`,
           commit: circleSha1,
-          branch: circleBranch,
+          branch,
           token: argosToken,
           threshold,
           parallel: {

--- a/packages/code-infra/src/cli/cmdArgosPush.mjs
+++ b/packages/code-infra/src/cli/cmdArgosPush.mjs
@@ -46,9 +46,6 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
     const { folder, verbose = false } = argv;
 
     const argosToken = requireEnv('ARGOS_TOKEN');
-    const circleSha1 = requireEnv('CIRCLE_SHA1');
-    // Let's a job report another branch, for example to skip the auto-approval of master builds.
-    const branch = process.env.ARGOS_BRANCH || requireEnv('CIRCLE_BRANCH');
     const circleBuildNum = requireEnv('CIRCLE_BUILD_NUM');
 
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'argos-screenshots-'));
@@ -93,8 +90,8 @@ export default /** @type {import('yargs').CommandModule<{}, Args>} */ ({
         // eslint-disable-next-line no-await-in-loop
         const result = await upload({
           root: `${tempDir}/${i}`,
-          commit: circleSha1,
-          branch,
+          // The SDK resolves `commit` and `branch`: it reads `ARGOS_COMMIT` and `ARGOS_BRANCH`
+          // first and falls back to `CIRCLE_SHA1` and `CIRCLE_BRANCH`.
           token: argosToken,
           threshold,
           parallel: {


### PR DESCRIPTION
`argos-push` passed `branch: CIRCLE_BRANCH` and `commit: CIRCLE_SHA1` to `upload()`. In `@argos-ci/core`, an explicit option wins over the environment, so `ARGOS_BRANCH` and `ARGOS_COMMIT` had no effect.

This PR stops passing them. The SDK reads `ARGOS_BRANCH` and `ARGOS_COMMIT` first, and its CircleCI detection falls back to `CIRCLE_BRANCH` and `CIRCLE_SHA1`, so nothing changes when they are not set. Every `ARGOS_*` variable that `@argos-ci/core` reads now works, except `ARGOS_PARALLEL`, `ARGOS_PARALLEL_TOTAL`, and `ARGOS_PARALLEL_NONCE`: `argos-push` still sets `parallel` itself, because each batched job needs its own nonce.

Use case: Material UI uploads its nightly React 18 and React next regression runs from master (https://github.com/mui/material-ui/pull/49123). Argos auto-approves master builds, so a React-specific failure never shows. With `ARGOS_BRANCH` set to another branch, Argos does not auto-approve them. The nightly jobs will also set `ARGOS_REFERENCE_COMMIT=$CIRCLE_SHA1`, so that Argos compares them with the stable run on the same commit. Without it, the SDK can look for a merge base with a branch that does not exist on origin, and then the build has no baseline.
